### PR TITLE
Add linter tests to 6 untested packages

### DIFF
--- a/marine_nav_behavior_tree/CMakeLists.txt
+++ b/marine_nav_behavior_tree/CMakeLists.txt
@@ -154,6 +154,11 @@ add_custom_command(TARGET generate_${PROJECT_NAME}_nodes_xml POST_BUILD
 install(FILES ${GENERATED_DIR}/marine_nav_behavior_tree_nodes.xml DESTINATION share/${PROJECT_NAME})
 
 
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
 ament_package()
 
 

--- a/marine_nav_behavior_tree/package.xml
+++ b/marine_nav_behavior_tree/package.xml
@@ -11,6 +11,9 @@
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
   <depend>marine_nav_tasks</depend>
 
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
     <behaviortree_cpp bt_lib_plugin="libmarine_nav_behavior_tree_plugins"/>

--- a/marine_nav_behaviors/CMakeLists.txt
+++ b/marine_nav_behaviors/CMakeLists.txt
@@ -50,4 +50,9 @@ install(FILES behavior_plugin.xml
   DESTINATION share/${PROJECT_NAME}
 )
 
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
 ament_package()

--- a/marine_nav_behaviors/package.xml
+++ b/marine_nav_behaviors/package.xml
@@ -16,6 +16,9 @@
   <depend>rclcpp_lifecycle</depend>
   <depend>visualization_msgs</depend>
 
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
     <nav2_core plugin="${prefix}/behavior_plugin.xml"/>

--- a/marine_nav_bt_task_navigator/CMakeLists.txt
+++ b/marine_nav_bt_task_navigator/CMakeLists.txt
@@ -50,5 +50,10 @@ install(
 
 install(DIRECTORY behavior_trees DESTINATION share/${PROJECT_NAME})
 
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
 ament_package()
 

--- a/marine_nav_bt_task_navigator/package.xml
+++ b/marine_nav_bt_task_navigator/package.xml
@@ -15,6 +15,9 @@
   <depend>nav2_core</depend>
   <depend>rclcpp</depend>
 
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
     <nav2_core plugin="${prefix}/navigator_plugin.xml"/>

--- a/marine_nav_crabbing_path_follower/CMakeLists.txt
+++ b/marine_nav_crabbing_path_follower/CMakeLists.txt
@@ -55,4 +55,9 @@ install(FILES plugin.xml
   DESTINATION share/${PROJECT_NAME}
 )
 
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
 ament_package()

--- a/marine_nav_crabbing_path_follower/package.xml
+++ b/marine_nav_crabbing_path_follower/package.xml
@@ -17,6 +17,9 @@
   <depend>tf2</depend>
   <depend>visualization_msgs</depend>
 
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/marine_nav_tasks/CMakeLists.txt
+++ b/marine_nav_tasks/CMakeLists.txt
@@ -73,5 +73,10 @@ ament_export_dependencies(
   yaml-cpp
 )
 
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
 ament_package()
 

--- a/marine_nav_tasks/package.xml
+++ b/marine_nav_tasks/package.xml
@@ -17,6 +17,9 @@
   <depend>visualization_msgs</depend>
   <depend>yaml_cpp_vendor</depend>
 
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/marine_nav_utilities/CMakeLists.txt
+++ b/marine_nav_utilities/CMakeLists.txt
@@ -65,5 +65,10 @@ ament_export_dependencies(
   rclcpp
 )
 
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
 ament_package()
 

--- a/marine_nav_utilities/package.xml
+++ b/marine_nav_utilities/package.xml
@@ -12,6 +12,9 @@
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
 
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
## Summary

- Add `ament_lint_auto` and `ament_lint_common` test dependencies to 6 packages that had no tests
- Add `BUILD_TESTING` blocks with `ament_lint_auto_find_test_dependencies()` to each package's `CMakeLists.txt`

### Packages updated
- `marine_nav_behavior_tree`
- `marine_nav_behaviors`
- `marine_nav_bt_task_navigator`
- `marine_nav_crabbing_path_follower`
- `marine_nav_tasks`
- `marine_nav_utilities`

## Test plan

- [x] All 6 packages build successfully
- [x] `colcon test` runs linter tests (copyright, cpplint, uncrustify, lint_cmake, flake8, pep257) for all packages
- [ ] Pre-existing lint findings to be addressed in follow-up issues

Closes #10

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
