### PR TITLE
fix(bt): use single quotes for string literals in Script nodes

### DIFF
--- a/marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml
+++ b/marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml
@@ -62,7 +62,7 @@
                      _autoremap="true"/>
           </IfThenElse>
         </Fallback>
-        <Script code="navigation_state := &quot;hover&quot;"/>
+        <Script code="navigation_state := &apos;hover&apos;"/>
         <Hover maximum_distance="0.000000"
                maximum_speed="0.000000"
                error_code_id="{hover_error_code}"
@@ -278,7 +278,7 @@
       <SubTree ID="CancelAllNavigation"
                _autoremap="true"/>
       <ReactiveSequence>
-        <Script code="navigation_state := &quot;survey_line&quot;"/>
+        <Script code="navigation_state := &apos;survey_line&apos;"/>
         <ControllerSelector topic_name="controller_selector"
                             default_controller="FollowPath"
                             selected_controller="{selected_controller}"/>
@@ -355,7 +355,7 @@
                   end_index="0"
                   start_index="0"
                   input_path="{survey_path}"/>
-      <Script code="navigation_state := &quot;transit&quot;"/>
+      <Script code="navigation_state := &apos;transit&apos;"/>
       <SubTree ID="NavigateThroughWaypoints"
                goals="{transit_path}"
                _autoremap="true"/>


### PR DESCRIPTION
## Summary

- BehaviorTree.CPP 4.9.0 (upgraded from 4.8.3 on 2026-04-12) now rejects double-quoted string literals in `<Script code="...">` expressions
- Fixes `bt_task_navigator` failing to activate with `"Invalid token '"' at position 20"` when loading `run_tasks.xml`
- Changes `&quot;` to `&apos;` for 3 string assignments in `run_tasks.xml`, matching existing style

Closes #12

## Test plan

- [x] Tested on salmon via gitcloud (`ca0f376`)
- [ ] CI build-and-test passes

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
