### PR TITLE
Field-validated hover and path_to_pose fixes from BizzyBoat 2026-04-16

### DIFF
--- a/marine_nav_behavior_tree/src/plugins/action/path_to_pose_vector.cpp
+++ b/marine_nav_behavior_tree/src/plugins/action/path_to_pose_vector.cpp
@@ -29,7 +29,9 @@ BT::NodeStatus PathToPoseVector::tick()
   std::vector<geometry_msgs::msg::PoseStamped> poses;
   for(const auto& pose: path.value().poses)
   {
-    poses.push_back(pose);
+    auto p = pose;
+    p.header.stamp = builtin_interfaces::msg::Time();   // NEW: zero stamp = "latest" in TF lookups
+    poses.push_back(p);
   }
 
   setOutput("poses", poses);

--- a/marine_nav_behaviors/src/hover.cpp
+++ b/marine_nav_behaviors/src/hover.cpp
@@ -129,11 +129,10 @@ nav2_behaviors::ResultStatus Hover::onCycleUpdate()
 
   if (steering_proportion > 0.25)
   {
-    current_target_speed = 0.0;
+    current_target_speed =  std::max(current_target_speed, 0.2);
   }
 
-  current_target_speed *= (1.0 - steering_proportion*4.0);
-
+  current_target_speed *= std::max(0.0, 1.0 - steering_proportion*4.0); 
   if (current_range > minimum_radius_)
   {
     current_target_speed = std::max(current_target_speed, minimum_speed_);

--- a/marine_nav_behaviors/src/hover.cpp
+++ b/marine_nav_behaviors/src/hover.cpp
@@ -130,14 +130,21 @@ nav2_behaviors::ResultStatus Hover::onCycleUpdate()
   // Smooth taper: 1.0 at aligned, 0.0 at >= 45° heading error.
   current_target_speed *= std::max(0.0, 1.0 - steering_proportion*4.0);
 
-  // Floor: ensure minimum forward thrust whenever heading correction
-  // is non-trivial, so vectored thrust has flow to redirect. Applied
-  // AFTER the taper so the floor isn't multiplied to zero.
-  // Threshold lowered from 0.25 to 0.1 (~18°) since vectored thrust
-  // needs flow even for moderate heading errors. (v3 of field patch.)
-  if (steering_proportion > 0.1)
+  // Range-aware floor for vectored-thrust authority during heading
+  // correction. Tapers linearly from 0.5 * maximum_speed_ at
+  // maximum_radius down to 0.2 * maximum_speed_ at minimum_radius, then
+  // drops to zero inside minimum_radius so the boat can settle on
+  // station instead of orbiting at the kinematic radius v_min/yaw_rate.
+  // (v4 of field patch — v3 used a flat 0.2 floor everywhere, which
+  // produced a ~3 m stable orbital loop in field testing.)
+  if (steering_proportion > 0.1 && current_range >= minimum_radius_)
   {
-    current_target_speed = std::max(current_target_speed, 0.2);
+    double range_factor = std::clamp(
+        (current_range - minimum_radius_) /
+        (maximum_radius_ - minimum_radius_),
+        0.0, 1.0);
+    double turn_min_speed = (0.2 + 0.3 * range_factor) * maximum_speed_;
+    current_target_speed = std::max(current_target_speed, turn_min_speed);
   }
 
   if (current_range > minimum_radius_)

--- a/marine_nav_behaviors/src/hover.cpp
+++ b/marine_nav_behaviors/src/hover.cpp
@@ -127,12 +127,19 @@ nav2_behaviors::ResultStatus Hover::onCycleUpdate()
     // steering_speed = 0.0;
   }
 
-  if (steering_proportion > 0.25)
+  // Smooth taper: 1.0 at aligned, 0.0 at >= 45° heading error.
+  current_target_speed *= std::max(0.0, 1.0 - steering_proportion*4.0);
+
+  // Floor: ensure minimum forward thrust whenever heading correction
+  // is non-trivial, so vectored thrust has flow to redirect. Applied
+  // AFTER the taper so the floor isn't multiplied to zero.
+  // Threshold lowered from 0.25 to 0.1 (~18°) since vectored thrust
+  // needs flow even for moderate heading errors. (v3 of field patch.)
+  if (steering_proportion > 0.1)
   {
-    current_target_speed =  std::max(current_target_speed, 0.2);
+    current_target_speed = std::max(current_target_speed, 0.2);
   }
 
-  current_target_speed *= std::max(0.0, 1.0 - steering_proportion*4.0); 
   if (current_range > minimum_radius_)
   {
     current_target_speed = std::max(current_target_speed, minimum_speed_);


### PR DESCRIPTION
## Summary

Field-validated fixes from BizzyBoat 2026-04-16 in-water session. All
three commits already deployed via `gitcloud/jazzy` and validated in
multiple in-water hover/survey runs.

### Commits

1. **`35b4b3d` Field fixes to hover and path to pose conversion** (initial
   v1+v2 of hover deadlock fixes + `PathToPoseVector` stamp zeroing for
   TF extrapolation issue)
2. **`ca0dc6f` fix(hover): apply taper before floor; lower threshold to
   0.1 (v3)** — fixed v2's order-of-operations bug
3. **`cfd8560` fix(hover): range-aware turn-min floor (v4) to break
   orbital limit cycle** — current production version

### Why

`marine_nav_behaviors::Hover` was tuned on IzzyBoat (skid-steer, can
pivot in place). When deployed on BizzyBoat (vectored thrusters,
needs forward speed for thrust vector to develop turning authority),
the throttle-kill-when-off-heading logic created a deadlock: heading
error → no throttle → no rudder authority → no rotation → heading
error. Iterated through the field to a range-aware floor:
- Inside `minimum_radius`: zero floor (boat can settle)
- At `minimum_radius`: 0.2 × max_speed (matches v3 behavior at boundary)
- At `maximum_radius` and beyond: 0.5 × max_speed (strong recovery)
- Linear interp between

`PathToPoseVector` fix addresses TF extrapolation when planning the
next survey line — original code preserved unroll-time stamps, which
exceeded the `bizzy/map → bizzy/map_tide` TF buffer by the time the
second line was processed (~70 s later). Zero-stamping makes TF use
latest available, same convention as `chart_datum_node`.

## Field validation

Bag analysis confirms v4 behavior:

- 52% of `cmd_lin` commands are exactly zero (boat allowed to settle inside the ring)
- Median range from target: 2.42 m (inside `minimum_radius`)
- Recovery from largest perturbation (16.8 m excursion) completed cleanly
- No more orbital limit cycle (v3 was stuck at ~3 m kinematic radius)

Full field debug history in `unh_echoboats_project11`'s
`docs/bizzyboat_deployment_log.md` (Session 2026-04-16).

## Test plan

- [x] Build clean across all three modified files
- [x] Live test hover on BizzyBoat — multiple successful sessions
- [x] Live test trackline (PathToPoseVector fix) — boat solidly tracking
- [ ] Sim regression test on IzzyBoat (skid-steer) — should be no
      regression: at `minimum_radius` the floor is 0.2 m/s = the
      original v3 floor IzzyBoat was exposed to via field testing.
      Worth a sanity check.

Closes #14

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-opus-4-6`
