### PR TITLE
feat: publish BT state to ROS topic for rosbag recording

### DIFF
--- a/marine_nav_bt_task_navigator/include/marine_nav_bt_task_navigator/task_navigator.h
+++ b/marine_nav_bt_task_navigator/include/marine_nav_bt_task_navigator/task_navigator.h
@@ -5,6 +5,7 @@
 #include "marine_nav_interfaces/action/run_tasks.hpp"
 #include "behaviortree_cpp/loggers/groot2_publisher.h"
 #include <behaviortree_cpp/loggers/bt_cout_logger.h>
+#include "nav2_behavior_tree/ros_topic_logger.hpp"
 
 namespace marine_nav_bt_task_navigator
 {
@@ -48,6 +49,7 @@ private:
   std::string active_task_blackboard_id_;
   rclcpp::Clock::SharedPtr clock_;
   std::shared_ptr<BT::Groot2Publisher> groot_;
+  std::shared_ptr<nav2_behavior_tree::RosTopicLogger> ros_topic_logger_;
   bool debug_ = false;
   std::shared_ptr<BT::StdCoutLogger> console_logger_;
 

--- a/marine_nav_bt_task_navigator/src/task_navigator.cpp
+++ b/marine_nav_bt_task_navigator/src/task_navigator.cpp
@@ -82,6 +82,13 @@ bool TaskNavigator::goalReceived(ActionT::Goal::ConstSharedPtr goal)
   groot_.reset();
   groot_ = std::make_shared<BT::Groot2Publisher>(bt_action_server_->getTree());
 
+  ros_topic_logger_.reset();
+  auto bt_node = bt_action_server_->getBlackboard()->get<rclcpp::Node::SharedPtr>("node");
+  if (bt_node) {
+    ros_topic_logger_ = std::make_shared<nav2_behavior_tree::RosTopicLogger>(
+      bt_node, bt_action_server_->getTree());
+  }
+
   if(debug_)
   {
     RCLCPP_INFO(logger_, "Logging to console");
@@ -111,6 +118,9 @@ void TaskNavigator::onLoop()
   }
   bt_action_server_->publishFeedback(feedback_msg);
 
+  if (ros_topic_logger_) {
+    ros_topic_logger_->flush();
+  }
 }
 
 void TaskNavigator::onPreempt(typename ActionT::Goal::ConstSharedPtr goal)


### PR DESCRIPTION
## Summary

Adds a `nav2_behavior_tree::RosTopicLogger` to `TaskNavigator` so BT
state transitions are published on `behavior_tree_log` as a ROS topic
and can be recorded by rosbag.

Closes #16

## Change

- **task_navigator.h**: added include + `ros_topic_logger_` member
- **task_navigator.cpp**:
  - `goalReceived()`: create logger from blackboard node + current tree
  - `onLoop()`: flush accumulated events each tick

The existing `Groot2Publisher` (ZMQ for Groot2 GUI) is unchanged.
No new dependencies — `nav2_behavior_tree` is already transitively
available through `nav2_core`.

## Test plan

- [x] Builds clean (`colcon build --packages-select marine_nav_bt_task_navigator`)
- [ ] Run on gabby/salmon and verify `ros2 topic echo /bizzy/behavior_tree_log` produces output during a mission
- [ ] Verify topic appears in rosbag after deploying with the logger config from [unh_echoboats_project11#59](https://github.com/rolker/unh_echoboats_project11/pull/59)

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-opus-4-6[1m]`

Generated with [Claude Code](https://claude.com/claude-code)
