### PR TITLE
Add RetryNode to survey BT for transient nav failures

### DIFF
--- a/marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml
+++ b/marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml
@@ -191,23 +191,25 @@
                      task_list="{survey_area_tasks}"
                      _autoremap="true"/>
             <RetryNode num_attempts="3">
-              <ReactiveFallback>
-                <SubTree ID="SurveyLineTask"
-                         lead_in_distance="{survey_lead_in_distance}"
-                         survey_line_task="{current_survey_area_task}"
-                         server_timeout="{server_timeout}"
-                         bt_loop_duration="{bt_loop_duration}"
-                         wait_for_service_timeout="{wait_for_service_timeout}"
-                         current_task_type="{current_survey_area_task_type}"
-                         _failureIf="current_survey_area_task_type != &apos;survey_line&apos;"
-                         _autoremap="true"/>
-                <SubTree ID="SurveyLineSetTask"
-                         name="SurveyAreaSurveyLineSetTask"
-                         survey_line_set_task="{current_survey_area_task}"
-                         _failureIf="current_survey_area_task_type != &apos;survey_line_set&apos;"
-                         _autoremap="true"/>
+              <Sequence>
+                <ReactiveFallback>
+                  <SubTree ID="SurveyLineTask"
+                           lead_in_distance="{survey_lead_in_distance}"
+                           survey_line_task="{current_survey_area_task}"
+                           server_timeout="{server_timeout}"
+                           bt_loop_duration="{bt_loop_duration}"
+                           wait_for_service_timeout="{wait_for_service_timeout}"
+                           current_task_type="{current_survey_area_task_type}"
+                           _failureIf="current_survey_area_task_type != &apos;survey_line&apos;"
+                           _autoremap="true"/>
+                  <SubTree ID="SurveyLineSetTask"
+                           name="SurveyAreaSurveyLineSetTask"
+                           survey_line_set_task="{current_survey_area_task}"
+                           _failureIf="current_survey_area_task_type != &apos;survey_line_set&apos;"
+                           _autoremap="true"/>
+                </ReactiveFallback>
                 <SetTaskDone task="{current_survey_area_task}"/>
-              </ReactiveFallback>
+              </Sequence>
             </RetryNode>
           </ReactiveSequence>
         </KeepRunningUntilFailure>

--- a/marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml
+++ b/marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml
@@ -190,23 +190,25 @@
                      default_controller="{=}"
                      task_list="{survey_area_tasks}"
                      _autoremap="true"/>
-            <ReactiveFallback>
-              <SubTree ID="SurveyLineTask"
-                       lead_in_distance="{survey_lead_in_distance}"
-                       survey_line_task="{current_survey_area_task}"
-                       server_timeout="{server_timeout}"
-                       bt_loop_duration="{bt_loop_duration}"
-                       wait_for_service_timeout="{wait_for_service_timeout}"
-                       current_task_type="{current_survey_area_task_type}"
-                       _failureIf="current_survey_area_task_type != &apos;survey_line&apos;"
-                       _autoremap="true"/>
-              <SubTree ID="SurveyLineSetTask"
-                       name="SurveyAreaSurveyLineSetTask"
-                       survey_line_set_task="{current_survey_area_task}"
-                       _failureIf="current_survey_area_task_type != &apos;survey_line_set&apos;"
-                       _autoremap="true"/>
-              <SetTaskDone task="{current_survey_area_task}"/>
-            </ReactiveFallback>
+            <RetryNode num_attempts="3">
+              <ReactiveFallback>
+                <SubTree ID="SurveyLineTask"
+                         lead_in_distance="{survey_lead_in_distance}"
+                         survey_line_task="{current_survey_area_task}"
+                         server_timeout="{server_timeout}"
+                         bt_loop_duration="{bt_loop_duration}"
+                         wait_for_service_timeout="{wait_for_service_timeout}"
+                         current_task_type="{current_survey_area_task_type}"
+                         _failureIf="current_survey_area_task_type != &apos;survey_line&apos;"
+                         _autoremap="true"/>
+                <SubTree ID="SurveyLineSetTask"
+                         name="SurveyAreaSurveyLineSetTask"
+                         survey_line_set_task="{current_survey_area_task}"
+                         _failureIf="current_survey_area_task_type != &apos;survey_line_set&apos;"
+                         _autoremap="true"/>
+                <SetTaskDone task="{current_survey_area_task}"/>
+              </ReactiveFallback>
+            </RetryNode>
           </ReactiveSequence>
         </KeepRunningUntilFailure>
       </WhileDoElse>
@@ -317,17 +319,19 @@
                      default_controller="{=}"
                      task_list="{survey_line_set_sub_tasks}"
                      _autoremap="true"/>
-            <Sequence>
-              <SubTree ID="SurveyLineTask"
-                       name="SurveyLineSetSurveyLineTask"
-                       survey_line_task="{survey_line_set_sub_task}"
-                       server_timeout="{server_timeout}"
-                       bt_loop_duration="{bt_loop_duration}"
-                       wait_for_service_timeout="{wait_for_service_timeout}"
-                       current_task_type="{survey_line_set_sub_task_type}"
-                       _autoremap="true"/>
-              <SetTaskDone task="{survey_line_set_sub_task}"/>
-            </Sequence>
+            <RetryNode num_attempts="3">
+              <Sequence>
+                <SubTree ID="SurveyLineTask"
+                         name="SurveyLineSetSurveyLineTask"
+                         survey_line_task="{survey_line_set_sub_task}"
+                         server_timeout="{server_timeout}"
+                         bt_loop_duration="{bt_loop_duration}"
+                         wait_for_service_timeout="{wait_for_service_timeout}"
+                         current_task_type="{survey_line_set_sub_task_type}"
+                         _autoremap="true"/>
+                <SetTaskDone task="{survey_line_set_sub_task}"/>
+              </Sequence>
+            </RetryNode>
           </ReactiveSequence>
         </KeepRunningUntilFailure>
       </WhileDoElse>


### PR DESCRIPTION
## Summary

- Add `RetryNode num_attempts="3"` around survey line execution in `SurveyLineSetTask` BT
- Add `RetryNode num_attempts="3"` around task dispatch in `RunSurveyAreaSubTasks` BT
- Handles transient navigation failures (costmap timeout, planner stalls) that previously caused the entire survey to be declared complete with unfinished lines

Closes #18

## Root cause

When `FollowPath` is aborted (e.g., costmap timeout after 1.0s), `SurveyLineTask` returns FAILURE. `KeepRunningUntilFailure` converts this FAILURE→SUCCESS, causing `WhileDoElse` to exit and the survey set to be marked done despite incomplete lines.

The `RetryNode` retries the failed line up to 3 times before allowing the failure to propagate. This is sufficient for transient issues like costmap stalls (which recover in seconds).

## Test plan

- [ ] Build `marine_nav_bt_task_navigator`
- [ ] Field test: run a 4+ line survey and verify all lines complete
- [ ] Verify retry behavior: if a line fails transiently, it should retry and complete
- [ ] Verify persistent failure: after 3 retries, survey should abort (fall back to hover)

## Future work

Replace binary `done` flag with task status (`done_success`, `done_error`) so failed lines are marked as errors and the survey advances to the next line instead of aborting entirely.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
