### PR TITLE
fix(bt): use RetryUntilSuccessful for BTCPP_format="4"

### DIFF
--- a/marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml
+++ b/marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml
@@ -190,7 +190,7 @@
                      default_controller="{=}"
                      task_list="{survey_area_tasks}"
                      _autoremap="true"/>
-            <RetryNode num_attempts="3">
+            <RetryUntilSuccessful num_attempts="3">
               <Sequence>
                 <ReactiveFallback>
                   <SubTree ID="SurveyLineTask"
@@ -210,7 +210,7 @@
                 </ReactiveFallback>
                 <SetTaskDone task="{current_survey_area_task}"/>
               </Sequence>
-            </RetryNode>
+            </RetryUntilSuccessful>
           </ReactiveSequence>
         </KeepRunningUntilFailure>
       </WhileDoElse>
@@ -321,7 +321,7 @@
                      default_controller="{=}"
                      task_list="{survey_line_set_sub_tasks}"
                      _autoremap="true"/>
-            <RetryNode num_attempts="3">
+            <RetryUntilSuccessful num_attempts="3">
               <Sequence>
                 <SubTree ID="SurveyLineTask"
                          name="SurveyLineSetSurveyLineTask"
@@ -333,7 +333,7 @@
                          _autoremap="true"/>
                 <SetTaskDone task="{survey_line_set_sub_task}"/>
               </Sequence>
-            </RetryNode>
+            </RetryUntilSuccessful>
           </ReactiveSequence>
         </KeepRunningUntilFailure>
       </WhileDoElse>


### PR DESCRIPTION
## Summary

- Rename two `<RetryNode>` tags to `<RetryUntilSuccessful>` in `marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml` (lines 193 and 324).
- `BTCPP_format="4"` registers the built-in retry decorator under the XML name `RetryUntilSuccessful`; `RetryNode` is only the C++ class name. Same file already used `<RetryUntilSuccessful>` correctly on line 105 — this PR makes the two new tags consistent.
- Introduced by e71a8c8 (PR #20, 2026-04-21). Without the fix `bt_task_navigator` fails to load `run_tasks.xml` with `Unknown node type: RetryNode`, the navigation lifecycle aborts, and all hover/goto goals are rejected.

Closes #21

## Test plan

- [x] `./core_ws/build.sh marine_nav_bt_task_navigator` — builds cleanly (pre-existing `-Wunused-parameter` warnings only).
- [x] `ros2 launch marine_simulation simulator_launch.py` — after rebuild:
  - No `[ERROR] Exception when loading BT` / `Unknown node type: RetryNode`.
  - No `[ERROR] Failed to change state for node: bt_task_navigator` / `Failed to bring up all requested nodes`.
  - `Activating bt_task_navigator` → `Server bt_task_navigator connected with bond`.
  - `TaskNavigator: Received goal: 2 tasks` — goals accepted and executed.
- [ ] Reviewer: spot-check the two renamed sections visually (the only change is the opening/closing tag name; `num_attempts="3"` attribute unchanged).

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
