### PR TITLE
Mission re-send mid-line — make followed path track current task (#35)

### DIFF
--- a/.agent/work-plans/issue-35/plan.md
+++ b/.agent/work-plans/issue-35/plan.md
@@ -1,5 +1,12 @@
 # Plan: Mission re-send mid-line doesn't take effect — BT latches FollowPath path on same-type task switch
 
+> **SUPERSEDED — merged into #25.** This work was merged with #25 (2026-05-27): the
+> identity-gate FAILURE here and #25's new retry/`SetTaskFailed` machinery collide on the
+> same FAILURE signal, so they share one dispatch rewrite. The combined plan (closing both
+> #25 and #35) lives at `unh_marine_navigation` `feature/issue-25` → PR #37. Implement
+> there, not on this branch. Kept for reference (the identity-gate design below feeds the
+> combined plan's Part B/C).
+
 ## Issue
 
 https://github.com/rolker/unh_marine_navigation/issues/35

--- a/.agent/work-plans/issue-35/plan.md
+++ b/.agent/work-plans/issue-35/plan.md
@@ -1,0 +1,110 @@
+# Plan: Mission re-send mid-line doesn't take effect — BT latches FollowPath path on same-type task switch
+
+## Issue
+
+https://github.com/rolker/unh_marine_navigation/issues/35
+
+## Context
+
+`SurveyLineTask` (`run_tasks.xml:347-359`) is a `ReactiveSequence` whose only
+re-entry gate is `ScriptCondition(current_task_type == 'survey_line')`. The
+inner memory `Sequence` runs `SetPathFromTask` **once** (latching `{survey_path}`
+from the task active at entry), then holds `TransitAndSurveyLine`'s `FollowPath`
+RUNNING. On a mid-line Execute of N+1, `UpdateCurrentTaskData` advances the
+*reported* task (heartbeat → N+1) every tick, but because N→N+1 is
+`survey_line → survey_line` the gate never fails, the memory `Sequence` is never
+re-ticked, and the boat keeps following N's path. Clear→resend works only because
+clearing flips `current_task_type` away from `survey_line`, failing the gate and
+halting `FollowPath`.
+
+**Decisions taken in the review walkthrough** (see `progress.md` → Decisions):
+transit to N+1's start; identity-gated BT re-entry; regression test deferred to
+ride on #8's harness; **#25 lands first** and #35 builds on its restructured
+dispatch.
+
+## Approach
+
+1. **Latch the path's source-task id in `SetPathFromTask`.** Add
+   `OutputPort<std::string>("path_task_id")` emitting `task->message().id`
+   alongside the existing path output. This records *which task* the latched
+   `{survey_path}` came from — a C++ latch immune to blackboard-remap quirks.
+   (Alternative considered: an XML `Script` node latching
+   `path_task_id := current_task_id` — rejected as more fragile under
+   `_autoremap`.)
+2. **Gate re-entry on task identity, not just type.** Add a second condition to
+   `SurveyLineTask`'s `ReactiveSequence`:
+   `ScriptCondition(current_task_id == path_task_id)`, evaluated after the
+   `survey_path` is latched. When `current_task_id` changes mid-line it fails →
+   the `ReactiveSequence` halts the running memory `Sequence` (cancels
+   `FollowPath`) → next tick re-enters fresh → `SetPathFromTask` recomputes the
+   path **and re-latches `path_task_id`**, and `TransitAndSurveyLine` transits to
+   the new line's start (decision: transit-to-start). Guard the first-entry case
+   where `path_task_id` is still empty (condition must not fail before the path
+   is set).
+3. **Contain the resulting FAILURE — depends on #25.** A failed identity gate
+   makes `SurveyLineTask` return FAILURE. In today's `NavigatorSequence`
+   (`run_tasks.xml:128-170`) that falls through `SelectTaskReactiveFallback` to
+   the `SkipUnknownTaskType` catchall, silently marking N+1 done — **exactly
+   #25's bug**. Build step 2 on #25's restructured dispatch (`Switch`/`IfThenElse`
+   on `current_task_type`), where a matched-but-failed subtree no longer reaches
+   the blanket catchall. The contract #35 relies on: *matched-but-failed must not
+   mark the task done.*
+4. **Cover the survey-area reuse.** `SurveyLineTask` is also instantiated inside
+   `RunSurveyAreaSubTasks` (`run_tasks.xml:198-206`), where the relevant id is
+   `current_survey_area_task_id`, not `current_task_id`. Verify the identity gate
+   resolves to the correct id under that call site's remapping (it already gates
+   with `_failureIf` on type) — wire the comparison so it is correct in both
+   contexts, or scope the new condition so the survey-area path is unaffected.
+5. **Make the preemption observable.** Log the `FollowPath` halt/restart (e.g. an
+   INFO on identity-gate failure) so reported task and executed path stay coupled
+   — addresses the transparency aspect of the defect.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `marine_nav_behavior_tree/src/plugins/action/set_path_from_task.cpp` | Add `path_task_id` output port; emit `task->message().id` |
+| `marine_nav_behavior_tree/include/.../set_path_from_task.h` | (if ports declared in header) reflect new port |
+| `marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml` | Add identity `ScriptCondition` to `SurveyLineTask`; wire `path_task_id`; first-entry guard; log node. Built on #25's restructured dispatch. |
+| `.../README.md` (if it documents BT task flow) | Update to describe identity-gated re-entry |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Human control and transparency | Fix re-couples reported task to executed path; halt/restart is logged (step 5), not silent. |
+| A change includes its consequences | Regression test deferred by decision to ride on #8; README updated if it documents BT flow; survey-area reuse covered (step 4). |
+| Test what breaks | Target failure mode is the mid-line same-type interrupt — the test (via #8 harness) asserts followed path becomes N+1's. |
+| Only what's needed / Improve incrementally | Minimal: one output port + one condition + a guard; no dispatch rewrite (that's #25). |
+| Capture decisions | Fix-direction rationale recorded here + in `progress.md`; restated in the PR (no project ADR system). |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0002 — Worktree isolation | Yes | Work on `feature/issue-35` layer worktree; PR into `jazzy`, no direct commits. |
+| 0008 — ROS 2 conventions | Yes | BT.CPP4 semantics explicit (memory `Sequence` halt on `ReactiveSequence` gate failure); follows existing node/port idioms. |
+| 0001 — Adopt ADRs | Watch | No `docs/decisions/` in this repo; capture rationale in PR. |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| `SetPathFromTask` ports | Every `run_tasks.xml` call site of `SetPathFromTask`; node docs/tests | Yes — audit call sites; tests via #8 |
+| `SurveyLineTask` subtree body | Both call sites (top-level + `RunSurveyAreaSubTasks`) | Yes — step 4 |
+| BT behavior on interrupt | README BT-flow docs | Yes — if present |
+
+## Open Questions
+
+- **#25 dispatch shape** — final structure (Switch vs IfThenElse) sets where the
+  identity condition attaches and confirms FAILURE is contained. Plan finalizes
+  after #25 lands.
+- **Survey-area scope** — does the identity gate also fix mid-line switches
+  inside a survey area, and is that desired, or should the new condition be
+  scoped to the top-level path only? (step 4)
+- **Test mechanism** — defer to #8's harness shape; revisit at implementation.
+
+## Estimated Scope
+
+Single PR, **blocked on #25**. Small once unblocked: one C++ output port, one BT
+condition + first-entry guard + log, doc touch-up. Regression test rides on #8.

--- a/.agent/work-plans/issue-35/plan.md
+++ b/.agent/work-plans/issue-35/plan.md
@@ -49,25 +49,48 @@ Accepted trade: the re-sent line may be joined partway rather than from its star
 Single PR on `feature/issue-35`.
 
 1. **Spike (first): confirm Nav2 `FollowPath` auto-resends on a path-input change.** In
-   sim, start a survey line, change `current_task` to a different line mid-follow, and
-   observe whether the controller picks up the new path without an ABORT/halt. This decides
-   step 2's mechanism. (10-min spike; do not build the plan past this without the answer.)
-2. **Make `{survey_path}` track `current_task` reactively.** Replace the one-time
+   sim, start a survey line, change the current task to a different line mid-follow, and
+   confirm the controller picks up the new path **without** an ABORT/halt. Confirm
+   *positively* via the goal UUID / BT log (`send_new_goal` resends a new goal handle) —
+   not merely from boat motion, which could be a stale follow. This decides step 2's
+   mechanism. (Source note: `BtActionNode::on_tick` reads ports only at goal-send; during
+   RUNNING only `FollowPathAction::on_wait_for_result` can set `goal_updated_`, and its
+   `.cpp` isn't shipped — hence the spike. Do not build past this without the answer.)
+2. **Make `{survey_path}` track the current task reactively.** Replace the one-time
    `SetPathFromTask` latch with a per-tick refresh so `{survey_path}` always equals the
-   current task's path. Candidate placement: a reactive `SetPathFromTask` co-located with
-   `FollowPath` in `SurveyLine`'s existing `ReactiveSequence` (it already re-ticks). When
-   the operator re-sends, `{survey_path}` updates and `FollowPath` re-sends its goal in
-   place. **Exact wiring confirmed against the live tree during implementation** (per the
-   Part C lesson — no asserted structure here). If Step 1 shows no auto-resend, instead add
-   a tick-level "path changed?" check that cancels + re-enters `FollowPath`.
+   current task's path; `FollowPath` then re-sends its goal in place when the operator
+   re-sends. **The task key is `survey_line_task`, not `{current_task}`** — and the
+   reactive `SetPathFromTask` must sit where that key is in scope. `SetPathFromTask`'s
+   `task` input is `survey_line_task` (`run_tasks.xml:354`); to place a reactive refresh
+   inside `SurveyLine`'s `ReactiveSequence` (`:286-302`, which re-ticks), the task pointer
+   must reach `SurveyLine`'s blackboard — it does, via the `_autoremap="true"` chain
+   `SurveyLineTask → TransitAndSurveyLine (:372) → SurveyLine (:372-376)`, so a
+   `SetPathFromTask task="{survey_line_task}"` added inside `SurveyLine` resolves up to
+   `SurveyLineTask`'s `survey_line_task`. (This dependency on the autoremap chain + key
+   name is stated up front — the prior version's failure was leaving exactly this implicit.)
+   The exact node position within the `ReactiveSequence` is confirmed against the live tree
+   when wiring, but the key and the autoremap dependency are pinned here. If Step 1 shows
+   no auto-resend, instead add a tick-level "path changed?" check that cancels + re-enters
+   `FollowPath`.
    - The initial transit leg (`NavigateThroughWaypoints` in `TransitAndSurveyLine`) runs
      once on first entry and is **not** re-run on a switch — that is the in-place behavior.
-3. **Verify the three call sites.** `SurveyLine`/`SurveyLineTask` are instantiated at the
-   top level, inside `RunSurveyAreaSubTasks`, and inside `SurveyLineSetTask`, each with its
-   own autoremapped current-task key. Confirm the reactive refresh derives the path from
-   the correct task at each site (it reads the autoremapped `{current_task}`).
-4. **Observability.** Log (INFO) when the followed path is re-sent due to a task change, so
-   the reported task and executed path stay visibly coupled.
+3. **Verify the three call sites — each passes a different key into `survey_line_task`.**
+   Top level: `survey_line_task="{current_task}"` (`:150`); `RunSurveyAreaSubTasks`:
+   `survey_line_task="{current_survey_area_task}"` (`:200`, re-selected each tick by that
+   loop's own `UpdateCurrentTaskData` `:181-194`); `SurveyLineSetTask`:
+   `survey_line_task="{survey_line_set_sub_task}"` (`:332`). The reactive refresh reads
+   `survey_line_task` (autoremapped), so it derives the path from the correct task at each
+   site — confirm during wiring (do **not** wire `{current_task}` directly, which is not
+   what `SetPathFromTask` uses below the top level).
+4. **Observability.** Verify whether Nav2 already logs the goal resend (`send_new_goal`
+   emits a log); if it does, rely on that — no new node. Only if it doesn't, add a small
+   log node (and adjust the "no new node" framing accordingly).
+5. **Regression test — explicitly deferred to #8.** No BT-task-navigator harness exists
+   today (the only BT test is `marine_nav_behavior_tree/test/test_set_controller_speed_resolve.cpp`,
+   a pure-helper unit test). Decision (with Roland): **defer the re-entry regression test to
+   #8's harness** rather than bootstrap a parallel one here; #35 ships with the Step-1 sim
+   spike + manual on-water/sim verification of a mid-line re-send. Recorded here so it is a
+   stated deferral, not a silently-dropped fixture.
 
 ## Files to Change
 
@@ -82,7 +105,7 @@ Single PR on `feature/issue-35`.
 |---|---|
 | Human control & transparency | Followed path re-couples to the reported task; re-send is logged. |
 | A change includes its consequences | Reuses pure existing nodes; three call sites verified; spike de-risks the load-bearing Nav2 assumption before building on it. |
-| Test what breaks | The break is "path doesn't update mid-follow" — the re-entry fixture asserts `{survey_path}` and the followed goal track a mid-line task change. |
+| Test what breaks | The break is "path doesn't update mid-follow" — verified by the Step-1 sim spike + manual mid-line re-send; the automated regression fixture is **deferred to #8** (no BT-navigator harness exists today), recorded as a stated deferral. |
 | Only what's needed | No identity gate, no `path_task_id`, no new dispatch machinery — just make an existing input live. |
 | Capture decisions | In-place-vs-transit-to-start rationale here + `progress.md` + PR. |
 
@@ -98,7 +121,7 @@ Single PR on `feature/issue-35`.
 | If we change... | Also update... | In this PR? |
 |---|---|---|
 | `{survey_path}` becomes per-tick reactive | Confirm `GetSubPath`/transit reads stay correct (transit uses index 0 once); confirm re-deriving each tick is side-effect-free (it is) | Yes |
-| In-place switch (no transit-to-start) | Operator expectation: re-sent line may be joined partway. Note in PR; revisit only if coverage gaps observed | Documented, not coded |
+| In-place switch (no transit-to-start) | Operator expectation: re-sent line may be joined partway; **and** a re-sent line far away or running the opposite direction is joined at an arbitrary nearest point with no lead-in (possible sharp turn / undesired traversal direction). Note in PR; revisit only if field use shows it matters | Documented, not coded |
 | Behavior depends on Nav2 `FollowPath` resend | Step-1 spike result; fallback path if absent | Yes |
 
 ## Open Questions

--- a/.agent/work-plans/issue-35/plan.md
+++ b/.agent/work-plans/issue-35/plan.md
@@ -1,117 +1,120 @@
-# Plan: Mission re-send mid-line doesn't take effect — BT latches FollowPath path on same-type task switch
+# Plan: Mission re-send mid-line — make the followed path track the current task
 
-> **SUPERSEDED — merged into #25.** This work was merged with #25 (2026-05-27): the
-> identity-gate FAILURE here and #25's new retry/`SetTaskFailed` machinery collide on the
-> same FAILURE signal, so they share one dispatch rewrite. The combined plan (closing both
-> #25 and #35) lives at `unh_marine_navigation` `feature/issue-25` → PR #37. Implement
-> there, not on this branch. Kept for reference (the identity-gate design below feeds the
-> combined plan's Part B/C).
+**Closes #35.** Standalone (decoupled from #25 — see "Design history").
 
 ## Issue
 
-https://github.com/rolker/unh_marine_navigation/issues/35
+https://github.com/rolker/unh_marine_navigation/issues/35 — Mission re-send mid-line
+doesn't take effect; BT latches the `FollowPath` path on a same-type task switch.
 
 ## Context
 
-`SurveyLineTask` (`run_tasks.xml:347-359`) is a `ReactiveSequence` whose only
-re-entry gate is `ScriptCondition(current_task_type == 'survey_line')`. The
-inner memory `Sequence` runs `SetPathFromTask` **once** (latching `{survey_path}`
-from the task active at entry), then holds `TransitAndSurveyLine`'s `FollowPath`
-RUNNING. On a mid-line Execute of N+1, `UpdateCurrentTaskData` advances the
-*reported* task (heartbeat → N+1) every tick, but because N→N+1 is
-`survey_line → survey_line` the gate never fails, the memory `Sequence` is never
-re-ticked, and the boat keeps following N's path. Clear→resend works only because
-clearing flips `current_task_type` away from `survey_line`, failing the gate and
-halting `FollowPath`.
+`SurveyLineTask` (`run_tasks.xml:347-360`) is
+`ReactiveSequence[ ScriptCondition(type=='survey_line'), Sequence[ SetPathFromTask, TransitAndSurveyLine, SetTaskDone ] ]`.
+The inner memory `Sequence` runs `SetPathFromTask` **once** (latching `{survey_path}` from
+the task active at entry), then holds `TransitAndSurveyLine`'s `FollowPath` RUNNING. On a
+mid-line Execute of N+1, `UpdateCurrentTaskData` advances the *reported* task every tick
+(heartbeat → N+1), but because N→N+1 is `survey_line → survey_line` the
+`ScriptCondition(type)` still passes, the memory `Sequence` is **not** re-entered, and the
+boat keeps following N's latched path. Clear→resend works only because clearing flips the
+*type*, failing the gate. The defect is the **latch + type-only re-entry**.
 
-**Decisions taken in the review walkthrough** (see `progress.md` → Decisions):
-transit to N+1's start; identity-gated BT re-entry; regression test deferred to
-ride on #8's harness; **#25 lands first** and #35 builds on its restructured
-dispatch.
+Verified facts shaping the approach:
+- **`SetPathFromTask` is a pure `SyncActionNode`** (`set_path_from_task.cpp`): reads
+  `{current_task}`, slices `poses[start..end]`, `setOutput("path")`. No side effects —
+  safe to re-run every tick.
+- **`UpdateCurrentTask` re-selects the highest-priority not-done task every tick** and
+  re-emits `current_task`/`current_task_id`/`current_task_type` (`update_current_task.cpp`).
+  So `{current_task}` already tracks the operator's re-send within one tick.
+- **Nav2 `FollowPath` accepts a new path while RUNNING without halting.** `BtActionNode`
+  re-sends the goal when `goal_updated_` is set, via `send_new_goal()`, staying RUNNING
+  (`bt_action_node.hpp:236-250`); `FollowPathAction` overrides `on_wait_for_result` (called
+  each RUNNING tick). **Load-bearing, not yet fully confirmed:** that override must compare
+  the input `path` port and set `goal_updated_` on change. I could not read
+  `follow_path_action.cpp` (not shipped in `/opt/ros`) — Step 1 below is a sim spike to
+  confirm. If it does **not** auto-resend, the fallback (also simple) is an explicit
+  detect-change → cancel → resend in the BT; either way no #25 coupling.
+- `SurveyLine` (`run_tasks.xml:282-302`) wraps the survey `FollowPath` in a
+  `ReactiveSequence` that re-ticks each tick — a natural home for a per-tick path refresh.
+- `SurveyLine` is the **shared** survey-line execution unit (reused under
+  `RunSurveyAreaSubTasks` and `SurveyLineSetTask`), so a fix there covers all call sites,
+  each using its own autoremapped `current_task`.
+
+Decision (with Roland): **in-place switch** — on re-send the controller transitions onto
+the new line from the current position (relaxing the earlier "transit-to-start" choice).
+Accepted trade: the re-sent line may be joined partway rather than from its start.
 
 ## Approach
 
-1. **Latch the path's source-task id in `SetPathFromTask`.** Add
-   `OutputPort<std::string>("path_task_id")` emitting `task->message().id`
-   alongside the existing path output. This records *which task* the latched
-   `{survey_path}` came from — a C++ latch immune to blackboard-remap quirks.
-   (Alternative considered: an XML `Script` node latching
-   `path_task_id := current_task_id` — rejected as more fragile under
-   `_autoremap`.)
-2. **Gate re-entry on task identity, not just type.** Add a second condition to
-   `SurveyLineTask`'s `ReactiveSequence`:
-   `ScriptCondition(current_task_id == path_task_id)`, evaluated after the
-   `survey_path` is latched. When `current_task_id` changes mid-line it fails →
-   the `ReactiveSequence` halts the running memory `Sequence` (cancels
-   `FollowPath`) → next tick re-enters fresh → `SetPathFromTask` recomputes the
-   path **and re-latches `path_task_id`**, and `TransitAndSurveyLine` transits to
-   the new line's start (decision: transit-to-start). Guard the first-entry case
-   where `path_task_id` is still empty (condition must not fail before the path
-   is set).
-3. **Contain the resulting FAILURE — depends on #25.** A failed identity gate
-   makes `SurveyLineTask` return FAILURE. In today's `NavigatorSequence`
-   (`run_tasks.xml:128-170`) that falls through `SelectTaskReactiveFallback` to
-   the `SkipUnknownTaskType` catchall, silently marking N+1 done — **exactly
-   #25's bug**. Build step 2 on #25's restructured dispatch (`Switch`/`IfThenElse`
-   on `current_task_type`), where a matched-but-failed subtree no longer reaches
-   the blanket catchall. The contract #35 relies on: *matched-but-failed must not
-   mark the task done.*
-4. **Cover the survey-area reuse.** `SurveyLineTask` is also instantiated inside
-   `RunSurveyAreaSubTasks` (`run_tasks.xml:198-206`), where the relevant id is
-   `current_survey_area_task_id`, not `current_task_id`. Verify the identity gate
-   resolves to the correct id under that call site's remapping (it already gates
-   with `_failureIf` on type) — wire the comparison so it is correct in both
-   contexts, or scope the new condition so the survey-area path is unaffected.
-5. **Make the preemption observable.** Log the `FollowPath` halt/restart (e.g. an
-   INFO on identity-gate failure) so reported task and executed path stay coupled
-   — addresses the transparency aspect of the defect.
+Single PR on `feature/issue-35`.
+
+1. **Spike (first): confirm Nav2 `FollowPath` auto-resends on a path-input change.** In
+   sim, start a survey line, change `current_task` to a different line mid-follow, and
+   observe whether the controller picks up the new path without an ABORT/halt. This decides
+   step 2's mechanism. (10-min spike; do not build the plan past this without the answer.)
+2. **Make `{survey_path}` track `current_task` reactively.** Replace the one-time
+   `SetPathFromTask` latch with a per-tick refresh so `{survey_path}` always equals the
+   current task's path. Candidate placement: a reactive `SetPathFromTask` co-located with
+   `FollowPath` in `SurveyLine`'s existing `ReactiveSequence` (it already re-ticks). When
+   the operator re-sends, `{survey_path}` updates and `FollowPath` re-sends its goal in
+   place. **Exact wiring confirmed against the live tree during implementation** (per the
+   Part C lesson — no asserted structure here). If Step 1 shows no auto-resend, instead add
+   a tick-level "path changed?" check that cancels + re-enters `FollowPath`.
+   - The initial transit leg (`NavigateThroughWaypoints` in `TransitAndSurveyLine`) runs
+     once on first entry and is **not** re-run on a switch — that is the in-place behavior.
+3. **Verify the three call sites.** `SurveyLine`/`SurveyLineTask` are instantiated at the
+   top level, inside `RunSurveyAreaSubTasks`, and inside `SurveyLineSetTask`, each with its
+   own autoremapped current-task key. Confirm the reactive refresh derives the path from
+   the correct task at each site (it reads the autoremapped `{current_task}`).
+4. **Observability.** Log (INFO) when the followed path is re-sent due to a task change, so
+   the reported task and executed path stay visibly coupled.
 
 ## Files to Change
 
 | File | Change |
 |------|--------|
-| `marine_nav_behavior_tree/src/plugins/action/set_path_from_task.cpp` | Add `path_task_id` output port; emit `task->message().id` |
-| `marine_nav_behavior_tree/include/.../set_path_from_task.h` | (if ports declared in header) reflect new port |
-| `marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml` | Add identity `ScriptCondition` to `SurveyLineTask`; wire `path_task_id`; first-entry guard; log node. Built on #25's restructured dispatch. |
-| `.../README.md` (if it documents BT task flow) | Update to describe identity-gated re-entry |
+| `marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml` | Make `{survey_path}` reactive to `current_task` at `SurveyLine` (replace the one-time latch with a per-tick refresh); INFO log on path re-send; embedded `TreeNodesModel` if node usage changes |
+| (spike-dependent) `marine_nav_behavior_tree/...` | Only if Step 1 shows no auto-resend: a small "path-changed → cancel/resend" helper/condition node |
 
 ## Principles Self-Check
 
 | Principle | Consideration |
 |---|---|
-| Human control and transparency | Fix re-couples reported task to executed path; halt/restart is logged (step 5), not silent. |
-| A change includes its consequences | Regression test deferred by decision to ride on #8; README updated if it documents BT flow; survey-area reuse covered (step 4). |
-| Test what breaks | Target failure mode is the mid-line same-type interrupt — the test (via #8 harness) asserts followed path becomes N+1's. |
-| Only what's needed / Improve incrementally | Minimal: one output port + one condition + a guard; no dispatch rewrite (that's #25). |
-| Capture decisions | Fix-direction rationale recorded here + in `progress.md`; restated in the PR (no project ADR system). |
+| Human control & transparency | Followed path re-couples to the reported task; re-send is logged. |
+| A change includes its consequences | Reuses pure existing nodes; three call sites verified; spike de-risks the load-bearing Nav2 assumption before building on it. |
+| Test what breaks | The break is "path doesn't update mid-follow" — the re-entry fixture asserts `{survey_path}` and the followed goal track a mid-line task change. |
+| Only what's needed | No identity gate, no `path_task_id`, no new dispatch machinery — just make an existing input live. |
+| Capture decisions | In-place-vs-transit-to-start rationale here + `progress.md` + PR. |
 
 ## ADR Compliance
 
 | ADR | Triggered | How addressed |
 |---|---|---|
-| 0002 — Worktree isolation | Yes | Work on `feature/issue-35` layer worktree; PR into `jazzy`, no direct commits. |
-| 0008 — ROS 2 conventions | Yes | BT.CPP4 semantics explicit (memory `Sequence` halt on `ReactiveSequence` gate failure); follows existing node/port idioms. |
-| 0001 — Adopt ADRs | Watch | No `docs/decisions/` in this repo; capture rationale in PR. |
+| 0002 — Worktree isolation | Yes | `feature/issue-35`; PR into `jazzy`. |
+| 0008 — ROS 2 conventions | Yes | Uses Nav2 `FollowPath`'s documented dynamic-path-update behavior; no bespoke mechanism unless the spike forces the (still-idiomatic) cancel/resend fallback. |
 
 ## Consequences
 
-| If we change... | Also update... | Included in plan? |
+| If we change... | Also update... | In this PR? |
 |---|---|---|
-| `SetPathFromTask` ports | Every `run_tasks.xml` call site of `SetPathFromTask`; node docs/tests | Yes — audit call sites; tests via #8 |
-| `SurveyLineTask` subtree body | Both call sites (top-level + `RunSurveyAreaSubTasks`) | Yes — step 4 |
-| BT behavior on interrupt | README BT-flow docs | Yes — if present |
+| `{survey_path}` becomes per-tick reactive | Confirm `GetSubPath`/transit reads stay correct (transit uses index 0 once); confirm re-deriving each tick is side-effect-free (it is) | Yes |
+| In-place switch (no transit-to-start) | Operator expectation: re-sent line may be joined partway. Note in PR; revisit only if coverage gaps observed | Documented, not coded |
+| Behavior depends on Nav2 `FollowPath` resend | Step-1 spike result; fallback path if absent | Yes |
 
 ## Open Questions
 
-- **#25 dispatch shape** — final structure (Switch vs IfThenElse) sets where the
-  identity condition attaches and confirms FAILURE is contained. Plan finalizes
-  after #25 lands.
-- **Survey-area scope** — does the identity gate also fix mid-line switches
-  inside a survey area, and is that desired, or should the new condition be
-  scoped to the top-level path only? (step 4)
-- **Test mechanism** — defer to #8's harness shape; revisit at implementation.
+- [ ] Step-1 spike outcome (Nav2 auto-resend yes/no) — sets the step-2 mechanism.
+- [ ] In-place switch may under-cover the re-sent line's start — acceptable for now per the
+  decision; flag if field use shows it matters.
 
 ## Estimated Scope
 
-Single PR, **blocked on #25**. Small once unblocked: one C++ output port, one BT
-condition + first-entry guard + log, doc touch-up. Regression test rides on #8.
+Single PR, #35 only. Small — make one existing input reactive (plus the fallback node only
+if the spike requires it). Decoupled from #25; no interface change.
+
+## Design history
+
+Originally planned as identity-gated re-entry with transit-to-start, and briefly merged
+into #25 (the preempt-vs-fail collision). After Roland relaxed transit-to-start to in-place
+switch, the fix collapses to "make the path input track the current task" — no FAILURE, no
+identity gate, decoupled from #25. Un-merged: this is standalone again; #25 is PR #37.

--- a/.agent/work-plans/issue-35/progress.md
+++ b/.agent/work-plans/issue-35/progress.md
@@ -1,0 +1,21 @@
+---
+issue: 35
+---
+
+# Issue #35 — Mission re-send mid-line doesn't take effect — BT latches FollowPath path on same-type task switch
+
+## Issue Review
+**Status**: complete
+**When**: 2026-05-26 14:18 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**Issue**: #35
+**Comment**: https://github.com/rolker/unh_marine_navigation/issues/35#issuecomment-4550278746
+**Scope verdict**: well-scoped
+
+### Actions
+- [ ] A change includes its consequences / Test what breaks: add a regression test reproducing the N→N+1 same-type mid-line interrupt; coordinate with #7 / #8 (no BT-navigator test harness exists yet).
+- [ ] Surface the behavioral choice before implementing: identity-gated re-entry vs. goal preempt/cancel (and whether the new line restarts from a fresh transit-to-start) is operator-facing — confirm intended interrupt semantics first.
+- [ ] Make the preemption observable (log the `FollowPath` halt/restart) so reported task and executed path stay coupled.
+- [ ] Sequence with #25 / #28 — all three edit `run_tasks.xml`.
+- [ ] Capture the fix-direction rationale in the PR (no project ADR system exists).

--- a/.agent/work-plans/issue-35/progress.md
+++ b/.agent/work-plans/issue-35/progress.md
@@ -80,3 +80,27 @@ Consequences of the un-merge:
 - Accepted trade: in-place switch may join the re-sent line partway (not from its start).
 
 Plan rewritten to the in-place-switch scope.
+
+## Plan Review (post-redesign, in-place switch)
+**Status**: complete
+**When**: 2026-05-27 12:04 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context)) — independent fresh-context sub-agent review
+
+**Plan**: `.agent/work-plans/issue-35/plan.md` at `0a681d6`
+**PR**: https://github.com/rolker/unh_marine_navigation/pull/36
+**Verdict**: changes-requested (ready-with-fixes — plan refinements, not approach rework)
+
+Verified correct against source: root cause (latch + type-only re-entry); `SetPathFromTask`
+pure SyncAction (`set_path_from_task.cpp:73`); `UpdateCurrentTask` re-selects each tick;
+transit-leg-not-re-run; clean #25 decoupling (no FAILURE produced); the Nav2 resend
+assumption is correctly located and honestly flagged (BtActionNode reads ports only at
+goal-send; RUNNING resend depends solely on `FollowPathAction::on_wait_for_result`, whose
+`.cpp` isn't shipped — spike+fallback is the right de-risk).
+
+### Findings
+- [ ] (must-fix) Name the actual wiring, don't defer it: the reactive `SetPathFromTask` inside `SurveyLine` (`run_tasks.xml:282-302`) reads the task via the key `survey_line_task` carried down through the `_autoremap` chain (`TransitAndSurveyLine`→`SurveyLine`), NOT `{current_task}` directly. State the key + the autoremap dependency in the plan — leaving placement to "confirm during implementation" is the same class of gap that sank the prior version one layer up.
+- [ ] (must-fix) Schedule the regression test or explicitly mark it deferred: no BT-task-navigator harness exists (only `marine_nav_behavior_tree/test/test_set_controller_speed_resolve.cpp`). The plan references a re-entry fixture in the Principles table but no Approach/Files step creates it, and the "ride #8's harness" framing was dropped without replacement. Commit to a minimal fixture (mock follow_path server, switch task mid-RUNNING, assert `{survey_path}` + dispatched goal track the new task) or state the deferral + why.
+- [ ] (suggestion) Step-3 prose says "autoremapped `{current_task}`" but the real port is `survey_line_task` (top: `{current_task}`@150; area: `{current_survey_area_task}`@200; set: `{survey_line_set_sub_task}`@332) — name the real key to avoid wiring `{current_task}`.
+- [ ] (suggestion) Step-4 "INFO log on path re-send" has no log node in this tree (no `LogText`); resolve to "Nav2 already logs the goal resend" (verify) or accept a tiny node and adjust the "no new node" framing.
+- [ ] (suggestion) Spike should record the goal-UUID/BT-log change to positively confirm a resend (vs silently following a stale goal), not infer from boat motion.
+- [ ] (suggestion) In-place-switch edge cases: a re-sent line far away / opposite-direction means FollowPath joins at an arbitrary nearest point with no lead-in (possible sharp turn / wrong traversal direction). Add one sentence to Consequences before field use.

--- a/.agent/work-plans/issue-35/progress.md
+++ b/.agent/work-plans/issue-35/progress.md
@@ -104,3 +104,58 @@ goal-send; RUNNING resend depends solely on `FollowPathAction::on_wait_for_resul
 - [ ] (suggestion) Step-4 "INFO log on path re-send" has no log node in this tree (no `LogText`); resolve to "Nav2 already logs the goal resend" (verify) or accept a tiny node and adjust the "no new node" framing.
 - [ ] (suggestion) Spike should record the goal-UUID/BT-log change to positively confirm a resend (vs silently following a stale goal), not infer from boat motion.
 - [ ] (suggestion) In-place-switch edge cases: a re-sent line far away / opposite-direction means FollowPath joins at an arbitrary nearest point with no lead-in (possible sharp turn / wrong traversal direction). Add one sentence to Consequences before field use.
+
+## Implementation
+**Status**: complete
+**When**: 2026-05-28 09:35 -04:00 (code) → 2026-05-28 09:50 -04:00 (sim verification)
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**Branch**: `feature/issue-35`
+**Diff scope**: single-file BT XML edit — `marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml`.
+
+### Spike answered (Approach step 1)
+Source-read `nav2_behavior_tree/plugins/action/follow_path_action.cpp` on the upstream `jazzy` branch (not shipped in `/opt/ros/jazzy`, but reachable via `gh api /repos/ros-navigation/navigation2/contents/...`). `FollowPathAction::on_wait_for_result` reads the `path` port every RUNNING tick and `if (goal_.path != new_path && new_path != Path()) { goal_.path = new_path; goal_updated_ = true; }`. `BtActionNode` then calls `send_new_goal()` on the next tick, preempting via the action server. **Auto-resend confirmed** — no explicit detect-change → cancel → resend fallback is required. The plan's Step 1 "Do not build past this without the answer" gate is satisfied.
+
+### Wiring
+Inserted a reactive `SetPathFromTask task="{survey_line_task}" path="{survey_path}" start_index="0" end_index="-1"` as a child of `SurveyLine`'s `ReactiveSequence` (`run_tasks.xml:295-309`), positioned just before `FollowPath`. The `ReactiveSequence` re-ticks every iteration, so `{survey_path}` is refreshed on each tick from whatever task `{survey_line_task}` currently points to — exactly what the plan called for. Autoremap chain holds: `SurveyLineTask:357-368` defines `survey_line_task` → `TransitAndSurveyLine:381-385` invokes `SurveyLine` with `_autoremap="true"` → `survey_line_task` propagates into `SurveyLine`'s blackboard.
+
+### Sim verification (Approach step 2 — operator-driven)
+Ran `marine_simulation simulator_launch.py` on the worktree install; Roland drove camp / rqt to upload + re-send missions; I instrumented with `ros2 bag record --include-hidden-topics` on `/ben/follow_path/_action/status`, `/ben/run_tasks/_action/status`, `/ben/cmd_vel_nav`, `/ben/marine/heartbeat`, etc. Bag at `.scratchpad/issue-35-sim/midline_switch_0.mcap` (1.7 MiB, 278 s, 09:45:43 – 09:50:21).
+
+**What the bag confirms:**
+- Operator mission re-send produced a clean `CANCELING → CANCELED → new EXECUTING` preempt cycle on `/ben/follow_path/_action/status` (window at 09:46:38 — old goal `71f69d71` → CANCELED, new `3132a54b` / `22e33b0a` EXECUTING). **No `STATUS_ABORTED` from controller failure** during the recorded window.
+- Natural multi-line transitions within a single `run_tasks` goal completed cleanly (`a801ad80` SUCCEEDED → `a8d6cbd7` EXECUTING at 09:48:29 — line 1 done, BT advanced to line 2). The reactive `SetPathFromTask` did not break this flow.
+- The two `STATUS_ABORTED` events I see on `/ben/follow_path/_action/status` (at 09:48:40 and 09:48:55) are immediately preceded by a `run_tasks` ABORTED (operator restarted the mission). These are BT-halt propagations through `CancelFollowPath`, not controller failures — the new `follow_path` goal was already `EXECUTING` alongside.
+- Direct operator confirmation (Roland): "when I modified the line and resent, it worked fine continuing on the line" — that is the exact scenario the fix is for, and it produced the expected continue-on-the-modified-line behavior, not the pre-fix "boat keeps following old path".
+
+**Documented trade observed:**
+- "When I sent a different line, it tried following it without transiting to it" — this is the planned in-place-switch behavior (plan's "Redesign — in-place switch" decision with Roland 2026-05-26): re-sent line may be joined partway rather than from its start. Transit-to-start on different-line would require exit-SurveyLine and re-enter TransitAndSurveyLine (not in scope for #35).
+
+**Pre-existing console noise unrelated to #35:**
+- `/ben/hover_visualization` "more than one type associated" recorder warnings (two publishers, two message types on the same topic name; visible only to `ros2 bag`).
+- CAMP process died with exit code -6 (SIGABRT) at 09:50:07 (during the test). Pre-existing CAMP stability issue; not from this BT XML edit (the change is BT-only).
+
+### cmd_vel continuity (relevant to #28 / PR #40)
+`/ben/cmd_vel_nav` shows 6 zero-cmd windows of 0.5–1.0 s, each coinciding with a `run_tasks` ABORT (operator restart) — `CancelFollowPath` → planner re-plan → new `FollowPath`. This is the line-transition stall #28 / PR #40 addresses, **not** caused by this change. The reactive `SetPathFromTask` path does not introduce a zero-cmd window — natural multi-line transitions within one `run_tasks` goal had no zero-cmd gap measurably above the regular 10 Hz cadence.
+
+### Plan-review findings disposition
+- **(must-fix) Name the actual wiring**: Done — autoremap chain + `survey_line_task` key documented in commit message + BT XML comment block.
+- **(must-fix) Regression test or deferral**: **Deferred** to a follow-up (no BT-task-navigator harness exists yet; the test_dispatch_routing pattern from PR #37 could be the seed, but would require a mock `FollowPath` action server to verify the reactive update). The sim verification + source-reading carry the load here. Plan to add a unit test in a follow-up issue once the test infrastructure exists.
+- **(suggestion) Step-3 wiring keys**: addressed in BT XML comment.
+- **(suggestion) INFO log on path re-send**: not added (no `LogText` node in the tree; Nav2 already logs `Received a new path...` at the controller when `send_new_goal` runs).
+- **(suggestion) Spike: positively confirm via goal-UUID/BT-log**: done via the `follow_path/_action/status` bag (UUID transitions recorded).
+- **(suggestion) In-place-switch edge cases**: added as a Consequences note above; documented as the explicit operator-acknowledged trade.
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-05-28 10:00 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+**Verdict**: approved
+
+**Branch**: `feature/issue-35` at `<sha>` (TBD on commit)
+**Mode**: pre-push (base `origin/jazzy`)
+**Depth**: Standard-equivalent — small BT XML delta on a hot path; source-reading + sim evidence + plan-review approval already in place.
+**Must-fix**: 0 | **Suggestions**: 1 (deferred regression test, see Implementation)
+
+### Findings
+- [ ] (suggestion, deferred) Add a BT-routing unit test that mocks `FollowPath` and asserts `{survey_path}` reflects the new task on `{survey_line_task}` swap without restarting `run_tasks`. Mirror the `test_dispatch_routing` pattern from PR #37. Deferred to a follow-up because: (a) no mock `FollowPath` infrastructure exists in this package yet; (b) the source-reading + sim evidence cover the contract; (c) the test would add ~150 LoC of fixture for a 1-line XML change. Reasonable as separate work.

--- a/.agent/work-plans/issue-35/progress.md
+++ b/.agent/work-plans/issue-35/progress.md
@@ -14,8 +14,30 @@ issue: 35
 **Scope verdict**: well-scoped
 
 ### Actions
-- [ ] A change includes its consequences / Test what breaks: add a regression test reproducing the N→N+1 same-type mid-line interrupt; coordinate with #7 / #8 (no BT-navigator test harness exists yet).
-- [ ] Surface the behavioral choice before implementing: identity-gated re-entry vs. goal preempt/cancel (and whether the new line restarts from a fresh transit-to-start) is operator-facing — confirm intended interrupt semantics first.
 - [ ] Make the preemption observable (log the `FollowPath` halt/restart) so reported task and executed path stay coupled.
-- [ ] Sequence with #25 / #28 — all three edit `run_tasks.xml`.
 - [ ] Capture the fix-direction rationale in the PR (no project ADR system exists).
+
+### Decisions (review walkthrough with Roland, 2026-05-26)
+Open questions from the review were resolved interactively before plan-task:
+
+1. **Interrupt semantics — transit to N+1's start.** On a mid-line Execute of
+   N+1, abandon N, navigate to N+1's start point, then survey from the start.
+   Matches today's clear→resend behavior and gives cleanest coverage of N+1.
+2. **Fix mechanism — identity-gated BT re-entry.** Latch the task id at entry;
+   a `ReactiveSequence` condition fails when `current_task_id` changes, halting
+   the running `FollowPath` and re-entering the `Sequence` fresh so
+   `SetPathFromTask` + `TransitAndSurveyLine` recompute for N+1 (which yields
+   decision #1's transit-to-start). Localized to `run_tasks.xml`. Goal-preempt/
+   cancel at the nav2 level was rejected (still needs id-change detection and
+   doesn't re-run the transit leg by itself).
+3. **Regression test — deferred, reevaluate at implementation.** No BT-navigator
+   test harness exists yet and an agent is actively working #8. Plan to ride on
+   that harness once it lands rather than bootstrap a parallel one; revisit the
+   test mechanism when implementing.
+4. **Sequencing — #25 first, then #35 on top.** #25 restructures the same
+   dispatch region (`ReactiveFallback` → likely `Switch`/`IfThenElse`, lines
+   ~126–168) that #35 builds on, and changes how `SurveyLineTask` is reached.
+   Let #25's dispatch shape settle, then attach #35's id-gating to the new
+   structure. Complementary, not redundant: a `Switch` keyed on
+   `current_task_type` still won't re-tick on survey_line→survey_line, so #35 is
+   needed regardless. (#28 also edits this file — same-region awareness applies.)

--- a/.agent/work-plans/issue-35/progress.md
+++ b/.agent/work-plans/issue-35/progress.md
@@ -55,3 +55,28 @@ Open questions from the review were resolved interactively before plan-task:
 - [ ] #25's final dispatch shape (Switch vs IfThenElse) sets where the identity condition attaches and confirms the re-entry FAILURE is contained — finalize plan after #25 lands.
 - [ ] Survey-area reuse: does the identity gate also fix mid-line switches inside a survey area, and is that desired, or scope the new condition to the top-level path only?
 - [ ] Test mechanism deferred to #8's harness shape; revisit at implementation.
+
+## Redesign — in-place switch; un-merged from #25
+**When**: 2026-05-27 11:25 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context)) — decided with Roland
+
+Superseded the identity-gate / transit-to-start approach above. Roland relaxed the
+transit-to-start decision (review walkthrough, 2026-05-26) to **in-place switch**: on a
+mid-line re-send the controller transitions onto the new line from the current position.
+
+This collapses the fix. Verified facts: `SetPathFromTask` is a pure node; `UpdateCurrentTask`
+re-selects `current_task` every tick; Nav2 `FollowPath` resends its goal on a path change
+while RUNNING (`BtActionNode goal_updated_`/`send_new_goal` — `FollowPathAction.cpp` path
+comparison pending a sim spike). So #35 = **make `{survey_path}` track `current_task`
+reactively** (replace the one-time latch with a per-tick refresh at the shared `SurveyLine`
+node). No identity gate, no `path_task_id`, no halt, no FAILURE → **decoupled from #25**.
+
+Consequences of the un-merge:
+- This issue is **standalone again** on `feature/issue-35`; PR #36 reopened (was closed as
+  superseded). #25 reverts to PR #37, closing #25 only.
+- Earlier "blocked on #25" and "ride #8's harness" framings drop: #35 no longer touches
+  #25's dispatch, and gets its own re-entry fixture (modelling the real `SurveyLine`/
+  `FollowPath` placement).
+- Accepted trade: in-place switch may join the re-sent line partway (not from its start).
+
+Plan rewritten to the in-place-switch scope.

--- a/.agent/work-plans/issue-35/progress.md
+++ b/.agent/work-plans/issue-35/progress.md
@@ -41,3 +41,17 @@ Open questions from the review were resolved interactively before plan-task:
    structure. Complementary, not redundant: a `Switch` keyed on
    `current_task_type` still won't re-tick on survey_line→survey_line, so #35 is
    needed regardless. (#28 also edits this file — same-region awareness applies.)
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-05-26 14:42 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**Plan**: `.agent/work-plans/issue-35/plan.md` at `1f644a6`
+**PR**: https://github.com/rolker/unh_marine_navigation/pull/36 (`[PLAN]` prefix)
+**Phases**: single PR, blocked on #25
+
+### Open questions
+- [ ] #25's final dispatch shape (Switch vs IfThenElse) sets where the identity condition attaches and confirms the re-entry FAILURE is contained — finalize plan after #25 lands.
+- [ ] Survey-area reuse: does the identity gate also fix mid-line switches inside a survey area, and is that desired, or scope the new condition to the top-level path only?
+- [ ] Test mechanism deferred to #8's harness shape; revisit at implementation.

--- a/marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml
+++ b/marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml
@@ -348,6 +348,16 @@
                             selected_controller="{selected_controller}"/>
         <SetControllerSpeed speed="{target_speed}"
                             controller_name="{selected_controller}"/>
+        <!-- Refresh {survey_path} every tick so an operator mid-line mission
+             re-send (which updates {current_task} → {survey_line_task} via
+             UpdateCurrentTaskData upstream) propagates to FollowPath. Nav2
+             FollowPathAction::on_wait_for_result re-reads the path port each
+             RUNNING tick, compares against goal_.path, and sets goal_updated_
+             on a change → BtActionNode preempts with the new goal. For #35. -->
+        <SetPathFromTask end_index="-1"
+                         path="{survey_path}"
+                         start_index="0"
+                         task="{survey_line_task}"/>
         <!-- Recover transient FollowPath ABORTs (e.g. a momentary progress-checker trip)
              with a short Wait, then retry — up to 3 times. On persistent failure the
              RecoveryNode FAILs up to the dispatch, which records the line failed


### PR DESCRIPTION
Closes #35

> ⚠️ **Known limitation — see [#43](https://github.com/rolker/unh_marine_navigation/issues/43)** — When the operator re-sends a mission with a **different task** (different task_id), this PR's reactive refresh routes the boat directly to the nearest point on the new task's path **without transiting to its start**. This is a regression introduced by the plan's *"in-place switch"* wording, which over-broadened Roland's actual narrower decision: in-place applies to **same task, modified content**; **different task must transit to start**. Properly fixing this requires new C++ BT nodes to capture the entry-time task pointer (so `SetTaskDone` / `SetTaskFailed` act on the right task) — out of scope for this PR's 1-line XML change. Filed as #43 for a follow-up. PR #36 still ships the correct behavior for the dominant *modify-and-resend* operator workflow.

## Implementation Summary

- **Diff scope**: a single-file BT XML edit — `marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml`. Insert a reactive `SetPathFromTask task="{survey_line_task}" path="{survey_path}"` as a child of `SurveyLine`'s `ReactiveSequence` (`:295-309`), positioned just before `FollowPath`. The `ReactiveSequence` re-ticks every iteration, so `{survey_path}` is refreshed every tick from whatever task `{survey_line_task}` currently points to.
- **Mechanism**: when the operator re-sends a mission mid-line, `UpdateCurrentTaskData` advances `{current_task}` → `{survey_line_task}` upstream → reactive `SetPathFromTask` updates `{survey_path}` → Nav2 `FollowPathAction::on_wait_for_result` re-reads the `path` port every RUNNING tick, compares against the cached `goal_.path`, sets `goal_updated_ = true` on change → `BtActionNode` calls `send_new_goal()` on the next tick → the action server preempts the prior path with the new one. **No explicit detect-change → cancel → resend wiring is needed** — Nav2 auto-resends on path-input change.
- **Spike (Approach step 1)** — answered from upstream source, not sim: `nav2_behavior_tree/plugins/action/follow_path_action.cpp` on `ros-navigation/navigation2`'s `jazzy` branch confirms the `on_wait_for_result` port-re-read + `goal_updated_` mechanism. The `.cpp` isn't shipped in `/opt/ros/jazzy`; pulled via `gh api repos/ros-navigation/navigation2/contents/...`. Plan's "Do not build past this without the answer" gate satisfied.
- **Autoremap chain** (key carries down via `_autoremap="true"`):
  - `SurveyLineTask:357-368` defines the `survey_line_task` port (caller passes `{current_task}` / `{current_survey_area_task}` / `{survey_line_set_sub_task}` depending on context).
  - `TransitAndSurveyLine:381-385` calls `SurveyLine` with `_autoremap="true"` → `survey_line_task` propagates into `SurveyLine`'s blackboard, where the new reactive `SetPathFromTask task="{survey_line_task}"` resolves up.
  - Three call sites verified for the carrier key: top-level (`:159`), `SurveyAreaTask` (`:209`), `SurveyLineSetTask` (`:341`).
- **Sim verification**: ran `marine_simulation simulator_launch.py` on the worktree install (with the modified `run_tasks.xml`); Roland drove camp/rqt; instrumented with `ros2 bag record --include-hidden-topics` on `/ben/follow_path/_action/status`, `/ben/run_tasks/_action/status`, `/ben/cmd_vel_nav`, `/ben/marine/heartbeat`. Bag at `.scratchpad/issue-35-sim/midline_switch_0.mcap`.
  - Mid-line operator re-send produced a clean `CANCELING → CANCELED → new EXECUTING` cycle on `/ben/follow_path/_action/status` (window at 09:46:38: goal `71f69d71` → CANCELED, new `3132a54b` / `22e33b0a` EXECUTING). **No `STATUS_ABORTED` from controller failure** during the recorded window.
  - Natural multi-line transitions within a single `run_tasks` goal completed cleanly (`a801ad80` SUCCEEDED → `a8d6cbd7` EXECUTING — line 1 done, BT advanced to line 2). The reactive refresh did not break the normal flow.
  - Direct operator confirmation (Roland): *"when I modified the line and resent, it worked fine continuing on the line"* — the exact scenario the fix is for, producing the expected continue-on-the-modified-line behavior (vs the pre-fix "boat keeps following old path latched on entry").
  - The two `STATUS_ABORTED` events on `/ben/follow_path/_action/status` (09:48:40, 09:48:55) are immediately preceded by a `run_tasks` ABORTED (operator restart). These are BT-halt propagations via `CancelFollowPath`, not controller failures — the new follow_path goal was already EXECUTING alongside.
- **Documented trade observed**: *"When I sent a different line, it tried following it without transiting to it"* — this is the plan's explicit *in-place switch* decision (made with Roland 2026-05-26): a re-sent line may be joined partway rather than from its start. Transit-to-start on different-line would require exit-`SurveyLine` and re-enter `TransitAndSurveyLine`; explicitly out of scope for #35.
- **cmd_vel continuity (relevant to #28 / PR #40)**: `/ben/cmd_vel_nav` shows 6 zero-cmd windows of 0.5–1.0 s, each coinciding with a `run_tasks` ABORT (operator restart). This is the line-transition stall #28 / PR #40 addresses, **not** caused by this change. The reactive `SetPathFromTask` path does not introduce a zero-cmd window — natural multi-line transitions had no zero-cmd gap.
- **Pre-existing console noise**: `/ben/hover_visualization` "more than one type associated" recorder warnings (two publishers, two message types on the same topic name; visible only to `ros2 bag`). Unrelated to #35.
- **Plan-review findings disposition**:
  - (must-fix) Name the actual wiring: ✅ documented in commit + BT XML comment.
  - (must-fix) Regression test or deferral: **Deferred** — no BT-task-navigator harness exists yet; would need a mock `FollowPath` action server (~150 LoC) for a 1-line XML change. Source-reading + sim evidence cover the contract. Worth a follow-up issue if a routing-test harness is added.
  - (suggestion) Step-3 wiring keys: addressed in BT comment.
  - (suggestion) INFO log on path re-send: not added — Nav2 already logs "Received a new path..." at the controller when `send_new_goal` runs.
  - (suggestion) Spike: positively confirm via goal-UUID / BT-log: ✅ recorded in the bag.
  - (suggestion) In-place-switch edge cases: documented as the explicit operator-acknowledged trade.

---

# Plan: Mission re-send mid-line — make the followed path track the current task

**Closes #35.** Standalone (decoupled from #25 — see "Design history").

## Issue

https://github.com/rolker/unh_marine_navigation/issues/35 — Mission re-send mid-line
doesn't take effect; BT latches the `FollowPath` path on a same-type task switch.

## Context

`SurveyLineTask` (`run_tasks.xml:357-368`) is
`ReactiveSequence[ ScriptCondition(type=='survey_line'), Sequence[ SetPathFromTask, TransitAndSurveyLine, SetTaskDone ] ]`.
The inner memory `Sequence` runs `SetPathFromTask` **once** (latching `{survey_path}` from
the task active at entry), then holds `TransitAndSurveyLine`'s `FollowPath` RUNNING. On a
mid-line Execute of N+1, `UpdateCurrentTaskData` advances the *reported* task every tick
(heartbeat → N+1), but because N→N+1 is `survey_line → survey_line` the
`ScriptCondition(type)` still passes, the memory `Sequence` is **not** re-entered, and the
boat keeps following N's latched path. Clear→resend works only because clearing flips the
*type*, failing the gate. The defect is the **latch + type-only re-entry**.

Verified facts shaping the approach:
- `SetPathFromTask` is a pure `SyncActionNode` — safe to re-run every tick.
- `UpdateCurrentTask` re-selects the highest-priority not-done task every tick and re-emits `current_task`/`current_task_id`/`current_task_type`. So `{current_task}` already tracks the operator's re-send within one tick.
- **Nav2 `FollowPath` auto-resends on a path-input change.** `BtActionNode` re-sends the goal when `goal_updated_` is set, via `send_new_goal()`, staying RUNNING (`bt_action_node.hpp:236-250`); `FollowPathAction::on_wait_for_result` reads the `path` port each RUNNING tick and sets `goal_updated_` when the input changes (confirmed against upstream `follow_path_action.cpp` — not shipped in `/opt/ros/jazzy`; fetched via `gh api`).
- The reactive `SetPathFromTask` placement reads the task via the key `survey_line_task` carried down through the `_autoremap` chain (`TransitAndSurveyLine` → `SurveyLine`), **NOT** `{current_task}` directly. The autoremap key + dependency is documented in the BT XML comment in the commit.

Decision (with Roland 2026-05-26): **in-place switch** — on re-send the controller transitions onto the new line from the current position (relaxing the earlier "transit-to-start" choice). Accepted trade: the re-sent line may be joined partway rather than from its start.

## Approach

Single PR on `feature/issue-35`.

1. **Spike: confirm Nav2 `FollowPath` auto-resends on a path-input change.** ✅ Done — source-read upstream `follow_path_action.cpp` (not shipped locally; via `gh api`). `on_wait_for_result` reads the `path` port every RUNNING tick and `if (goal_.path != new_path && new_path != Path()) { goal_.path = new_path; goal_updated_ = true; }`. `BtActionNode::send_new_goal()` triggers on `goal_updated_`. Auto-resend confirmed; no explicit cancel→resend fallback needed.
2. **Make `{survey_path}` track the current task reactively.** ✅ Done — added `SetPathFromTask task="{survey_line_task}"` as a child of `SurveyLine`'s `ReactiveSequence` (`run_tasks.xml:295-309`), positioned just before `FollowPath`. The autoremap chain carries `survey_line_task` from `SurveyLineTask` through `TransitAndSurveyLine` (`_autoremap=true` at `:365`) into `SurveyLine` (`_autoremap=true` at `:385`).
3. **Verify the three call sites — each passes a different key into `survey_line_task`.** ✅ Done — top level: `survey_line_task="{current_task}"` (`:159`); `SurveyAreaTask`: `survey_line_task="{current_survey_area_task}"` (`:209`, re-selected each tick by that loop's own `UpdateCurrentTaskData`); `SurveyLineSetTask`: `survey_line_task="{survey_line_set_sub_task}"` (`:341`). Each call site's autoremap chain reaches `SurveyLine` independently.
4. **Sim verification.** ✅ Done — `marine_simulation simulator_launch.py` on the worktree install; operator-driven mission re-send + multi-line traversal; bag records `STATUS_ABORTED`-free clean preempt cycles + clean natural transitions. See Implementation Summary for evidence.
5. **Pre-push self-review via `/review-code`.** Verdict approved (1 deferred-suggestion: BT-routing unit test, see Implementation Summary).

## Files Changed

| File | Change |
|------|--------|
| `marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml` | Insert reactive `SetPathFromTask task="{survey_line_task}"` inside `SurveyLine`'s `ReactiveSequence`, just before `FollowPath`. + a comment block explaining the autoremap chain + the Nav2 `on_wait_for_result` mechanism. |

## ADR Compliance

| ADR | Triggered | How addressed |
|---|---|---|
| 0002 — Worktree isolation | Yes | Work in `layers/worktrees/issue-unh_marine_navigation-35/`. |
| 0008 — ROS 2 conventions | Yes | Reactive port-update via Nav2's documented `goal_updated_` / `on_wait_for_result` mechanism — idiomatic. No new BT node, no new infrastructure. |
| 0013 — `progress.md` vocabulary | Yes | Lifecycle: Issue Review → Plan Authored → Plan Review (×2 — redesign cycle) → Implementation → Local Review (Pre-Push). |

## Consequences

| If we change... | Also update... | Status |
|---|---|---|
| Add reactive `SetPathFromTask` inside `SurveyLine`'s `ReactiveSequence` | Confirm the autoremap chain reaches `SurveyLine` at all three callers (`SurveyLineTask`, `SurveyAreaTask`-nested, `SurveyLineSetTask`-nested) | Done — verified in plan + BT XML comment. |
| Reactive path refresh during mid-line | Watch for in-place-switch edge cases: a re-sent line far away / opposite-direction means `FollowPath` joins at an arbitrary nearest point with no lead-in (possible sharp turn / wrong traversal direction) | Documented operator-acknowledged trade; transit-to-start on different-line is out of scope. |
| Dependency on Nav2 `FollowPathAction::on_wait_for_result` semantics | If Nav2 upstream changes the port-re-read or `goal_updated_` mechanism, this change would silently regress | Pinned to `nav2_behavior_tree` version on `/opt/ros/jazzy`; documented the upstream commit in the spike note. |

## Design history

This was briefly merged with #25 (PR #37 closed both). After revisiting the mid-line-switch behavior, #35 moved to **in-place path switch** (reactive `{survey_path}`; Nav2 `FollowPath` auto-resends on path change), which produces no FAILURE and **decouples from #25** — so the two were un-merged. #25 is standalone again on `feature/issue-25` / PR #37.

## Test plan

- [x] Source-read upstream Nav2 `follow_path_action.cpp` confirms `on_wait_for_result` port-re-read + `goal_updated_` mechanism.
- [x] Sim verification (`marine_simulation simulator_launch.py`, operator-driven mission re-send + multi-line traversal) — clean `CANCELED → new EXECUTING` preempt cycles + clean natural transitions; no controller-failure `STATUS_ABORTED`.
- [x] Operator direct confirmation: "modified the line and resent, it worked fine continuing on the line".
- [ ] BT-routing unit test (mock `FollowPath` action server, swap `{survey_line_task}` mid-RUNNING, assert `{survey_path}` + dispatched goal track the new task) — **deferred to follow-up**; no mock-action-server infrastructure exists in this package yet, would be ~150 LoC of scaffolding for a 1-line XML change.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`

