### PR TITLE
Cropped local-costmap republisher for operator display

### DIFF
--- a/.agent/work-plans/issue-38/progress.md
+++ b/.agent/work-plans/issue-38/progress.md
@@ -61,9 +61,10 @@ The initial runtime check appeared to show the integer set still rejected; this 
 **CI**: all-pass (copilot reviewer check)
 
 ### Findings
-- [ ] (valid, Copilot R3) non-atomic param callback: on-set mutates `window_size_` before the request is known to succeed (and `continue`s on type failure); diverges from the store if a co-set param fails. Refactor to pre-set validate-only + `add_post_set_parameters_callback` apply — `costmap_window_node.h`
-- [ ] (valid, Copilot R3) `ament_export_dependencies` missing `tf2` (public header includes tf2, lib links tf2::tf2); breaks downstream find_package transitive deps — `marine_nav_utilities/CMakeLists.txt`
-- [ ] (valid-doc, Copilot R3) "coerced to double" wording misleading — stored param keeps integer type, only internal value is double; clarify descriptor + test comment — `costmap_window_node.h`, `test/test_costmap_window_node.cpp`
+All resolved in `8424050` (16 gtest cases pass; param behavior re-verified at runtime on a single clean node).
+- [x] (valid, Copilot R3) non-atomic param callback: on-set mutates `window_size_` before the request is known to succeed (and `continue`s on type failure); diverges from the store if a co-set param fails. Refactored to pre-set validate-only + `add_post_set_parameters_callback` apply — `costmap_window_node.h`
+- [x] (valid, Copilot R3) `ament_export_dependencies` missing `tf2` (public header includes tf2, lib links tf2::tf2); breaks downstream find_package transitive deps — `marine_nav_utilities/CMakeLists.txt`
+- [x] (valid-doc, Copilot R3) "coerced to double" wording misleading — stored param keeps integer type, only internal value is double; clarified descriptor + test name/comment — `costmap_window_node.h`, `test/test_costmap_window_node.cpp`
 
 ### False positives
 - (none this round)

--- a/.agent/work-plans/issue-38/progress.md
+++ b/.agent/work-plans/issue-38/progress.md
@@ -1,0 +1,25 @@
+---
+issue: 38
+---
+
+# Issue #38 — Cropped local-costmap republisher for operator display
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-05-27 11:55 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+**Verdict**: approved
+
+**Branch**: feature/issue-38 at `8c912e9`
+**Mode**: pre-push
+**Depth**: Standard (reason: new node with non-trivial crop/origin math)
+**Must-fix**: 0 remaining (5 found and fixed in-branch) | **Suggestions**: 0 open
+
+### Findings
+- [x] (must-fix) NaN/non-positive window size — `std::clamp` UB, collapsed to 0x0 grid — `src/costmap_window.cpp:20`
+- [x] (must-fix) non-finite resolution slipped past `<= 0` guard into `std::clamp` — `src/costmap_window.cpp:20`
+- [x] (must-fix) `info.map_load_time` dropped; now copies whole `info` then overrides — `src/costmap_window.cpp:45`
+- [x] (must-fix) row copy assumed `data.size()==width*height`; added bounds guard — `src/costmap_window.cpp:28`
+- [x] (suggestion) non-finite quaternion → NaN origin; folded into identity guard — `src/costmap_window.cpp:63`
+- [x] (suggestion) subscription reliability now best-available (was default reliable) — `src/costmap_window_node.cpp:28`
+- [ ] (rejected) pub best_effort for "lossy path" — false positive: this DDS hop is node→bridge, both local on gabby; lossiness is downstream of the bridge

--- a/.agent/work-plans/issue-38/progress.md
+++ b/.agent/work-plans/issue-38/progress.md
@@ -23,3 +23,25 @@ issue: 38
 - [x] (suggestion) non-finite quaternion → NaN origin; folded into identity guard — `src/costmap_window.cpp:63`
 - [x] (suggestion) subscription reliability now best-available (was default reliable) — `src/costmap_window_node.cpp:28`
 - [ ] (rejected) pub best_effort for "lossy path" — false positive: this DDS hop is node→bridge, both local on gabby; lossiness is downstream of the bridge
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-05-27 12:31 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**PR**: #39 at `ad1106c`
+**Sources**: 4 (Copilot R2 @ `ad1106c`, Copilot R1 @ `94898b0` [stale], Local Review (Pre-Push) @ `8c912e9`, CI rollup)
+**Cross-source confirmations**: 0 (D & E raised in both Copilot rounds — same source, persistence signal)
+**CI**: all-pass (copilot reviewer check; no build/test CI on this repo yet — issue #9)
+
+### Findings
+- [ ] (valid, Copilot R1+R2) package.xml missing `tf2` / `tf2_geometry_msgs` `<depend>` (linked + included, undeclared) — `marine_nav_utilities/package.xml`
+- [ ] (valid, Copilot R2) `window_size_` data race under a MultiThreadedExecutor + non-default callback group; make `std::atomic<double>` — `marine_nav_utilities/include/marine_nav_utilities/costmap_window_node.h`
+- [ ] (valid, Copilot R1+R2) docstring omits non-finite-resolution/window and data.size-mismatch no-op cases — `marine_nav_utilities/include/marine_nav_utilities/costmap_window.h`
+- [ ] (valid-low, Copilot R1) invalid origin quaternion: offset uses identity but output orientation left as invalid input; write identity on guard — `marine_nav_utilities/src/costmap_window.cpp`
+- [ ] (test-gap, Copilot R1) no test for invalid-quaternion→identity path — `marine_nav_utilities/test/test_costmap_window.cpp`
+- [ ] (decision, from Copilot R2 FP) bare-integer `param set` is rejected by static typing; decide whether to support ints via dynamic typing + coercion — `marine_nav_utilities/include/marine_nav_utilities/costmap_window_node.h`
+
+### False positives
+- (Copilot R2) `OnSetParametersCallbackHandle::SharedPtr` "likely to fail to compile" — false: `rclcpp::Node` aliases it (node.hpp:1014), resolves via base-class lookup; executable is built.
+- (Copilot R2) `as_double()` "will throw and can crash" on integer set — false: static parameter typing rejects a non-double with "Wrong parameter type" before the on-set callback runs; verified at runtime, node stayed alive.

--- a/.agent/work-plans/issue-38/progress.md
+++ b/.agent/work-plans/issue-38/progress.md
@@ -49,3 +49,21 @@ All resolved in `b5ef231` (16 gtest cases pass; integer/double/invalid param beh
 
 ### Note
 The initial runtime check appeared to show the integer set still rejected; this was an **orphaned stale node** from a `ros2 run … &` + `kill <wrapper-pid>` pattern (killed the wrapper, the node lingered). After clearing orphans and running the binary directly, integer coercion works as designed. Reinforces the workspace rule against backgrounded `ros2 run`/`launch` for lifecycle.
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-05-27 13:19 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**PR**: #39 at `c09d45a`
+**Sources**: 2 (Copilot R3 @ `c09d45a`, prior Integrated Review @ `ad1106c`)
+**Cross-source confirmations**: 0 (all R3 comments are new, about the round-1 fixes)
+**CI**: all-pass (copilot reviewer check)
+
+### Findings
+- [ ] (valid, Copilot R3) non-atomic param callback: on-set mutates `window_size_` before the request is known to succeed (and `continue`s on type failure); diverges from the store if a co-set param fails. Refactor to pre-set validate-only + `add_post_set_parameters_callback` apply — `costmap_window_node.h`
+- [ ] (valid, Copilot R3) `ament_export_dependencies` missing `tf2` (public header includes tf2, lib links tf2::tf2); breaks downstream find_package transitive deps — `marine_nav_utilities/CMakeLists.txt`
+- [ ] (valid-doc, Copilot R3) "coerced to double" wording misleading — stored param keeps integer type, only internal value is double; clarify descriptor + test comment — `costmap_window_node.h`, `test/test_costmap_window_node.cpp`
+
+### False positives
+- (none this round)

--- a/.agent/work-plans/issue-38/progress.md
+++ b/.agent/work-plans/issue-38/progress.md
@@ -35,13 +35,17 @@ issue: 38
 **CI**: all-pass (copilot reviewer check; no build/test CI on this repo yet — issue #9)
 
 ### Findings
-- [ ] (valid, Copilot R1+R2) package.xml missing `tf2` / `tf2_geometry_msgs` `<depend>` (linked + included, undeclared) — `marine_nav_utilities/package.xml`
-- [ ] (valid, Copilot R2) `window_size_` data race under a MultiThreadedExecutor + non-default callback group; make `std::atomic<double>` — `marine_nav_utilities/include/marine_nav_utilities/costmap_window_node.h`
-- [ ] (valid, Copilot R1+R2) docstring omits non-finite-resolution/window and data.size-mismatch no-op cases — `marine_nav_utilities/include/marine_nav_utilities/costmap_window.h`
-- [ ] (valid-low, Copilot R1) invalid origin quaternion: offset uses identity but output orientation left as invalid input; write identity on guard — `marine_nav_utilities/src/costmap_window.cpp`
-- [ ] (test-gap, Copilot R1) no test for invalid-quaternion→identity path — `marine_nav_utilities/test/test_costmap_window.cpp`
-- [ ] (decision, from Copilot R2 FP) bare-integer `param set` is rejected by static typing; decide whether to support ints via dynamic typing + coercion — `marine_nav_utilities/include/marine_nav_utilities/costmap_window_node.h`
+All resolved in `b5ef231` (16 gtest cases pass; integer/double/invalid param behavior verified at runtime on a single clean node).
+- [x] (valid, Copilot R1+R2) package.xml missing `tf2` / `tf2_geometry_msgs` `<depend>` (linked + included, undeclared) — `marine_nav_utilities/package.xml`
+- [x] (valid, Copilot R2) `window_size_` data race under a MultiThreadedExecutor + non-default callback group; make `std::atomic<double>` — `marine_nav_utilities/include/marine_nav_utilities/costmap_window_node.h`
+- [x] (valid, Copilot R1+R2) docstring omits non-finite-resolution/window and data.size-mismatch no-op cases — `marine_nav_utilities/include/marine_nav_utilities/costmap_window.h`
+- [x] (valid-low, Copilot R1) invalid origin quaternion: offset uses identity but output orientation left as invalid input; write identity on guard — `marine_nav_utilities/src/costmap_window.cpp`
+- [x] (test-gap, Copilot R1) no test for invalid-quaternion→identity path — `marine_nav_utilities/test/test_costmap_window.cpp`
+- [x] (decision→resolved, Copilot R2) bare-integer `param set`: user chose to support it — enabled dynamic typing + int→double coercion in the on-set callback — `marine_nav_utilities/include/marine_nav_utilities/costmap_window_node.h`
 
 ### False positives
 - (Copilot R2) `OnSetParametersCallbackHandle::SharedPtr` "likely to fail to compile" — false: `rclcpp::Node` aliases it (node.hpp:1014), resolves via base-class lookup; executable is built.
-- (Copilot R2) `as_double()` "will throw and can crash" on integer set — false: static parameter typing rejects a non-double with "Wrong parameter type" before the on-set callback runs; verified at runtime, node stayed alive.
+- (Copilot R2) `as_double()` "will throw and can crash" on integer set — false: static parameter typing rejected a non-double with "Wrong parameter type" before the on-set callback ran; verified at runtime, node stayed alive. Now mooted — dynamic typing + coercion accepts integers.
+
+### Note
+The initial runtime check appeared to show the integer set still rejected; this was an **orphaned stale node** from a `ros2 run … &` + `kill <wrapper-pid>` pattern (killed the wrapper, the node lingered). After clearing orphans and running the binary directly, integer coercion works as designed. Reinforces the workspace rule against backgrounded `ros2 run`/`launch` for lifecycle.

--- a/marine_nav_utilities/CMakeLists.txt
+++ b/marine_nav_utilities/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
+find_package(rcl_interfaces REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
@@ -44,6 +45,7 @@ add_executable(costmap_window_node src/costmap_window_node.cpp)
 target_link_libraries(costmap_window_node
   ${PROJECT_NAME}
   ${nav_msgs_TARGETS}
+  ${rcl_interfaces_TARGETS}
   rclcpp::rclcpp
 )
 
@@ -77,6 +79,7 @@ ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_dependencies(
   geometry_msgs
   nav_msgs
+  rcl_interfaces
   tf2
   tf2_geometry_msgs
   rclcpp

--- a/marine_nav_utilities/CMakeLists.txt
+++ b/marine_nav_utilities/CMakeLists.txt
@@ -11,6 +11,7 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(geometry_msgs REQUIRED)
+find_package(nav_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
@@ -18,6 +19,7 @@ find_package(tf2_geometry_msgs REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED
   src/utilities.cpp
+  src/costmap_window.cpp
 )
 
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
@@ -30,11 +32,23 @@ target_include_directories(
     "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
 )
 
-target_link_libraries( ${PROJECT_NAME} 
+target_link_libraries( ${PROJECT_NAME}
   ${geometry_msgs_TARGETS}
+  ${nav_msgs_TARGETS}
   rclcpp::rclcpp
   tf2::tf2
   tf2_geometry_msgs::tf2_geometry_msgs
+)
+
+add_executable(costmap_window_node src/costmap_window_node.cpp)
+target_link_libraries(costmap_window_node
+  ${PROJECT_NAME}
+  ${nav_msgs_TARGETS}
+  rclcpp::rclcpp
+)
+
+install(TARGETS costmap_window_node
+  DESTINATION lib/${PROJECT_NAME}
 )
 
 install(
@@ -52,6 +66,7 @@ install(
 
 ament_target_dependencies(${PROJECT_NAME}
   geometry_msgs
+  nav_msgs
   rclcpp
   tf2
   tf2_geometry_msgs
@@ -61,6 +76,7 @@ ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 
 ament_export_dependencies(
   geometry_msgs
+  nav_msgs
   tf2_geometry_msgs
   rclcpp
 )
@@ -68,6 +84,13 @@ ament_export_dependencies(
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(test_costmap_window test/test_costmap_window.cpp)
+  target_link_libraries(test_costmap_window
+    ${PROJECT_NAME}
+    ${nav_msgs_TARGETS}
+  )
 endif()
 
 ament_package()

--- a/marine_nav_utilities/CMakeLists.txt
+++ b/marine_nav_utilities/CMakeLists.txt
@@ -91,6 +91,13 @@ if(BUILD_TESTING)
     ${PROJECT_NAME}
     ${nav_msgs_TARGETS}
   )
+
+  ament_add_gtest(test_costmap_window_node test/test_costmap_window_node.cpp)
+  target_link_libraries(test_costmap_window_node
+    ${PROJECT_NAME}
+    ${nav_msgs_TARGETS}
+    rclcpp::rclcpp
+  )
 endif()
 
 ament_package()

--- a/marine_nav_utilities/CMakeLists.txt
+++ b/marine_nav_utilities/CMakeLists.txt
@@ -77,6 +77,7 @@ ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_dependencies(
   geometry_msgs
   nav_msgs
+  tf2
   tf2_geometry_msgs
   rclcpp
 )

--- a/marine_nav_utilities/include/marine_nav_utilities/costmap_window.h
+++ b/marine_nav_utilities/include/marine_nav_utilities/costmap_window.h
@@ -1,0 +1,31 @@
+#ifndef MARINE_NAV_UTILITIES_COSTMAP_WINDOW_H
+#define MARINE_NAV_UTILITIES_COSTMAP_WINDOW_H
+
+#include "nav_msgs/msg/occupancy_grid.hpp"
+
+namespace marine_nav_utilities
+{
+
+/// Center-crop a square window out of an OccupancyGrid.
+///
+/// Extracts a square sub-grid `window_size_meters` on a side, centered on the
+/// geometric center of \p input, at the input resolution (no resampling). The
+/// result is a valid OccupancyGrid: same \c header and \c resolution, \c width /
+/// \c height set to the window, and \c info.origin shifted to the cropped
+/// region's corner. The shift is applied along the grid's own axes via the input
+/// origin orientation, so it is correct even for a rotated grid.
+///
+/// For a Nav2 \c rolling_window costmap the robot sits at the grid center, so a
+/// center crop is robot-centered. For a static/global grid this crops the
+/// geometric center, which is not the robot.
+///
+/// The window side in cells is `round(window_size_meters / resolution)`, clamped
+/// to `[1, min(width, height)]`. If \p input has a non-positive resolution or no
+/// cells, it is returned unchanged.
+nav_msgs::msg::OccupancyGrid cropCostmapWindow(
+  const nav_msgs::msg::OccupancyGrid & input,
+  double window_size_meters);
+
+}  // namespace marine_nav_utilities
+
+#endif  // MARINE_NAV_UTILITIES_COSTMAP_WINDOW_H

--- a/marine_nav_utilities/include/marine_nav_utilities/costmap_window.h
+++ b/marine_nav_utilities/include/marine_nav_utilities/costmap_window.h
@@ -1,10 +1,20 @@
 #ifndef MARINE_NAV_UTILITIES_COSTMAP_WINDOW_H
 #define MARINE_NAV_UTILITIES_COSTMAP_WINDOW_H
 
+#include <cmath>
+
 #include "nav_msgs/msg/occupancy_grid.hpp"
 
 namespace marine_nav_utilities
 {
+
+/// A window size (meters) is usable only if it is finite and positive. A NaN
+/// would otherwise slip past a bare `<= 0` test into std::clamp (undefined
+/// behavior). Shared by cropCostmapWindow() and the node's parameter validation.
+inline bool windowSizeIsValid(double window_size_meters)
+{
+  return std::isfinite(window_size_meters) && window_size_meters > 0.0;
+}
 
 /// Center-crop a square window out of an OccupancyGrid.
 ///

--- a/marine_nav_utilities/include/marine_nav_utilities/costmap_window.h
+++ b/marine_nav_utilities/include/marine_nav_utilities/costmap_window.h
@@ -30,8 +30,10 @@ inline bool windowSizeIsValid(double window_size_meters)
 /// geometric center, which is not the robot.
 ///
 /// The window side in cells is `round(window_size_meters / resolution)`, clamped
-/// to `[1, min(width, height)]`. If \p input has a non-positive resolution or no
-/// cells, it is returned unchanged.
+/// to `[1, min(width, height)]`. \p input is returned unchanged when it can't be
+/// cropped meaningfully: non-finite or non-positive resolution, zero width or
+/// height, a non-finite or non-positive \p window_size_meters, or a `data` size
+/// that doesn't equal `width * height`.
 nav_msgs::msg::OccupancyGrid cropCostmapWindow(
   const nav_msgs::msg::OccupancyGrid & input,
   double window_size_meters);

--- a/marine_nav_utilities/include/marine_nav_utilities/costmap_window_node.h
+++ b/marine_nav_utilities/include/marine_nav_utilities/costmap_window_node.h
@@ -35,11 +35,18 @@ public:
     descriptor.dynamic_typing = true;
     descriptor.description =
       "Side length in meters of the square window cropped from the costmap "
-      "(finite, > 0). Integer values are accepted and coerced to double.";
+      "(finite, > 0). An integer value is accepted and used as a double "
+      "internally; the stored parameter keeps its original type.";
     window_size_ = declare_parameter("window_size", 200.0, descriptor);
 
+    // Validate in the pre-set callback (no side effects) and apply only in the
+    // post-set callback, which fires after the whole atomic request commits.
+    // This keeps window_size_ in sync with the parameter store even when a
+    // co-set parameter in the same request is rejected.
     param_callback_handle_ = add_on_set_parameters_callback(
       std::bind(&CostmapWindowNode::onSetParameters, this, std::placeholders::_1));
+    post_param_callback_handle_ = add_post_set_parameters_callback(
+      std::bind(&CostmapWindowNode::onPostSetParameters, this, std::placeholders::_1));
 
     // Nav2 publishes the costmap reliable + transient-local (latched). Use
     // best-available for both policies so we attach and receive the streamed
@@ -58,35 +65,60 @@ public:
   }
 
 private:
+  // Read a window_size parameter as a double, accepting INTEGER or DOUBLE.
+  // Returns false (leaving \p value untouched) for any other type.
+  static bool windowSizeFromParameter(const rclcpp::Parameter & parameter, double & value)
+  {
+    switch (parameter.get_type()) {
+      case rclcpp::ParameterType::PARAMETER_DOUBLE:
+        value = parameter.as_double();
+        return true;
+      case rclcpp::ParameterType::PARAMETER_INTEGER:
+        value = static_cast<double>(parameter.as_int());
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  // Pre-set: validate only, with no side effects. A SetParameters request is
+  // atomic — returning unsuccessful means none of its parameters are applied —
+  // so mutating state here would risk diverging from the parameter store.
   rcl_interfaces::msg::SetParametersResult onSetParameters(
     const std::vector<rclcpp::Parameter> & parameters)
   {
     rcl_interfaces::msg::SetParametersResult result;
     result.successful = true;
     for (const auto & parameter : parameters) {
-      if (parameter.get_name() == "window_size") {
-        double value;
-        switch (parameter.get_type()) {
-          case rclcpp::ParameterType::PARAMETER_DOUBLE:
-            value = parameter.as_double();
-            break;
-          case rclcpp::ParameterType::PARAMETER_INTEGER:
-            value = static_cast<double>(parameter.as_int());
-            break;
-          default:
-            result.successful = false;
-            result.reason = "window_size must be a number (double or integer)";
-            continue;
-        }
-        if (!windowSizeIsValid(value)) {
-          result.successful = false;
-          result.reason = "window_size must be finite and > 0";
-        } else {
-          window_size_ = value;
-        }
+      if (parameter.get_name() != "window_size") {
+        continue;
+      }
+      double value;
+      if (!windowSizeFromParameter(parameter, value)) {
+        result.successful = false;
+        result.reason = "window_size must be a number (double or integer)";
+        break;
+      }
+      if (!windowSizeIsValid(value)) {
+        result.successful = false;
+        result.reason = "window_size must be finite and > 0";
+        break;
       }
     }
     return result;
+  }
+
+  // Post-set: apply the validated value, called only after the request commits.
+  void onPostSetParameters(const std::vector<rclcpp::Parameter> & parameters)
+  {
+    for (const auto & parameter : parameters) {
+      double value;
+      if (parameter.get_name() == "window_size" &&
+        windowSizeFromParameter(parameter, value))
+      {
+        window_size_ = value;
+      }
+    }
   }
 
   void costmapCallback(const nav_msgs::msg::OccupancyGrid & grid)
@@ -107,6 +139,7 @@ private:
   std::atomic<double> window_size_{200.0};
   bool logged_{false};
   OnSetParametersCallbackHandle::SharedPtr param_callback_handle_;
+  PostSetParametersCallbackHandle::SharedPtr post_param_callback_handle_;
   rclcpp::Subscription<nav_msgs::msg::OccupancyGrid>::SharedPtr subscription_;
   rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr publisher_;
 };

--- a/marine_nav_utilities/include/marine_nav_utilities/costmap_window_node.h
+++ b/marine_nav_utilities/include/marine_nav_utilities/costmap_window_node.h
@@ -1,0 +1,93 @@
+#ifndef MARINE_NAV_UTILITIES_COSTMAP_WINDOW_NODE_H
+#define MARINE_NAV_UTILITIES_COSTMAP_WINDOW_NODE_H
+
+#include <functional>
+#include <vector>
+
+#include "marine_nav_utilities/costmap_window.h"
+#include "nav_msgs/msg/occupancy_grid.hpp"
+#include "rcl_interfaces/msg/set_parameters_result.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+namespace marine_nav_utilities
+{
+
+/// Republishes a cropped, smaller window of an OccupancyGrid (typically a Nav2
+/// rolling local costmap) so it is cheap enough to forward to the operator over
+/// a lossy, rate-limited link. The output is a full, self-contained grid each
+/// time, so it tolerates dropped frames without any delta-stitching downstream.
+///
+/// The `window_size` parameter (meters) is dynamically updatable: a set-parameter
+/// request with a non-finite or non-positive value is rejected so the operator
+/// gets immediate feedback rather than a silent no-crop.
+class CostmapWindowNode : public rclcpp::Node
+{
+public:
+  explicit CostmapWindowNode(const rclcpp::NodeOptions & options)
+  : rclcpp::Node("costmap_window", options)
+  {
+    window_size_ = declare_parameter("window_size", 200.0);
+
+    param_callback_handle_ = add_on_set_parameters_callback(
+      std::bind(&CostmapWindowNode::onSetParameters, this, std::placeholders::_1));
+
+    // Nav2 publishes the costmap reliable + transient-local (latched). Use
+    // best-available for both policies so we attach and receive the streamed
+    // updates regardless of how the source is configured.
+    rclcpp::QoS sub_qos(1);
+    sub_qos.reliability_best_available();
+    sub_qos.durability_best_available();
+    subscription_ = create_subscription<nav_msgs::msg::OccupancyGrid>(
+      "costmap", sub_qos,
+      std::bind(&CostmapWindowNode::costmapCallback, this, std::placeholders::_1));
+
+    // Publish latched so a late-joining consumer (CAMP / the bridge) immediately
+    // gets the most recent window.
+    publisher_ = create_publisher<nav_msgs::msg::OccupancyGrid>(
+      "costmap_windowed", rclcpp::QoS(1).transient_local());
+  }
+
+private:
+  rcl_interfaces::msg::SetParametersResult onSetParameters(
+    const std::vector<rclcpp::Parameter> & parameters)
+  {
+    rcl_interfaces::msg::SetParametersResult result;
+    result.successful = true;
+    for (const auto & parameter : parameters) {
+      if (parameter.get_name() == "window_size") {
+        const double value = parameter.as_double();
+        if (!windowSizeIsValid(value)) {
+          result.successful = false;
+          result.reason = "window_size must be finite and > 0";
+        } else {
+          window_size_ = value;
+        }
+      }
+    }
+    return result;
+  }
+
+  void costmapCallback(const nav_msgs::msg::OccupancyGrid & grid)
+  {
+    const auto windowed = cropCostmapWindow(grid, window_size_);
+    if (!logged_) {
+      RCLCPP_INFO(
+        get_logger(),
+        "Cropping costmap %ux%u @ %.3f m -> %ux%u (window %.1f m)",
+        grid.info.width, grid.info.height, grid.info.resolution,
+        windowed.info.width, windowed.info.height, window_size_);
+      logged_ = true;
+    }
+    publisher_->publish(windowed);
+  }
+
+  double window_size_{200.0};
+  bool logged_{false};
+  OnSetParametersCallbackHandle::SharedPtr param_callback_handle_;
+  rclcpp::Subscription<nav_msgs::msg::OccupancyGrid>::SharedPtr subscription_;
+  rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr publisher_;
+};
+
+}  // namespace marine_nav_utilities
+
+#endif  // MARINE_NAV_UTILITIES_COSTMAP_WINDOW_NODE_H

--- a/marine_nav_utilities/include/marine_nav_utilities/costmap_window_node.h
+++ b/marine_nav_utilities/include/marine_nav_utilities/costmap_window_node.h
@@ -1,11 +1,13 @@
 #ifndef MARINE_NAV_UTILITIES_COSTMAP_WINDOW_NODE_H
 #define MARINE_NAV_UTILITIES_COSTMAP_WINDOW_NODE_H
 
+#include <atomic>
 #include <functional>
 #include <vector>
 
 #include "marine_nav_utilities/costmap_window.h"
 #include "nav_msgs/msg/occupancy_grid.hpp"
+#include "rcl_interfaces/msg/parameter_descriptor.hpp"
 #include "rcl_interfaces/msg/set_parameters_result.hpp"
 #include "rclcpp/rclcpp.hpp"
 
@@ -26,7 +28,15 @@ public:
   explicit CostmapWindowNode(const rclcpp::NodeOptions & options)
   : rclcpp::Node("costmap_window", options)
   {
-    window_size_ = declare_parameter("window_size", 200.0);
+    // Dynamic typing so a bare integer (`ros2 param set ... window_size 100`)
+    // reaches the callback to be coerced, rather than being rejected up front by
+    // static type checking. The callback enforces the type and value.
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.dynamic_typing = true;
+    descriptor.description =
+      "Side length in meters of the square window cropped from the costmap "
+      "(finite, > 0). Integer values are accepted and coerced to double.";
+    window_size_ = declare_parameter("window_size", 200.0, descriptor);
 
     param_callback_handle_ = add_on_set_parameters_callback(
       std::bind(&CostmapWindowNode::onSetParameters, this, std::placeholders::_1));
@@ -55,7 +65,19 @@ private:
     result.successful = true;
     for (const auto & parameter : parameters) {
       if (parameter.get_name() == "window_size") {
-        const double value = parameter.as_double();
+        double value;
+        switch (parameter.get_type()) {
+          case rclcpp::ParameterType::PARAMETER_DOUBLE:
+            value = parameter.as_double();
+            break;
+          case rclcpp::ParameterType::PARAMETER_INTEGER:
+            value = static_cast<double>(parameter.as_int());
+            break;
+          default:
+            result.successful = false;
+            result.reason = "window_size must be a number (double or integer)";
+            continue;
+        }
         if (!windowSizeIsValid(value)) {
           result.successful = false;
           result.reason = "window_size must be finite and > 0";
@@ -69,19 +91,20 @@ private:
 
   void costmapCallback(const nav_msgs::msg::OccupancyGrid & grid)
   {
-    const auto windowed = cropCostmapWindow(grid, window_size_);
+    const double window_size = window_size_.load();
+    const auto windowed = cropCostmapWindow(grid, window_size);
     if (!logged_) {
       RCLCPP_INFO(
         get_logger(),
         "Cropping costmap %ux%u @ %.3f m -> %ux%u (window %.1f m)",
         grid.info.width, grid.info.height, grid.info.resolution,
-        windowed.info.width, windowed.info.height, window_size_);
+        windowed.info.width, windowed.info.height, window_size);
       logged_ = true;
     }
     publisher_->publish(windowed);
   }
 
-  double window_size_{200.0};
+  std::atomic<double> window_size_{200.0};
   bool logged_{false};
   OnSetParametersCallbackHandle::SharedPtr param_callback_handle_;
   rclcpp::Subscription<nav_msgs::msg::OccupancyGrid>::SharedPtr subscription_;

--- a/marine_nav_utilities/package.xml
+++ b/marine_nav_utilities/package.xml
@@ -12,6 +12,8 @@
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
+  <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/marine_nav_utilities/package.xml
+++ b/marine_nav_utilities/package.xml
@@ -10,8 +10,10 @@
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
   <depend>geometry_msgs</depend>
+  <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/marine_nav_utilities/package.xml
+++ b/marine_nav_utilities/package.xml
@@ -11,6 +11,7 @@
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
+  <depend>rcl_interfaces</depend>
   <depend>rclcpp</depend>
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>

--- a/marine_nav_utilities/src/costmap_window.cpp
+++ b/marine_nav_utilities/src/costmap_window.cpp
@@ -17,11 +17,10 @@ nav_msgs::msg::OccupancyGrid cropCostmapWindow(
   const double resolution = input.info.resolution;
 
   // Nothing meaningful to crop from a degenerate grid or a bad window size.
-  // Reject non-finite resolution/window explicitly: a NaN slips past a bare
-  // `<= 0.0` test and std::clamp with a NaN bound is undefined behavior (it
-  // would otherwise collapse to a 0x0 grid).
+  // Reject a non-finite resolution explicitly: a NaN slips past a bare `<= 0.0`
+  // test and std::clamp with a NaN bound is undefined behavior.
   if (!std::isfinite(resolution) || resolution <= 0.0 || width == 0 || height == 0 ||
-    !std::isfinite(window_size_meters) || window_size_meters <= 0.0)
+    !windowSizeIsValid(window_size_meters))
   {
     return input;
   }

--- a/marine_nav_utilities/src/costmap_window.cpp
+++ b/marine_nav_utilities/src/costmap_window.cpp
@@ -1,0 +1,87 @@
+#include "marine_nav_utilities/costmap_window.h"
+
+#include <algorithm>
+#include <cmath>
+
+#include "tf2/utils.h"
+
+namespace marine_nav_utilities
+{
+
+nav_msgs::msg::OccupancyGrid cropCostmapWindow(
+  const nav_msgs::msg::OccupancyGrid & input,
+  double window_size_meters)
+{
+  const unsigned int width = input.info.width;
+  const unsigned int height = input.info.height;
+  const double resolution = input.info.resolution;
+
+  // Nothing meaningful to crop from a degenerate grid or a bad window size.
+  // Reject non-finite resolution/window explicitly: a NaN slips past a bare
+  // `<= 0.0` test and std::clamp with a NaN bound is undefined behavior (it
+  // would otherwise collapse to a 0x0 grid).
+  if (!std::isfinite(resolution) || resolution <= 0.0 || width == 0 || height == 0 ||
+    !std::isfinite(window_size_meters) || window_size_meters <= 0.0)
+  {
+    return input;
+  }
+
+  // A well-formed OccupancyGrid has exactly width*height cells; bail rather than
+  // read out of bounds on a malformed message.
+  if (input.data.size() != static_cast<size_t>(width) * height) {
+    return input;
+  }
+
+  // Window side in cells, clamped to fit within the grid.
+  const unsigned int min_dim = std::min(width, height);
+  const double requested_cells = std::round(window_size_meters / resolution);
+  const unsigned int side = static_cast<unsigned int>(
+    std::clamp(requested_cells, 1.0, static_cast<double>(min_dim)));
+
+  // Center-crop offsets. Integer division puts any odd leftover cell on the high
+  // side, which is the conventional centered-window behavior.
+  const unsigned int x0 = (width - side) / 2;
+  const unsigned int y0 = (height - side) / 2;
+
+  nav_msgs::msg::OccupancyGrid output;
+  output.header = input.header;
+  // Copy all metadata (resolution, map_load_time, origin, ...), then override
+  // the dimensions and origin below. Copying wholesale keeps any future
+  // MapMetaData field carried over instead of silently dropped.
+  output.info = input.info;
+  output.info.width = side;
+  output.info.height = side;
+
+  // Shift the origin to the cropped corner. info.origin is the pose of cell
+  // (0,0); the new corner is (x0, y0) cells away along the grid's local axes, so
+  // rotate that offset by the origin orientation before adding it to the origin
+  // position. Orientation is unchanged. A zero/unset quaternion is treated as
+  // identity (no rotation).
+  tf2::Quaternion q(
+    input.info.origin.orientation.x, input.info.origin.orientation.y,
+    input.info.origin.orientation.z, input.info.origin.orientation.w);
+  if (!std::isfinite(q.length2()) || q.length2() < 1e-9) {
+    q = tf2::Quaternion::getIdentity();
+  }
+  const tf2::Vector3 world_offset =
+    tf2::Matrix3x3(q.normalized()) *
+    tf2::Vector3(x0 * resolution, y0 * resolution, 0.0);
+
+  output.info.origin.position.x += world_offset.x();
+  output.info.origin.position.y += world_offset.y();
+  output.info.origin.position.z += world_offset.z();
+
+  // Copy the windowed cells row by row (row-major, row 0 at the origin).
+  output.data.resize(static_cast<size_t>(side) * side);
+  for (unsigned int row = 0; row < side; ++row) {
+    const auto in_begin =
+      input.data.begin() + static_cast<size_t>(y0 + row) * width + x0;
+    std::copy(
+      in_begin, in_begin + side,
+      output.data.begin() + static_cast<size_t>(row) * side);
+  }
+
+  return output;
+}
+
+}  // namespace marine_nav_utilities

--- a/marine_nav_utilities/src/costmap_window.cpp
+++ b/marine_nav_utilities/src/costmap_window.cpp
@@ -54,21 +54,27 @@ nav_msgs::msg::OccupancyGrid cropCostmapWindow(
   // Shift the origin to the cropped corner. info.origin is the pose of cell
   // (0,0); the new corner is (x0, y0) cells away along the grid's local axes, so
   // rotate that offset by the origin orientation before adding it to the origin
-  // position. Orientation is unchanged. A zero/unset quaternion is treated as
-  // identity (no rotation).
+  // position. A zero/unset/non-finite quaternion is treated as identity (no
+  // rotation). The sanitized, unit-normalized orientation is written back so the
+  // output is a self-consistent, valid grid even for malformed input.
   tf2::Quaternion q(
     input.info.origin.orientation.x, input.info.origin.orientation.y,
     input.info.origin.orientation.z, input.info.origin.orientation.w);
   if (!std::isfinite(q.length2()) || q.length2() < 1e-9) {
     q = tf2::Quaternion::getIdentity();
   }
+  q.normalize();
+
   const tf2::Vector3 world_offset =
-    tf2::Matrix3x3(q.normalized()) *
-    tf2::Vector3(x0 * resolution, y0 * resolution, 0.0);
+    tf2::Matrix3x3(q) * tf2::Vector3(x0 * resolution, y0 * resolution, 0.0);
 
   output.info.origin.position.x += world_offset.x();
   output.info.origin.position.y += world_offset.y();
   output.info.origin.position.z += world_offset.z();
+  output.info.origin.orientation.x = q.x();
+  output.info.origin.orientation.y = q.y();
+  output.info.origin.orientation.z = q.z();
+  output.info.origin.orientation.w = q.w();
 
   // Copy the windowed cells row by row (row-major, row 0 at the origin).
   output.data.resize(static_cast<size_t>(side) * side);

--- a/marine_nav_utilities/src/costmap_window_node.cpp
+++ b/marine_nav_utilities/src/costmap_window_node.cpp
@@ -1,63 +1,7 @@
-#include <functional>
 #include <memory>
 
-#include "marine_nav_utilities/costmap_window.h"
-#include "nav_msgs/msg/occupancy_grid.hpp"
+#include "marine_nav_utilities/costmap_window_node.h"
 #include "rclcpp/rclcpp.hpp"
-
-namespace marine_nav_utilities
-{
-
-/// Republishes a cropped, smaller window of an OccupancyGrid (typically a Nav2
-/// rolling local costmap) so it is cheap enough to forward to the operator over
-/// a lossy, rate-limited link. The output is a full, self-contained grid each
-/// time, so it tolerates dropped frames without any delta-stitching downstream.
-class CostmapWindowNode : public rclcpp::Node
-{
-public:
-  explicit CostmapWindowNode(const rclcpp::NodeOptions & options)
-  : rclcpp::Node("costmap_window", options)
-  {
-    window_size_ = declare_parameter("window_size", 200.0);
-
-    // Nav2 publishes the costmap reliable + transient-local (latched). Use
-    // best-available for both policies so we attach and receive the streamed
-    // updates regardless of how the source is configured.
-    rclcpp::QoS sub_qos(1);
-    sub_qos.reliability_best_available();
-    sub_qos.durability_best_available();
-    subscription_ = create_subscription<nav_msgs::msg::OccupancyGrid>(
-      "costmap", sub_qos,
-      std::bind(&CostmapWindowNode::costmapCallback, this, std::placeholders::_1));
-
-    // Publish latched so a late-joining consumer (CAMP / the bridge) immediately
-    // gets the most recent window.
-    publisher_ = create_publisher<nav_msgs::msg::OccupancyGrid>(
-      "costmap_windowed", rclcpp::QoS(1).transient_local());
-  }
-
-private:
-  void costmapCallback(const nav_msgs::msg::OccupancyGrid & grid)
-  {
-    const auto windowed = cropCostmapWindow(grid, window_size_);
-    if (!logged_) {
-      RCLCPP_INFO(
-        get_logger(),
-        "Cropping costmap %ux%u @ %.3f m -> %ux%u (window %.1f m)",
-        grid.info.width, grid.info.height, grid.info.resolution,
-        windowed.info.width, windowed.info.height, window_size_);
-      logged_ = true;
-    }
-    publisher_->publish(windowed);
-  }
-
-  double window_size_{200.0};
-  bool logged_{false};
-  rclcpp::Subscription<nav_msgs::msg::OccupancyGrid>::SharedPtr subscription_;
-  rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr publisher_;
-};
-
-}  // namespace marine_nav_utilities
 
 int main(int argc, char ** argv)
 {

--- a/marine_nav_utilities/src/costmap_window_node.cpp
+++ b/marine_nav_utilities/src/costmap_window_node.cpp
@@ -1,0 +1,69 @@
+#include <functional>
+#include <memory>
+
+#include "marine_nav_utilities/costmap_window.h"
+#include "nav_msgs/msg/occupancy_grid.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+namespace marine_nav_utilities
+{
+
+/// Republishes a cropped, smaller window of an OccupancyGrid (typically a Nav2
+/// rolling local costmap) so it is cheap enough to forward to the operator over
+/// a lossy, rate-limited link. The output is a full, self-contained grid each
+/// time, so it tolerates dropped frames without any delta-stitching downstream.
+class CostmapWindowNode : public rclcpp::Node
+{
+public:
+  explicit CostmapWindowNode(const rclcpp::NodeOptions & options)
+  : rclcpp::Node("costmap_window", options)
+  {
+    window_size_ = declare_parameter("window_size", 200.0);
+
+    // Nav2 publishes the costmap reliable + transient-local (latched). Use
+    // best-available for both policies so we attach and receive the streamed
+    // updates regardless of how the source is configured.
+    rclcpp::QoS sub_qos(1);
+    sub_qos.reliability_best_available();
+    sub_qos.durability_best_available();
+    subscription_ = create_subscription<nav_msgs::msg::OccupancyGrid>(
+      "costmap", sub_qos,
+      std::bind(&CostmapWindowNode::costmapCallback, this, std::placeholders::_1));
+
+    // Publish latched so a late-joining consumer (CAMP / the bridge) immediately
+    // gets the most recent window.
+    publisher_ = create_publisher<nav_msgs::msg::OccupancyGrid>(
+      "costmap_windowed", rclcpp::QoS(1).transient_local());
+  }
+
+private:
+  void costmapCallback(const nav_msgs::msg::OccupancyGrid & grid)
+  {
+    const auto windowed = cropCostmapWindow(grid, window_size_);
+    if (!logged_) {
+      RCLCPP_INFO(
+        get_logger(),
+        "Cropping costmap %ux%u @ %.3f m -> %ux%u (window %.1f m)",
+        grid.info.width, grid.info.height, grid.info.resolution,
+        windowed.info.width, windowed.info.height, window_size_);
+      logged_ = true;
+    }
+    publisher_->publish(windowed);
+  }
+
+  double window_size_{200.0};
+  bool logged_{false};
+  rclcpp::Subscription<nav_msgs::msg::OccupancyGrid>::SharedPtr subscription_;
+  rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr publisher_;
+};
+
+}  // namespace marine_nav_utilities
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(
+    std::make_shared<marine_nav_utilities::CostmapWindowNode>(rclcpp::NodeOptions()));
+  rclcpp::shutdown();
+  return 0;
+}

--- a/marine_nav_utilities/test/test_costmap_window.cpp
+++ b/marine_nav_utilities/test/test_costmap_window.cpp
@@ -1,0 +1,169 @@
+#include <cmath>
+
+#include <gtest/gtest.h>
+
+#include "marine_nav_utilities/costmap_window.h"
+
+namespace
+{
+
+// Build a grid with identity origin orientation and data[i] = i % 100, so every
+// cell is individually identifiable for crop-correctness checks.
+nav_msgs::msg::OccupancyGrid makeGrid(
+  unsigned int width, unsigned int height, double resolution,
+  double origin_x = 0.0, double origin_y = 0.0)
+{
+  nav_msgs::msg::OccupancyGrid grid;
+  grid.info.width = width;
+  grid.info.height = height;
+  grid.info.resolution = resolution;
+  grid.info.origin.position.x = origin_x;
+  grid.info.origin.position.y = origin_y;
+  grid.info.origin.orientation.w = 1.0;
+  grid.data.resize(static_cast<size_t>(width) * height);
+  for (size_t i = 0; i < grid.data.size(); ++i) {
+    grid.data[i] = static_cast<int8_t>(i % 100);
+  }
+  return grid;
+}
+
+}  // namespace
+
+using marine_nav_utilities::cropCostmapWindow;
+
+TEST(CropCostmapWindow, BasicCenterCrop)
+{
+  const auto in = makeGrid(8, 8, 1.0);
+  const auto out = cropCostmapWindow(in, 4.0);
+
+  EXPECT_EQ(out.info.width, 4u);
+  EXPECT_EQ(out.info.height, 4u);
+  EXPECT_DOUBLE_EQ(out.info.resolution, 1.0);
+  // x0 = y0 = (8 - 4) / 2 = 2 cells -> origin shifts by 2 m.
+  EXPECT_DOUBLE_EQ(out.info.origin.position.x, 2.0);
+  EXPECT_DOUBLE_EQ(out.info.origin.position.y, 2.0);
+  ASSERT_EQ(out.data.size(), 16u);
+  for (unsigned int row = 0; row < 4; ++row) {
+    for (unsigned int col = 0; col < 4; ++col) {
+      EXPECT_EQ(out.data[row * 4 + col], in.data[(row + 2) * 8 + (col + 2)])
+        << "row=" << row << " col=" << col;
+    }
+  }
+}
+
+TEST(CropCostmapWindow, ResolutionScalesOriginShift)
+{
+  const auto in = makeGrid(8, 8, 0.5, /*origin_x=*/-10.0, /*origin_y=*/5.0);
+  const auto out = cropCostmapWindow(in, 2.0);  // 2 m / 0.5 = 4 cells
+
+  EXPECT_EQ(out.info.width, 4u);
+  EXPECT_EQ(out.info.height, 4u);
+  // x0 = (8 - 4) / 2 = 2 cells -> 2 * 0.5 = 1.0 m shift from the existing origin.
+  EXPECT_DOUBLE_EQ(out.info.origin.position.x, -10.0 + 1.0);
+  EXPECT_DOUBLE_EQ(out.info.origin.position.y, 5.0 + 1.0);
+}
+
+TEST(CropCostmapWindow, WindowLargerThanGridClampsToGrid)
+{
+  const auto in = makeGrid(8, 8, 1.0);
+  const auto out = cropCostmapWindow(in, 100.0);
+
+  EXPECT_EQ(out.info.width, 8u);
+  EXPECT_EQ(out.info.height, 8u);
+  EXPECT_DOUBLE_EQ(out.info.origin.position.x, 0.0);
+  EXPECT_DOUBLE_EQ(out.info.origin.position.y, 0.0);
+  EXPECT_EQ(out.data, in.data);
+}
+
+TEST(CropCostmapWindow, NonSquareGridClampsToShorterSide)
+{
+  const auto in = makeGrid(10, 6, 1.0);
+  const auto out = cropCostmapWindow(in, 4.0);
+
+  EXPECT_EQ(out.info.width, 4u);
+  EXPECT_EQ(out.info.height, 4u);
+  // x0 = (10 - 4) / 2 = 3, y0 = (6 - 4) / 2 = 1.
+  EXPECT_DOUBLE_EQ(out.info.origin.position.x, 3.0);
+  EXPECT_DOUBLE_EQ(out.info.origin.position.y, 1.0);
+  for (unsigned int row = 0; row < 4; ++row) {
+    for (unsigned int col = 0; col < 4; ++col) {
+      EXPECT_EQ(out.data[row * 4 + col], in.data[(row + 1) * 10 + (col + 3)]);
+    }
+  }
+}
+
+TEST(CropCostmapWindow, RotatedOriginShiftsAlongGridAxes)
+{
+  auto in = makeGrid(8, 8, 1.0);
+  // Rotate origin +90 deg about z: the grid's local +x points along world +y.
+  in.info.origin.orientation.z = std::sin(M_PI / 4.0);
+  in.info.origin.orientation.w = std::cos(M_PI / 4.0);
+
+  const auto out = cropCostmapWindow(in, 4.0);  // x0 = y0 = 2 cells
+
+  // Local corner offset (2, 2) rotated +90 deg -> world (-2, 2).
+  EXPECT_NEAR(out.info.origin.position.x, -2.0, 1e-9);
+  EXPECT_NEAR(out.info.origin.position.y, 2.0, 1e-9);
+}
+
+TEST(CropCostmapWindow, DegenerateGridReturnedUnchanged)
+{
+  const auto zero_res = makeGrid(8, 8, 0.0);
+  const auto out = cropCostmapWindow(zero_res, 4.0);
+  EXPECT_EQ(out.info.width, 8u);
+  EXPECT_EQ(out.info.height, 8u);
+  EXPECT_EQ(out.data, zero_res.data);
+
+  nav_msgs::msg::OccupancyGrid empty;
+  empty.info.resolution = 1.0;  // width / height left at zero
+  const auto out_empty = cropCostmapWindow(empty, 4.0);
+  EXPECT_EQ(out_empty.info.width, 0u);
+  EXPECT_EQ(out_empty.info.height, 0u);
+}
+
+TEST(CropCostmapWindow, InvalidWindowSizeReturnedUnchanged)
+{
+  const auto in = makeGrid(8, 8, 1.0);
+  // A non-finite or non-positive window must not produce a malformed (0x0)
+  // grid; the input is returned unchanged.
+  for (const double bad : {std::nan(""), 0.0, -4.0}) {
+    const auto out = cropCostmapWindow(in, bad);
+    EXPECT_EQ(out.info.width, 8u) << "window=" << bad;
+    EXPECT_EQ(out.info.height, 8u) << "window=" << bad;
+    EXPECT_EQ(out.data, in.data) << "window=" << bad;
+  }
+}
+
+TEST(CropCostmapWindow, NonFiniteResolutionReturnedUnchanged)
+{
+  auto nan_res = makeGrid(8, 8, 1.0);
+  nan_res.info.resolution = std::nan("");  // NaN slips past a bare <= 0 test
+  const auto out = cropCostmapWindow(nan_res, 4.0);
+  EXPECT_EQ(out.info.width, 8u);
+  EXPECT_EQ(out.info.height, 8u);
+  EXPECT_EQ(out.data, nan_res.data);
+}
+
+TEST(CropCostmapWindow, MismatchedDataSizeReturnedUnchanged)
+{
+  auto bad = makeGrid(8, 8, 1.0);
+  bad.data.resize(10);  // fewer cells than width * height -> would read OOB
+  const auto out = cropCostmapWindow(bad, 4.0);
+  EXPECT_EQ(out.info.width, 8u);
+  EXPECT_EQ(out.info.height, 8u);
+  EXPECT_EQ(out.data.size(), 10u);
+}
+
+TEST(CropCostmapWindow, PreservesMetadata)
+{
+  auto in = makeGrid(8, 8, 1.0);
+  in.header.frame_id = "map_tide";
+  in.info.map_load_time.sec = 123;
+  in.info.map_load_time.nanosec = 456;
+
+  const auto out = cropCostmapWindow(in, 4.0);
+
+  EXPECT_EQ(out.header.frame_id, "map_tide");
+  EXPECT_EQ(out.info.map_load_time.sec, 123);
+  EXPECT_EQ(out.info.map_load_time.nanosec, 456u);
+}

--- a/marine_nav_utilities/test/test_costmap_window.cpp
+++ b/marine_nav_utilities/test/test_costmap_window.cpp
@@ -106,6 +106,23 @@ TEST(CropCostmapWindow, RotatedOriginShiftsAlongGridAxes)
   EXPECT_NEAR(out.info.origin.position.y, 2.0, 1e-9);
 }
 
+TEST(CropCostmapWindow, InvalidOriginQuaternionTreatedAsIdentity)
+{
+  auto in = makeGrid(8, 8, 1.0);
+  in.info.origin.orientation.w = 0.0;  // all-zero quaternion -> invalid
+
+  const auto out = cropCostmapWindow(in, 4.0);
+
+  // Offset computed as if identity: x0 = y0 = 2 cells -> shift (2, 2).
+  EXPECT_DOUBLE_EQ(out.info.origin.position.x, 2.0);
+  EXPECT_DOUBLE_EQ(out.info.origin.position.y, 2.0);
+  // Output orientation sanitized to identity, so the result is a valid grid.
+  EXPECT_DOUBLE_EQ(out.info.origin.orientation.x, 0.0);
+  EXPECT_DOUBLE_EQ(out.info.origin.orientation.y, 0.0);
+  EXPECT_DOUBLE_EQ(out.info.origin.orientation.z, 0.0);
+  EXPECT_DOUBLE_EQ(out.info.origin.orientation.w, 1.0);
+}
+
 TEST(CropCostmapWindow, DegenerateGridReturnedUnchanged)
 {
   const auto zero_res = makeGrid(8, 8, 0.0);

--- a/marine_nav_utilities/test/test_costmap_window_node.cpp
+++ b/marine_nav_utilities/test/test_costmap_window_node.cpp
@@ -1,6 +1,7 @@
 #include <cmath>
 #include <limits>
 #include <memory>
+#include <string>
 
 #include <gtest/gtest.h>
 
@@ -47,4 +48,20 @@ TEST_F(CostmapWindowNodeTest, InvalidWindowSizeRejectedAndValueUnchanged)
     // Rejected sets must leave the previous (default) value intact.
     EXPECT_DOUBLE_EQ(node_->get_parameter("window_size").as_double(), 200.0) << "bad=" << bad;
   }
+}
+
+TEST_F(CostmapWindowNodeTest, IntegerWindowSizeAcceptedAndCoerced)
+{
+  // A bare integer (`ros2 param set ... window_size 150`) is accepted via dynamic
+  // typing and coerced to double, rather than rejected as a type mismatch.
+  const auto result = node_->set_parameter(rclcpp::Parameter("window_size", 150));
+  EXPECT_TRUE(result.successful);
+  EXPECT_EQ(node_->get_parameter("window_size").as_int(), 150);
+}
+
+TEST_F(CostmapWindowNodeTest, NonNumericWindowSizeRejected)
+{
+  const auto result = node_->set_parameter(rclcpp::Parameter("window_size", std::string("wide")));
+  EXPECT_FALSE(result.successful);
+  EXPECT_DOUBLE_EQ(node_->get_parameter("window_size").as_double(), 200.0);
 }

--- a/marine_nav_utilities/test/test_costmap_window_node.cpp
+++ b/marine_nav_utilities/test/test_costmap_window_node.cpp
@@ -50,10 +50,11 @@ TEST_F(CostmapWindowNodeTest, InvalidWindowSizeRejectedAndValueUnchanged)
   }
 }
 
-TEST_F(CostmapWindowNodeTest, IntegerWindowSizeAcceptedAndCoerced)
+TEST_F(CostmapWindowNodeTest, IntegerWindowSizeAcceptedAndUsedAsDouble)
 {
   // A bare integer (`ros2 param set ... window_size 150`) is accepted via dynamic
-  // typing and coerced to double, rather than rejected as a type mismatch.
+  // typing rather than rejected as a type mismatch, and used as a double
+  // internally. The stored parameter keeps its integer type.
   const auto result = node_->set_parameter(rclcpp::Parameter("window_size", 150));
   EXPECT_TRUE(result.successful);
   EXPECT_EQ(node_->get_parameter("window_size").as_int(), 150);

--- a/marine_nav_utilities/test/test_costmap_window_node.cpp
+++ b/marine_nav_utilities/test/test_costmap_window_node.cpp
@@ -1,0 +1,50 @@
+#include <cmath>
+#include <limits>
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "marine_nav_utilities/costmap_window_node.h"
+#include "rclcpp/rclcpp.hpp"
+
+using marine_nav_utilities::CostmapWindowNode;
+
+class CostmapWindowNodeTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+    node_ = std::make_shared<CostmapWindowNode>(rclcpp::NodeOptions());
+  }
+
+  void TearDown() override
+  {
+    node_.reset();
+    rclcpp::shutdown();
+  }
+
+  std::shared_ptr<CostmapWindowNode> node_;
+};
+
+TEST_F(CostmapWindowNodeTest, WindowSizeDefaultsTo200)
+{
+  EXPECT_DOUBLE_EQ(node_->get_parameter("window_size").as_double(), 200.0);
+}
+
+TEST_F(CostmapWindowNodeTest, ValidWindowSizeUpdatesDynamically)
+{
+  const auto result = node_->set_parameter(rclcpp::Parameter("window_size", 100.0));
+  EXPECT_TRUE(result.successful);
+  EXPECT_DOUBLE_EQ(node_->get_parameter("window_size").as_double(), 100.0);
+}
+
+TEST_F(CostmapWindowNodeTest, InvalidWindowSizeRejectedAndValueUnchanged)
+{
+  for (const double bad : {0.0, -5.0, std::nan(""), std::numeric_limits<double>::infinity()}) {
+    const auto result = node_->set_parameter(rclcpp::Parameter("window_size", bad));
+    EXPECT_FALSE(result.successful) << "bad=" << bad;
+    // Rejected sets must leave the previous (default) value intact.
+    EXPECT_DOUBLE_EQ(node_->get_parameter("window_size").as_double(), 200.0) << "bad=" << bad;
+  }
+}


### PR DESCRIPTION
## What

Adds a boat-side node that republishes a **cropped, smaller window** of the local
costmap, so it's cheap enough to forward to the operator (CAMP) over the lossy,
rate-limited bridge.

- **`marine_nav_utilities::cropCostmapWindow(grid, window_size_m)`** — pure,
  unit-tested function. Center-crops a square window out of a
  `nav_msgs/OccupancyGrid` at the input resolution (no resampling), shifting
  `info.origin` along the grid's own axes (correct even for a rotated grid) and
  carrying the rest of the metadata over. Returns the input unchanged for
  degenerate grids, non-finite/non-positive resolution or window size, and
  `data.size()` that doesn't match `width*height`.
- **`costmap_window_node`** — thin executable: subscribes to `costmap`, crops,
  publishes `costmap_windowed`. Best-available QoS on the subscription (matches
  Nav2's reliable + transient-local costmap); latched publish so a late-joining
  consumer gets the latest window immediately. The **`window_size` parameter is
  dynamically updatable** (`ros2 param set`) via a validating set-parameters
  callback — non-finite/non-positive values are rejected at set time.

## Why

Per [`rolker/unh_marine_autonomy#127`](https://github.com/rolker/unh_marine_autonomy/issues/127):
the full BizzyBoat local costmap is 400 m × 400 m @ 0.25 m = 1600×1600 = **2.56
MB/msg** at 2 Hz, fragments into ~65 UDP packets, and loses ~78% over the bridge.
CAMP already renders `nav_msgs/OccupancyGrid` directly, so the only gap is getting
a small-enough, self-contained frame across.

First step is a **pure crop at 200 m @ 0.25 m** (800×800 = 640 kB, 4× smaller) —
no decimation yet, to validate the crop → bridge → CAMP path before adding
downsampling (max-pool). The output stays a full, self-contained grid each cycle,
so it tolerates dropped frames with no delta-stitching downstream — unlike the
`costmap_updates` increment topic. Live `window_size` tuning makes it easy to
trade coverage for bandwidth in the field without relaunching.

## Scope

- This PR: the node + library function + unit tests in `marine_nav_utilities`.
- **Not** in this PR: forwarding `costmap_windowed` over the udp_bridge + launching
  the node on the boat — handled separately in `unh_echoboats_project11`.
- Resolution downsampling / max-pool decimation: follow-up once the crop path is
  validated in the field.

## Test plan

- [x] `colcon build --packages-select marine_nav_utilities`
- [x] `colcon test` — 13 GTest cases pass:
  - `test_costmap_window` (10): center crop, resolution-scaled origin shift,
    window-larger-than-grid clamp, non-square clamp, rotated origin, degenerate
    grid, invalid (NaN/0/negative) window, non-finite resolution, mismatched data
    size, metadata preservation.
  - `test_costmap_window_node` (3): default 200 m, valid dynamic update applied,
    invalid values (0/negative/NaN/inf) rejected with value unchanged.
- [ ] Field: wire over the bridge and confirm CAMP renders the windowed costmap
      (separate `unh_echoboats_project11` PR).

## Review

Pre-push review run locally (Standard tier: static analysis + fresh-context Claude
adversarial + Copilot cross-model adversarial). Findings addressed in-branch:
NaN/non-finite window and resolution guards (`std::clamp` UB), `data.size()`
bounds guard, `info.map_load_time` preservation, non-finite-quaternion guard, and
best-available subscription reliability.

Closes #38
Part of rolker/unh_marine_autonomy#127

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
