### PR TITLE
marine_nav: TF extrapolation error on multi-line survey goals (stale header.stamp on per-line goals)

### DIFF
--- a/.agent/work-plans/issue-23/plan.md
+++ b/.agent/work-plans/issue-23/plan.md
@@ -1,0 +1,79 @@
+# Plan: marine_nav: TF extrapolation error on multi-line survey goals (stale header.stamp on per-line goals)
+
+## Issue
+
+https://github.com/rolker/unh_marine_navigation/issues/23
+
+## Context
+
+Multi-line survey goals carry a stale `header.stamp` from task-upload time, so Nav2's `FollowPath` then does `lookupTransform(..., path.header.stamp)` with a time outside the TF buffer (~10 s default) → extrapolation error → goal aborts at the line transition. Real-world repro: `unh_echoboats_project11/docs/logs/2026/2026-04-27_dev_logs.md:421` — "weird turn onto 3rd line" on a live multi-line survey, bag at `~/data/logs/bizzyboat/` on gabby.
+
+**Two producers, identical bug shape** — both inherit the path's outer header from the first pose's stale stamp:
+
+- `marine_nav_behavior_tree/src/plugins/action/set_path_from_task.cpp:71` — `path.header = path.poses.front().header;` (builds `{survey_path}` for SurveyLine).
+- `marine_nav_behavior_tree/src/plugins/action/get_sub_path.cpp:49` — `output_path.header = output_path.poses.front().header;` (builds `{transit_path}` for TransitAndSurveyLine at `run_tasks.xml:373`).
+
+`clear_path.cpp` is fine — it emits a default-constructed empty `Path()` (zero stamp). The codebase already has the idiomatic fix in `marine_nav_behavior_tree/src/plugins/action/path_to_pose_vector.cpp:33`: `p.header.stamp = builtin_interfaces::msg::Time();   // zero stamp = "latest" in TF lookups`. Mirror that.
+
+**Per-pose stamps are load-bearing** — `marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp:347–348` reads `p1.header.stamp` / `p2.header.stamp` as `segment_start_time` / `segment_end_time`, and `marine_nav_utilities/src/utilities.cpp:22` advances per-pose stamps by `distance/speed`. The fix touches only the outer `path.header.stamp` — per-pose stamps stay untouched.
+
+## Approach
+
+1. **Verify the "preserved on purpose?" caveat.** Grep across `unh_marine_navigation`, `unh_marine_autonomy`, `unh_echoboats_project11` for consumers of `path.header.stamp` (the outer one, not per-pose). Expectation: only Nav2's TF lookup. Record finding in PR body — answers the issue body's `there may be a reason the source stamp is preserved` caveat instead of assuming.
+2. **Pull the 2026-04-27 bag** from gabby `~/data/logs/bizzyboat/`; identify the line-3 transition window from the dev log. Canonical offline repro for pre/post validation. If pruned, fall back to a sim-based repro (publish a Path with old `header.stamp` and confirm the extrapolation error pre-fix → none post-fix).
+3. **Apply the fix in both producers.** For both `set_path_from_task.cpp:71` and `get_sub_path.cpp:49`, replace the buggy line with:
+   ```cpp
+   path.header.frame_id = path.poses.front().header.frame_id;
+   path.header.stamp = builtin_interfaces::msg::Time();   // zero = "latest" in TF lookups (mirrors path_to_pose_vector.cpp:33; for #23)
+   ```
+4. **Add regression tests.** Two new GTest files mirroring `test_dispatch_routing.cpp` / `test_set_task_failed.cpp` (same package):
+   - `marine_nav_behavior_tree/test/test_set_path_from_task.cpp` — tick `SetPathFromTask` with a Task whose poses have stale stamps; assert output `path.header.stamp` is zero, `frame_id` preserved, **per-pose stamps preserved (not zeroed)**.
+   - `marine_nav_behavior_tree/test/test_get_sub_path.cpp` — same assertions for `GetSubPath` on a stale-stamped input path.
+   - Update `marine_nav_behavior_tree/CMakeLists.txt` with the two new `ament_add_gtest` blocks.
+5. **Build + run all `marine_nav_behavior_tree` tests.** New tests pass; existing tests still pass. (Pre-existing uncrustify 0.78.1 drift is package-wide and unrelated — out of scope.)
+6. **Offline-validate against the bag (or sim repro).** Confirm the line-3 TF-extrapolation error no longer fires and that crabbing's segment timing on subsequent lines continues to work (per-pose stamps unchanged). Record bag-window evidence in PR body.
+7. **Pre-push self-review via `/review-code`.** Address findings; flip the PR from `[PLAN]` draft to ready.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `marine_nav_behavior_tree/src/plugins/action/set_path_from_task.cpp` | Replace stale-stamp inherit with explicit `frame_id` + zero-stamp; 1-line comment. |
+| `marine_nav_behavior_tree/src/plugins/action/get_sub_path.cpp` | Same fix shape. |
+| `marine_nav_behavior_tree/test/test_set_path_from_task.cpp` | New: regression test for stamp / frame_id / per-pose behaviour. |
+| `marine_nav_behavior_tree/test/test_get_sub_path.cpp` | New: same shape for `GetSubPath`. |
+| `marine_nav_behavior_tree/CMakeLists.txt` | Register the two new GTest targets (mirror existing `test_dispatch_routing` / `test_set_task_failed` blocks). |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Capture decisions | Step 1's grep finding (the "preserved on purpose?" question) is recorded in the PR body, not assumed away. |
+| A change includes its consequences | Same-PR per-pose-stamp consumer verification (`crabbing_path_follower`, `utilities`); both buggy producers fixed, not just one; build + tests + bag-replay all in scope. |
+| Only what's needed | ~3-line code change × 2 files, mirroring an in-repo precedent; no new abstractions. |
+| Test what breaks | GTest regression covers the failure mode plus neighbouring invariants (per-pose stamps untouched, `frame_id` preserved); bag-replay covers the actual field repro. |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0002 — Worktree isolation | Yes | Work in `layers/worktrees/issue-unh_marine_navigation-23/`. |
+| 0008 — ROS 2 conventions | Yes (lightly) | `builtin_interfaces::msg::Time()` zero-stamp = "latest" is the standard tf2 idiom; mirrors in-repo precedent. |
+| 0013 — `progress.md` vocabulary | Yes | Lifecycle: `## Issue Review` (done) → `## Plan Authored` (this skill) → `## Plan Review` → `## Local Review (Pre-Push)` → `## Integrated Review` → `## Implementation`. |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| Outer `path.header.stamp` emitted by `SetPathFromTask` / `GetSubPath` | Any consumer of the outer stamp other than Nav2 FollowPath | Yes — step 1 grep verifies none exist; step 6 bag-replay confirms downstream behaviour. |
+| Per-pose `header.stamp` | (intentionally not changed) — `crabbing_path_follower:347–348`, `utilities.cpp:22` rely on them | Verified untouched by the fix. |
+| Test target list | `marine_nav_behavior_tree/CMakeLists.txt` `ament_add_gtest` blocks | Yes — step 4. |
+
+## Open Questions
+
+- **Zero-stamp vs `node->now()`** — both work for the TF-lookup case; the in-repo precedent uses zero-stamp ("latest"). BT nodes don't carry an `rclcpp::Node` handle in this codebase pattern, so zero-stamp is also the simpler form. Going with the precedent unless review-plan objects.
+- **2026-04-27 bag availability** — if pruned/rotated on gabby, sim-based repro is the fallback. Either way, validation is feasible.
+
+## Estimated Scope
+
+Single PR, ~S effort. ~6 lines of code change across 2 files + 2 new test files + a small CMakeLists block. Coordinate with [#35 (PR #36)](https://github.com/rolker/unh_marine_navigation/pull/36) — same producer file (`set_path_from_task.cpp`); land #23 first since #35 is still plan-only.

--- a/.agent/work-plans/issue-23/plan.md
+++ b/.agent/work-plans/issue-23/plan.md
@@ -8,28 +8,32 @@ https://github.com/rolker/unh_marine_navigation/issues/23
 
 Multi-line survey goals carry a stale `header.stamp` from task-upload time, so Nav2's `FollowPath` then does `lookupTransform(..., path.header.stamp)` with a time outside the TF buffer (~10 s default) → extrapolation error → goal aborts at the line transition. Real-world repro: `unh_echoboats_project11/docs/logs/2026/2026-04-27_dev_logs.md:421` — "weird turn onto 3rd line" on a live multi-line survey, bag at `~/data/logs/bizzyboat/` on gabby.
 
-**Two producers, identical bug shape** — both inherit the path's outer header from the first pose's stale stamp:
+**Two producers, identical bug shape** — both inherit the path's outer header from the first pose's stale stamp. Tracing `run_tasks.xml` shows they reach Nav2 differently:
 
-- `marine_nav_behavior_tree/src/plugins/action/set_path_from_task.cpp:71` — `path.header = path.poses.front().header;` (builds `{survey_path}` for SurveyLine).
-- `marine_nav_behavior_tree/src/plugins/action/get_sub_path.cpp:49` — `output_path.header = output_path.poses.front().header;` (builds `{transit_path}` for TransitAndSurveyLine at `run_tasks.xml:373`).
+- `marine_nav_behavior_tree/src/plugins/action/set_path_from_task.cpp:68` — `path.header = path.poses.front().header;` (builds `{survey_path}` for SurveyLine). **Load-bearing**: `{survey_path}` is fed directly to `FollowPath` in the `SurveyLine` subtree — this is the actual TF-extrapolation repro path.
+- `marine_nav_behavior_tree/src/plugins/action/get_sub_path.cpp:49` — `output_path.header = output_path.poses.front().header;` (builds `{transit_path}` for TransitAndSurveyLine at `run_tasks.xml:373`). **Defense-in-depth**: the `{transit_path}` flow goes through `FixPathOrientations` (pass-through for the outer header) → `PathToPoseVector` (drops the outer header — extracts a pose vector) → `ComputePathThroughPoses` (Nav2 plans a fresh path) → `FollowPath`, so the stale stamp never reaches Nav2's TF lookup directly. Still right to fix — same buggy shape, prevents a regression if downstream wiring changes.
 
 `clear_path.cpp` is fine — it emits a default-constructed empty `Path()` (zero stamp). The codebase already has the idiomatic fix in `marine_nav_behavior_tree/src/plugins/action/path_to_pose_vector.cpp:33`: `p.header.stamp = builtin_interfaces::msg::Time();   // zero stamp = "latest" in TF lookups`. Mirror that.
 
 **Per-pose stamps are load-bearing** — `marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp:347–348` reads `p1.header.stamp` / `p2.header.stamp` as `segment_start_time` / `segment_end_time`, and `marine_nav_utilities/src/utilities.cpp:22` advances per-pose stamps by `distance/speed`. The fix touches only the outer `path.header.stamp` — per-pose stamps stay untouched.
 
+**Consumer grep finding (Step 1)**: across `unh_marine_navigation`, `unh_marine_autonomy`, and `unh_echoboats_project11`, **no in-repo code reads the outer `path.header.stamp`** (only `fix_path_orientations.cpp` reads `path.header.frame_id`, and `bt_types.cpp` round-trips header for blackboard JSON). The only consumer is Nav2's external TF-lookup machinery, which honours zero-stamp as "latest." The "preserved on purpose?" caveat from the issue body is resolved — no other consumer depends on the legacy stamp value.
+
 ## Approach
 
-1. **Verify the "preserved on purpose?" caveat.** Grep across `unh_marine_navigation`, `unh_marine_autonomy`, `unh_echoboats_project11` for consumers of `path.header.stamp` (the outer one, not per-pose). Expectation: only Nav2's TF lookup. Record finding in PR body — answers the issue body's `there may be a reason the source stamp is preserved` caveat instead of assuming.
+1. **Verify the "preserved on purpose?" caveat.** *(Done during plan amendment — see Context.)* Grep across `unh_marine_navigation`, `unh_marine_autonomy`, `unh_echoboats_project11` returned **zero in-repo consumers** of the outer `path.header.stamp`. Only Nav2's external TF lookup reads it. Recorded in Context + reproduced in PR body.
 2. **Pull the 2026-04-27 bag** from gabby `~/data/logs/bizzyboat/`; identify the line-3 transition window from the dev log. Canonical offline repro for pre/post validation. If pruned, fall back to a sim-based repro (publish a Path with old `header.stamp` and confirm the extrapolation error pre-fix → none post-fix).
-3. **Apply the fix in both producers.** For both `set_path_from_task.cpp:71` and `get_sub_path.cpp:49`, replace the buggy line with:
+3. **Apply the fix in both producers, via a static helper.** Extract a `static nav_msgs::msg::Path buildPath(...)` helper on each class — mirrors `PredictStoppingPose::projectStoppingPose` (the in-repo testability precedent). The helper performs the index-range copy and sets the outer header to `frame_id` only + zero stamp:
    ```cpp
    path.header.frame_id = path.poses.front().header.frame_id;
    path.header.stamp = builtin_interfaces::msg::Time();   // zero = "latest" in TF lookups (mirrors path_to_pose_vector.cpp:33; for #23)
    ```
-4. **Add regression tests.** Two new GTest files mirroring `test_dispatch_routing.cpp` / `test_set_task_failed.cpp` (same package):
-   - `marine_nav_behavior_tree/test/test_set_path_from_task.cpp` — tick `SetPathFromTask` with a Task whose poses have stale stamps; assert output `path.header.stamp` is zero, `frame_id` preserved, **per-pose stamps preserved (not zeroed)**.
-   - `marine_nav_behavior_tree/test/test_get_sub_path.cpp` — same assertions for `GetSubPath` on a stale-stamped input path.
-   - Update `marine_nav_behavior_tree/CMakeLists.txt` with the two new `ament_add_gtest` blocks.
+   `tick()` becomes a thin BT-blackboard wrapper around the helper. Per-pose stamps in `path.poses` are unchanged.
+4. **Add regression tests.** Two new GTest files mirroring `test_predict_stopping_pose.cpp` (static-helper style; no BT-tick fixture — and avoids depending on unmerged `test_dispatch_routing.cpp`/`test_set_task_failed.cpp` from open PR #37):
+   - `marine_nav_behavior_tree/test/test_set_path_from_task.cpp` — exercises `SetPathFromTask::buildPath` with a stale-stamped pose vector.
+   - `marine_nav_behavior_tree/test/test_get_sub_path.cpp` — exercises `GetSubPath::buildSubPath` with a stale-stamped input path.
+   - Assertion matrix (both tests): outer `path.header.stamp` is zero; outer `frame_id` preserved (non-empty round-trip); per-pose stamps **not** zeroed (representative `sec`/`nanosec` survives input → output); empty range (`start > end` or empty input) returns a default-constructed `Path` with a zero header; single-pose range works; negative `end_index` (= "from end") normalizes correctly.
+   - Update `marine_nav_behavior_tree/CMakeLists.txt` with two new `ament_add_gtest` blocks (link `${PROJECT_NAME}_bt_plugins`; `ament_target_dependencies`: `behaviortree_cpp`, `geometry_msgs`, `nav_msgs`, `rclcpp`; plus `marine_nav_tasks` for `test_set_path_from_task`).
 5. **Build + run all `marine_nav_behavior_tree` tests.** New tests pass; existing tests still pass. (Pre-existing uncrustify 0.78.1 drift is package-wide and unrelated — out of scope.)
 6. **Offline-validate against the bag (or sim repro).** Confirm the line-3 TF-extrapolation error no longer fires and that crabbing's segment timing on subsequent lines continues to work (per-pose stamps unchanged). Record bag-window evidence in PR body.
 7. **Pre-push self-review via `/review-code`.** Address findings; flip the PR from `[PLAN]` draft to ready.
@@ -38,11 +42,13 @@ Multi-line survey goals carry a stale `header.stamp` from task-upload time, so N
 
 | File | Change |
 |------|--------|
-| `marine_nav_behavior_tree/src/plugins/action/set_path_from_task.cpp` | Replace stale-stamp inherit with explicit `frame_id` + zero-stamp; 1-line comment. |
-| `marine_nav_behavior_tree/src/plugins/action/get_sub_path.cpp` | Same fix shape. |
-| `marine_nav_behavior_tree/test/test_set_path_from_task.cpp` | New: regression test for stamp / frame_id / per-pose behaviour. |
-| `marine_nav_behavior_tree/test/test_get_sub_path.cpp` | New: same shape for `GetSubPath`. |
-| `marine_nav_behavior_tree/CMakeLists.txt` | Register the two new GTest targets (mirror existing `test_dispatch_routing` / `test_set_task_failed` blocks). |
+| `marine_nav_behavior_tree/include/marine_nav_behavior_tree/plugins/action/set_path_from_task.h` | Add `static nav_msgs::msg::Path buildPath(const std::vector<geometry_msgs::msg::PoseStamped>&, int start, int end);` declaration. |
+| `marine_nav_behavior_tree/src/plugins/action/set_path_from_task.cpp` | Implement `buildPath` (frame_id + zero-stamp idiom); simplify `tick()` to call it. |
+| `marine_nav_behavior_tree/include/marine_nav_behavior_tree/plugins/action/get_sub_path.h` | Add `static nav_msgs::msg::Path buildSubPath(const nav_msgs::msg::Path&, int start, int end);` declaration. |
+| `marine_nav_behavior_tree/src/plugins/action/get_sub_path.cpp` | Implement `buildSubPath`; simplify `tick()` to call it. |
+| `marine_nav_behavior_tree/test/test_set_path_from_task.cpp` | New: static-helper test for `buildPath` per assertion matrix in step 4. |
+| `marine_nav_behavior_tree/test/test_get_sub_path.cpp` | New: same shape for `buildSubPath`. |
+| `marine_nav_behavior_tree/CMakeLists.txt` | Register the two new `ament_add_gtest` blocks (style: `test_predict_stopping_pose`). |
 
 ## Principles Self-Check
 
@@ -76,4 +82,10 @@ Multi-line survey goals carry a stale `header.stamp` from task-upload time, so N
 
 ## Estimated Scope
 
-Single PR, ~S effort. ~6 lines of code change across 2 files + 2 new test files + a small CMakeLists block. Coordinate with [#35 (PR #36)](https://github.com/rolker/unh_marine_navigation/pull/36) — same producer file (`set_path_from_task.cpp`); land #23 first since #35 is still plan-only.
+Single PR, ~S effort. Helper extraction + fix across 2 production files (~20 lines net) + 2 new test files + 2 CMakeLists `ament_add_gtest` blocks. Coordinate with:
+- [#35 (PR #36)](https://github.com/rolker/unh_marine_navigation/pull/36) — same producer file (`set_path_from_task.cpp`); land #23 first since #35 is still plan-only.
+- [#28 (PR #40)](https://github.com/rolker/unh_marine_navigation/pull/40) — competing root-cause hypothesis for the same 2026-04-27 / 2026-05-22 line-transition failures (`CancelFollowPath` zero-command window tripping FCU's 3 s GUIDED watchdog). Both can be true simultaneously; #23 does not foreclose #28.
+
+## Out-of-scope sibling
+
+`marine_nav_behavior_tree/src/plugins/action/set_polygon_from_task.cpp:63` has the same anti-pattern on `PolygonStamped` (`polygon.header = poses[i].header;` — likely costmap-area). Out of scope for this Path-focused issue; flag in PR body for a future ticket so it doesn't bite the costmap layer the same way.

--- a/.agent/work-plans/issue-23/progress.md
+++ b/.agent/work-plans/issue-23/progress.md
@@ -37,3 +37,24 @@ issue: 23
 - Two producers, not one — `set_path_from_task.cpp:71` + `get_sub_path.cpp:49` (verified during planning).
 - Step 1 grep + step 6 bag-replay address the "Watch" findings from Issue Review.
 - Coordination with #35 reaffirmed in plan's Estimated Scope.
+
+## Plan Review
+**Status**: complete
+**When**: 2026-05-27 23:45 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))  <!-- performed by a fresh-context general-purpose sub-agent for independence; not the in-context plan author -->
+
+**Plan**: `.agent/work-plans/issue-23/plan.md` at `6b61501`
+**PR**: https://github.com/rolker/unh_marine_navigation/pull/41
+**Verdict**: approve-with-suggestions
+
+### Findings
+- [ ] (must-fix, narrative) Causal chain holds only for `SetPathFromTask` → `{survey_path}` (directly to `FollowPath`); `GetSubPath` → `{transit_path}` is dropped at `PathToPoseVector`/`ComputePathThroughPoses` so its stale stamp never reaches Nav2 `FollowPath`. Fixing `GetSubPath` is defense-in-depth, not load-bearing. Revise plan Context + PR body accordingly. — `plan.md` Context
+- [ ] (must-fix, minor) Line-number drift: `set_path_from_task.cpp:71` is actually line `68` in the worktree; the `setOutput` is at 71. Update plan or describe by content. — `plan.md:11`
+- [ ] (suggestion) Test-fixture references depend on PR #37 (still OPEN, not merged); `test_dispatch_routing.cpp` / `test_set_task_failed.cpp` do not yet exist on `jazzy`. Pick a strategy: wait for #37, rebase #23 onto #37, or write tests fresh without copying that pattern. — `plan.md` Approach step 4
+- [ ] (suggestion) Step 1's grep finding (consumers of outer `path.header.stamp`) should be recorded in the PR body, not assumed — satisfies the issue-review "Capture decisions" Watch note. — PR body
+- [ ] (suggestion) Add `marine_nav_tasks` (and likely `nav_msgs`) to the new test target's `ament_target_dependencies`; existing test blocks don't include this. — `plan.md` Files to Change
+- [ ] (suggestion) Spell out the test-assertion matrix: empty path (guard skips buggy line), single-pose path, `frame_id` round-trip with non-empty value. — `plan.md` Approach step 4
+- [ ] (suggestion) Acknowledge divergence between the plan's test ("outer stamp is zero") and the issue body's literal AC ("goal stamps advance per-line") — the zero-stamp form is correct for the chosen fix; note in PR body. — PR body
+- [ ] (suggestion) Add coordination note for **#28 (PR #40)** alongside the existing #35 (PR #36) entry — both reference the same field events with different mechanisms (TF extrapolation vs `CancelFollowPath` FCU watchdog). — `plan.md` Estimated Scope
+- [ ] (informational) `set_polygon_from_task.cpp:63` has the same anti-pattern on `PolygonStamped`; out-of-scope sibling, flag in PR body for a future ticket. — out of plan
+- [ ] (suggestion) Add a sentence in plan Context noting `FixPathOrientations` is a pass-through for the outer header — structural evidence the producer-side fix is sufficient. — `plan.md` Context

--- a/.agent/work-plans/issue-23/progress.md
+++ b/.agent/work-plans/issue-23/progress.md
@@ -19,3 +19,21 @@ issue: 23
 - [ ] Pull the 2026-04-27 bag from gabby (`~/data/logs/bizzyboat/`); use the line-3 transition as the canonical offline repro for fix validation before deployment.
 - [ ] Mirror the in-repo precedent for the fix idiom (`marine_nav_behavior_tree/src/plugins/action/path_to_pose_vector.cpp:33`, zero-stamp = "latest" in TF lookups) and the GTest fixture style from `test_dispatch_routing.cpp` / `test_set_task_failed.cpp` for the regression test.
 - [ ] Coordinate with #35 (PR #36) — same file (`set_path_from_task.cpp`); land #23 first since #35 is still plan-only.
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-05-27 23:35 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**Plan**: `.agent/work-plans/issue-23/plan.md` at `6b61501`
+**PR**: https://github.com/rolker/unh_marine_navigation/pull/41 (`[PLAN]` prefix)
+**Phases**: single
+
+### Open questions
+- [ ] Zero-stamp ("latest" in TF) vs. `node->now()` — going with the in-repo precedent (zero-stamp at `path_to_pose_vector.cpp:33`) unless review-plan objects; BT nodes don't carry an `rclcpp::Node` handle in this codebase pattern anyway.
+- [ ] 2026-04-27 bag availability on gabby — fall back to sim-based repro if pruned/rotated.
+
+### Plan-derived scope notes (carried from Issue Review actions)
+- Two producers, not one — `set_path_from_task.cpp:71` + `get_sub_path.cpp:49` (verified during planning).
+- Step 1 grep + step 6 bag-replay address the "Watch" findings from Issue Review.
+- Coordination with #35 reaffirmed in plan's Estimated Scope.

--- a/.agent/work-plans/issue-23/progress.md
+++ b/.agent/work-plans/issue-23/progress.md
@@ -58,3 +58,35 @@ issue: 23
 - [ ] (suggestion) Add coordination note for **#28 (PR #40)** alongside the existing #35 (PR #36) entry — both reference the same field events with different mechanisms (TF extrapolation vs `CancelFollowPath` FCU watchdog). — `plan.md` Estimated Scope
 - [ ] (informational) `set_polygon_from_task.cpp:63` has the same anti-pattern on `PolygonStamped`; out-of-scope sibling, flag in PR body for a future ticket. — out of plan
 - [ ] (suggestion) Add a sentence in plan Context noting `FixPathOrientations` is a pass-through for the outer header — structural evidence the producer-side fix is sufficient. — `plan.md` Context
+
+## Implementation
+**Status**: complete
+**When**: 2026-05-28 00:00 -04:00 (impl) → 2026-05-28 09:00 -04:00 (review-driven hardening)
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**Branch**: `feature/issue-23`
+**Commits**:
+- `40b8f3f` — fix: zero outer `path.header.stamp` in SetPathFromTask + GetSubPath (initial fix + 16 GTest cases + plan amendment)
+- `c8c8e1c` — style: apply uncrustify to new test files (whitespace; new test files only — pre-existing package-wide drift left untouched)
+- `54c8c61` — fix: guard buildPath/buildSubPath against signed/unsigned wrap (round-2 hardening from adversarial review; 4 additional GTest cases)
+
+**Tests**: 31/31 marine_nav_behavior_tree gtests pass (test_set_path_from_task 10/10, test_get_sub_path 10/10, existing 11/11). Pre-existing uncrustify drift on untouched files remains out-of-scope (see PR #37 for the same situation).
+
+**Plan step 6 (bag/sim validation)**: GTest regression covers the failure class as a pure-function unit test (assertion matrix: outer stamp zero on non-empty result, outer frame_id preserved, per-pose stamps untouched, empty/single/inverted/very-negative ranges). The 2026-04-27 gabby bag replay was the additional field-event validation step; deferred — not blocking. The structural fix (zero-stamp = "latest" in tf2 lookups) is the load-bearing change and the unit tests cover its observable contract.
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-05-28 09:00 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+**Verdict**: approved
+
+**Branch**: `feature/issue-23` at `54c8c61`
+**Mode**: pre-push
+**Depth**: Standard (reason: BT plugin + Nav2/tf2 interaction; 9 files, ~500 lines, no security/cross-layer triggers)
+**Must-fix**: 1 | **Suggestions**: 3
+
+### Findings
+- [x] (must-fix) Range math signed/unsigned wrap in `buildPath`/`buildSubPath` — very-negative end_index leaves end_index < 0 after normalization; cast to size_t wraps to a huge value, loop copies whole vector. Cross-model agreement (Claude Adversarial + Copilot Adversarial, independently). Addressed in `54c8c61` with explicit bounds guard + 4 new GTest cases. — `set_path_from_task.cpp:60-68`, `get_sub_path.cpp:42-50`
+- [x] (suggestion) Zero-stamp comment "mirrors path_to_pose_vector.cpp's idiom" was misleading — same idiom but different field (outer Path header here vs per-pose stamps there). Reworded in `54c8c61`. — `set_path_from_task.cpp:78-80`, `get_sub_path.cpp:64-66`
+- [x] (suggestion) `makeStalePath()` comment "outer (stale, what the bug propagated)" misattributed the bug source — the original code copied the first per-pose stamp (1000), not the input outer (999). Reworded in `54c8c61`. — `test_get_sub_path.cpp:27`
+- [ ] (suggestion, declined) `task_bb.value()->message()` doesn't guard against a null shared_ptr in the blackboard (Copilot Adversarial, single-source). Declined: per the workspace's "don't validate for scenarios that can't happen" rule (`CLAUDE.md`), and no current call site puts null in `{current_task}`. The BT runtime would surface a segfault as a node failure rather than silently mask it.

--- a/.agent/work-plans/issue-23/progress.md
+++ b/.agent/work-plans/issue-23/progress.md
@@ -1,0 +1,21 @@
+---
+issue: 23
+---
+
+# Issue #23 — marine_nav: TF extrapolation error on multi-line survey goals (stale header.stamp on per-line goals)
+
+## Issue Review
+**Status**: complete
+**When**: 2026-05-27 23:05 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**Issue**: #23
+**Comment**: https://github.com/rolker/unh_marine_navigation/issues/23#issuecomment-4560573280
+**Scope verdict**: well-scoped
+
+### Actions
+- [ ] (Watch — Capture decisions) Resolve the "is the source stamp preserved for a reason?" question explicitly in plan.md (grep consumers of `path.header.stamp` across the workspace; record the finding).
+- [ ] (Watch — A change includes its consequences) Verify in the same PR that the per-pose-stamp consumers (`marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp:347–348`, `marine_nav_utilities/src/utilities.cpp:22`) are unaffected — the proposed fix touches only the outer `path.header.stamp`.
+- [ ] Pull the 2026-04-27 bag from gabby (`~/data/logs/bizzyboat/`); use the line-3 transition as the canonical offline repro for fix validation before deployment.
+- [ ] Mirror the in-repo precedent for the fix idiom (`marine_nav_behavior_tree/src/plugins/action/path_to_pose_vector.cpp:33`, zero-stamp = "latest" in TF lookups) and the GTest fixture style from `test_dispatch_routing.cpp` / `test_set_task_failed.cpp` for the regression test.
+- [ ] Coordinate with #35 (PR #36) — same file (`set_path_from_task.cpp`); land #23 first since #35 is still plan-only.

--- a/marine_nav_behavior_tree/CMakeLists.txt
+++ b/marine_nav_behavior_tree/CMakeLists.txt
@@ -206,6 +206,40 @@ if(BUILD_TESTING)
       tf2_geometry_msgs
     )
   endif()
+
+  ament_add_gtest(test_set_path_from_task
+    test/test_set_path_from_task.cpp
+  )
+  if(TARGET test_set_path_from_task)
+    target_include_directories(test_set_path_from_task PRIVATE
+      "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    )
+    target_link_libraries(test_set_path_from_task
+      ${PROJECT_NAME}_bt_plugins
+    )
+    ament_target_dependencies(test_set_path_from_task
+      behaviortree_cpp
+      geometry_msgs
+      nav_msgs
+    )
+  endif()
+
+  ament_add_gtest(test_get_sub_path
+    test/test_get_sub_path.cpp
+  )
+  if(TARGET test_get_sub_path)
+    target_include_directories(test_get_sub_path PRIVATE
+      "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    )
+    target_link_libraries(test_get_sub_path
+      ${PROJECT_NAME}_bt_plugins
+    )
+    ament_target_dependencies(test_get_sub_path
+      behaviortree_cpp
+      geometry_msgs
+      nav_msgs
+    )
+  endif()
 endif()
 
 ament_package()

--- a/marine_nav_behavior_tree/include/marine_nav_behavior_tree/plugins/action/get_sub_path.h
+++ b/marine_nav_behavior_tree/include/marine_nav_behavior_tree/plugins/action/get_sub_path.h
@@ -23,6 +23,16 @@ public:
   }
 
   BT::NodeStatus tick() override;
+
+  // Extract a sub-range [start_index, end_index] (negative end_index counts
+  // from the end) of input_path.poses into a new Path. The outer header
+  // takes the first selected pose's frame_id but zeros its stamp — "latest"
+  // in TF lookups, the same idiom used in path_to_pose_vector.cpp (see #23).
+  // Per-pose stamps stay untouched.
+  static nav_msgs::msg::Path buildSubPath(
+    const nav_msgs::msg::Path& input_path,
+    int start_index,
+    int end_index);
 };
 
 } // namespace marine_nav_behavior_tree

--- a/marine_nav_behavior_tree/include/marine_nav_behavior_tree/plugins/action/set_path_from_task.h
+++ b/marine_nav_behavior_tree/include/marine_nav_behavior_tree/plugins/action/set_path_from_task.h
@@ -1,7 +1,11 @@
 #ifndef MARINE_NAV_BEHAVIOR_TREE_ACTIONS_SET_PATH_FROM_TASK_H
 #define MARINE_NAV_BEHAVIOR_TREE_ACTIONS_SET_PATH_FROM_TASK_H
 
+#include <vector>
+
 #include <behaviortree_cpp/bt_factory.h>
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "nav_msgs/msg/path.hpp"
 
 namespace marine_nav_behavior_tree
 {
@@ -14,6 +18,18 @@ public:
   static BT::PortsList providedPorts();
 
   BT::NodeStatus tick() override;
+
+  // Build a Path from a pose vector by copying the index range
+  // [start_index, end_index] (negative end_index counts from the end).
+  // The outer header keeps the first pose's frame_id but zeros its stamp —
+  // "latest" in TF lookups, the same idiom used in path_to_pose_vector.cpp
+  // (see #23). Per-pose stamps stay untouched; downstream consumers
+  // (crabbing_path_follower segment timing, marine_nav_utilities trajectory
+  // computation) rely on them.
+  static nav_msgs::msg::Path buildPath(
+    const std::vector<geometry_msgs::msg::PoseStamped>& poses,
+    int start_index,
+    int end_index);
 };
 
 } // namespace marine_nav_behavior_tree

--- a/marine_nav_behavior_tree/src/plugins/action/get_sub_path.cpp
+++ b/marine_nav_behavior_tree/src/plugins/action/get_sub_path.cpp
@@ -47,6 +47,16 @@ nav_msgs::msg::Path GetSubPath::buildSubPath(
 
   nav_msgs::msg::Path output_path;
 
+  // Out-of-range indices yield an empty path. Without this guard, casting a
+  // still-negative end_index (e.g. end_index = -poses.size()-1) to size_t in
+  // the loop below wraps to a huge value and the loop iterates the whole
+  // vector instead — silently honouring an invalid range. Same shape for a
+  // negative start_index.
+  if(start_index < 0 || end_index < 0 || start_index > end_index)
+  {
+    return output_path;
+  }
+
   for(std::size_t i = start_index; i <= static_cast<std::size_t>(end_index) && i < input_path.poses.size(); i++)
   {
     output_path.poses.push_back(input_path.poses[i]);
@@ -55,8 +65,9 @@ nav_msgs::msg::Path GetSubPath::buildSubPath(
   if(!output_path.poses.empty())
   {
     output_path.header.frame_id = output_path.poses.front().header.frame_id;
-    // Zero stamp = "latest" in TF lookups; mirrors path_to_pose_vector.cpp's idiom.
-    // Per-pose stamps stay untouched (load-bearing downstream — see header). For #23.
+    // Zero-stamp idiom (same as path_to_pose_vector.cpp:33, applied here to
+    // the outer Path header) tells TF lookups to use "latest". Per-pose
+    // stamps stay untouched (load-bearing downstream — see header). For #23.
     output_path.header.stamp = builtin_interfaces::msg::Time();
   }
 

--- a/marine_nav_behavior_tree/src/plugins/action/get_sub_path.cpp
+++ b/marine_nav_behavior_tree/src/plugins/action/get_sub_path.cpp
@@ -1,5 +1,7 @@
 #include "marine_nav_behavior_tree/plugins/action/get_sub_path.h"
 
+#include "builtin_interfaces/msg/time.hpp"
+
 namespace marine_nav_behavior_tree
 {
 
@@ -16,8 +18,6 @@ BT::NodeStatus GetSubPath::tick()
   {
     throw BT::RuntimeError(name(), " missing required input [input_path]: ", input_path_bb.error() );
   }
-  auto input_path = input_path_bb.value();
-
   auto start_index_bb = getInput<int>("start_index");
   if(!start_index_bb)
   {
@@ -29,29 +29,38 @@ BT::NodeStatus GetSubPath::tick()
     throw BT::RuntimeError(name(), " missing required input [end_index]: ", end_index_bb.error() );
   }
 
-  auto start_index = start_index_bb.value();
-  auto end_index = end_index_bb.value();
+  setOutput("output_path",
+            buildSubPath(input_path_bb.value(), start_index_bb.value(), end_index_bb.value()));
 
+  return BT::NodeStatus::SUCCESS;
+}
+
+nav_msgs::msg::Path GetSubPath::buildSubPath(
+  const nav_msgs::msg::Path& input_path,
+  int start_index,
+  int end_index)
+{
   if(end_index < 0)
   {
-    end_index = input_path.poses.size() + end_index;
+    end_index = static_cast<int>(input_path.poses.size()) + end_index;
   }
 
   nav_msgs::msg::Path output_path;
 
-  for(std::size_t i = start_index; i <= end_index && i < input_path.poses.size(); i++)
+  for(std::size_t i = start_index; i <= static_cast<std::size_t>(end_index) && i < input_path.poses.size(); i++)
   {
     output_path.poses.push_back(input_path.poses[i]);
   }
 
   if(!output_path.poses.empty())
   {
-    output_path.header = output_path.poses.front().header;
+    output_path.header.frame_id = output_path.poses.front().header.frame_id;
+    // Zero stamp = "latest" in TF lookups; mirrors path_to_pose_vector.cpp's idiom.
+    // Per-pose stamps stay untouched (load-bearing downstream — see header). For #23.
+    output_path.header.stamp = builtin_interfaces::msg::Time();
   }
 
-  setOutput("output_path", output_path);
-
-  return BT::NodeStatus::SUCCESS;
+  return output_path;
 }
 
 } // namespace marine_nav_behavior_tree

--- a/marine_nav_behavior_tree/src/plugins/action/set_path_from_task.cpp
+++ b/marine_nav_behavior_tree/src/plugins/action/set_path_from_task.cpp
@@ -1,5 +1,6 @@
 #include "marine_nav_behavior_tree/plugins/action/set_path_from_task.h"
-#include "nav_msgs/msg/path.hpp"
+
+#include "builtin_interfaces/msg/time.hpp"
 #include "marine_nav_tasks/task.h"
 
 
@@ -47,30 +48,35 @@ BT::NodeStatus SetPathFromTask::tick()
     throw BT::RuntimeError(name(), " missing required input [end_index]: ", end_index_bb.error() );
   }
 
-  auto start_index = start_index_bb.value();
-  auto end_index = end_index_bb.value();
+  setOutput("path", buildPath(task->message().poses, start_index_bb.value(), end_index_bb.value()));
 
+  return BT::NodeStatus::SUCCESS;
+}
+
+nav_msgs::msg::Path SetPathFromTask::buildPath(
+  const std::vector<geometry_msgs::msg::PoseStamped>& poses,
+  int start_index,
+  int end_index)
+{
   if(end_index < 0)
   {
-    end_index = task->message().poses.size() + end_index;
+    end_index = static_cast<int>(poses.size()) + end_index;
   }
-
-  const auto& poses = task->message().poses;
 
   nav_msgs::msg::Path path;
 
-  for(std::size_t i = start_index; i <= end_index && i < poses.size(); i++)
+  for(std::size_t i = start_index; i <= static_cast<std::size_t>(end_index) && i < poses.size(); i++)
   {
     path.poses.push_back(poses[i]);
   }
   if(!path.poses.empty())
   {
-    path.header = path.poses.front().header;
+    path.header.frame_id = path.poses.front().header.frame_id;
+    // Zero stamp = "latest" in TF lookups; mirrors path_to_pose_vector.cpp's idiom.
+    // Per-pose stamps stay untouched (load-bearing downstream — see header). For #23.
+    path.header.stamp = builtin_interfaces::msg::Time();
   }
-
-  setOutput("path", path);
-
-  return BT::NodeStatus::SUCCESS;
+  return path;
 }
 
 } // namespace marine_nav_behavior_tree

--- a/marine_nav_behavior_tree/src/plugins/action/set_path_from_task.cpp
+++ b/marine_nav_behavior_tree/src/plugins/action/set_path_from_task.cpp
@@ -65,6 +65,16 @@ nav_msgs::msg::Path SetPathFromTask::buildPath(
 
   nav_msgs::msg::Path path;
 
+  // Out-of-range indices yield an empty path. Without this guard, casting a
+  // still-negative end_index (e.g. end_index = -poses.size()-1) to size_t in
+  // the loop below wraps to a huge value and the loop iterates the whole
+  // vector instead — silently honouring an invalid range. Same shape for a
+  // negative start_index.
+  if(start_index < 0 || end_index < 0 || start_index > end_index)
+  {
+    return path;
+  }
+
   for(std::size_t i = start_index; i <= static_cast<std::size_t>(end_index) && i < poses.size(); i++)
   {
     path.poses.push_back(poses[i]);
@@ -72,8 +82,9 @@ nav_msgs::msg::Path SetPathFromTask::buildPath(
   if(!path.poses.empty())
   {
     path.header.frame_id = path.poses.front().header.frame_id;
-    // Zero stamp = "latest" in TF lookups; mirrors path_to_pose_vector.cpp's idiom.
-    // Per-pose stamps stay untouched (load-bearing downstream — see header). For #23.
+    // Zero-stamp idiom (same as path_to_pose_vector.cpp:33, applied here to
+    // the outer Path header) tells TF lookups to use "latest". Per-pose
+    // stamps stay untouched (load-bearing downstream — see header). For #23.
     path.header.stamp = builtin_interfaces::msg::Time();
   }
   return path;

--- a/marine_nav_behavior_tree/test/test_get_sub_path.cpp
+++ b/marine_nav_behavior_tree/test/test_get_sub_path.cpp
@@ -26,8 +26,7 @@ nav_msgs::msg::Path makeStalePath()
   p.header.frame_id = "map";
   p.header.stamp.sec = 999;   // outer (stale, what the bug propagated)
 
-  for(int i = 0; i < 3; ++i)
-  {
+  for(int i = 0; i < 3; ++i) {
     geometry_msgs::msg::PoseStamped pose;
     pose.header.frame_id = "map";
     pose.header.stamp.sec = 1000 + i;
@@ -53,7 +52,9 @@ TEST(GetSubPathBuildSubPath, ZeroesOuterStampOnNonEmptyResult)
 TEST(GetSubPathBuildSubPath, PreservesOuterFrameId)
 {
   auto in = makeStalePath();
-  for(auto& p : in.poses) p.header.frame_id = "odom";
+  for(auto & p : in.poses) {
+    p.header.frame_id = "odom";
+  }
   auto path = GetSubPath::buildSubPath(in, 0, -1);
   EXPECT_EQ(path.header.frame_id, "odom");
 }

--- a/marine_nav_behavior_tree/test/test_get_sub_path.cpp
+++ b/marine_nav_behavior_tree/test/test_get_sub_path.cpp
@@ -24,7 +24,12 @@ nav_msgs::msg::Path makeStalePath()
 {
   nav_msgs::msg::Path p;
   p.header.frame_id = "map";
-  p.header.stamp.sec = 999;   // outer (stale, what the bug propagated)
+  // Distinct outer stamp + per-pose stamps below. The bug propagated the
+  // first per-pose stamp (1000) into the outer header, not this 999 — that
+  // gets dropped because buildSubPath rebuilds the outer header from the
+  // first output pose. Tests assert outer == 0 post-fix, which catches a
+  // regression to either source.
+  p.header.stamp.sec = 999;
 
   for(int i = 0; i < 3; ++i) {
     geometry_msgs::msg::PoseStamped pose;
@@ -110,6 +115,25 @@ TEST(GetSubPathBuildSubPath, InvertedRangeReturnsEmpty)
   EXPECT_TRUE(path.poses.empty());
   EXPECT_EQ(path.header.stamp.sec, 0);
   EXPECT_TRUE(path.header.frame_id.empty());
+}
+
+// Very-negative end_index (more negative than -size) leaves it still negative
+// after the "counts from end" normalization. The bounds guard must catch this
+// and return empty, not silently wrap to size_t and copy the whole vector.
+TEST(GetSubPathBuildSubPath, VeryNegativeEndIndexReturnsEmpty)
+{
+  auto path = GetSubPath::buildSubPath(makeStalePath(), 0, -5);   // size=3, -5 → -2
+  EXPECT_TRUE(path.poses.empty());
+  EXPECT_EQ(path.header.stamp.sec, 0);
+}
+
+// Negative start_index would also wrap to a huge size_t in the loop init.
+// Treat any negative index as out-of-range → empty path.
+TEST(GetSubPathBuildSubPath, NegativeStartIndexReturnsEmpty)
+{
+  auto path = GetSubPath::buildSubPath(makeStalePath(), -1, 2);
+  EXPECT_TRUE(path.poses.empty());
+  EXPECT_EQ(path.header.stamp.sec, 0);
 }
 
 int main(int argc, char ** argv)

--- a/marine_nav_behavior_tree/test/test_get_sub_path.cpp
+++ b/marine_nav_behavior_tree/test/test_get_sub_path.cpp
@@ -1,0 +1,118 @@
+// Unit tests for GetSubPath::buildSubPath — the static helper that extracts
+// a pose index-range from an input Path. Same fix shape as
+// SetPathFromTask::buildPath; defense-in-depth for #23 (this producer builds
+// {transit_path}, whose stale stamp is dropped at PathToPoseVector before
+// reaching Nav2 FollowPath, but the identical bug shape is fixed for
+// regression resistance against future BT rewiring).
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "marine_nav_behavior_tree/plugins/action/get_sub_path.h"
+#include "nav_msgs/msg/path.hpp"
+
+using marine_nav_behavior_tree::GetSubPath;
+
+namespace
+{
+
+// Input path with a stale outer stamp AND distinct per-pose stamps — exercises
+// both: the outer-stamp zeroing fix and the per-pose preservation invariant.
+nav_msgs::msg::Path makeStalePath()
+{
+  nav_msgs::msg::Path p;
+  p.header.frame_id = "map";
+  p.header.stamp.sec = 999;   // outer (stale, what the bug propagated)
+
+  for(int i = 0; i < 3; ++i)
+  {
+    geometry_msgs::msg::PoseStamped pose;
+    pose.header.frame_id = "map";
+    pose.header.stamp.sec = 1000 + i;
+    pose.header.stamp.nanosec = static_cast<uint32_t>(111 * (i + 1));
+    pose.pose.position.x = static_cast<double>(i);
+    p.poses.push_back(pose);
+  }
+  return p;
+}
+
+}  // namespace
+
+// Core fix: outer stamp must be zero ("latest" in TF lookups), not the input
+// path's outer stamp nor the first per-pose stamp.
+TEST(GetSubPathBuildSubPath, ZeroesOuterStampOnNonEmptyResult)
+{
+  auto path = GetSubPath::buildSubPath(makeStalePath(), 0, -1);
+  EXPECT_EQ(path.header.stamp.sec, 0);
+  EXPECT_EQ(path.header.stamp.nanosec, 0u);
+}
+
+// Outer frame_id round-trips (spatial reference, not stamp).
+TEST(GetSubPathBuildSubPath, PreservesOuterFrameId)
+{
+  auto in = makeStalePath();
+  for(auto& p : in.poses) p.header.frame_id = "odom";
+  auto path = GetSubPath::buildSubPath(in, 0, -1);
+  EXPECT_EQ(path.header.frame_id, "odom");
+}
+
+// Per-pose stamps stay untouched — load-bearing downstream.
+TEST(GetSubPathBuildSubPath, PerPoseStampsUntouched)
+{
+  auto path = GetSubPath::buildSubPath(makeStalePath(), 0, -1);
+  ASSERT_EQ(path.poses.size(), 3u);
+  EXPECT_EQ(path.poses[0].header.stamp.sec, 1000);
+  EXPECT_EQ(path.poses[0].header.stamp.nanosec, 111u);
+  EXPECT_EQ(path.poses[1].header.stamp.sec, 1001);
+  EXPECT_EQ(path.poses[2].header.stamp.sec, 1002);
+}
+
+TEST(GetSubPathBuildSubPath, NegativeEndIndexNormalizes)
+{
+  EXPECT_EQ(GetSubPath::buildSubPath(makeStalePath(), 0, -1).poses.size(), 3u);
+  EXPECT_EQ(GetSubPath::buildSubPath(makeStalePath(), 0, -2).poses.size(), 2u);
+}
+
+TEST(GetSubPathBuildSubPath, SubRangeSelectsCorrectly)
+{
+  auto path = GetSubPath::buildSubPath(makeStalePath(), 1, 2);
+  ASSERT_EQ(path.poses.size(), 2u);
+  EXPECT_DOUBLE_EQ(path.poses[0].pose.position.x, 1.0);
+  EXPECT_DOUBLE_EQ(path.poses[1].pose.position.x, 2.0);
+}
+
+TEST(GetSubPathBuildSubPath, SinglePoseRange)
+{
+  auto path = GetSubPath::buildSubPath(makeStalePath(), 1, 1);
+  ASSERT_EQ(path.poses.size(), 1u);
+  EXPECT_DOUBLE_EQ(path.poses[0].pose.position.x, 1.0);
+  EXPECT_EQ(path.poses[0].header.stamp.sec, 1001);
+  EXPECT_EQ(path.header.stamp.sec, 0);
+}
+
+// Empty input path → default-constructed Path (the empty-result guard skips
+// the header assignment).
+TEST(GetSubPathBuildSubPath, EmptyInputReturnsZeroHeaderPath)
+{
+  nav_msgs::msg::Path empty;
+  auto path = GetSubPath::buildSubPath(empty, 0, -1);
+  EXPECT_TRUE(path.poses.empty());
+  EXPECT_EQ(path.header.stamp.sec, 0);
+  EXPECT_TRUE(path.header.frame_id.empty());
+}
+
+TEST(GetSubPathBuildSubPath, InvertedRangeReturnsEmpty)
+{
+  auto path = GetSubPath::buildSubPath(makeStalePath(), 2, 1);
+  EXPECT_TRUE(path.poses.empty());
+  EXPECT_EQ(path.header.stamp.sec, 0);
+  EXPECT_TRUE(path.header.frame_id.empty());
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/marine_nav_behavior_tree/test/test_set_path_from_task.cpp
+++ b/marine_nav_behavior_tree/test/test_set_path_from_task.cpp
@@ -120,6 +120,25 @@ TEST(SetPathFromTaskBuildPath, InvertedRangeReturnsEmpty)
   EXPECT_TRUE(path.header.frame_id.empty());
 }
 
+// Very-negative end_index (more negative than -size) leaves it still negative
+// after the "counts from end" normalization. The bounds guard must catch this
+// and return empty, not silently wrap to size_t and copy the whole vector.
+TEST(SetPathFromTaskBuildPath, VeryNegativeEndIndexReturnsEmpty)
+{
+  auto path = SetPathFromTask::buildPath(stalePoses(), 0, -5);   // size=3, -5 → -2
+  EXPECT_TRUE(path.poses.empty());
+  EXPECT_EQ(path.header.stamp.sec, 0);
+}
+
+// Negative start_index would also wrap to a huge size_t in the loop init.
+// Treat any negative index as out-of-range → empty path.
+TEST(SetPathFromTaskBuildPath, NegativeStartIndexReturnsEmpty)
+{
+  auto path = SetPathFromTask::buildPath(stalePoses(), -1, 2);
+  EXPECT_TRUE(path.poses.empty());
+  EXPECT_EQ(path.header.stamp.sec, 0);
+}
+
 int main(int argc, char ** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/marine_nav_behavior_tree/test/test_set_path_from_task.cpp
+++ b/marine_nav_behavior_tree/test/test_set_path_from_task.cpp
@@ -19,7 +19,7 @@ namespace
 {
 
 geometry_msgs::msg::PoseStamped makePose(
-  double x, int32_t sec, uint32_t nanosec, const std::string& frame = "map")
+  double x, int32_t sec, uint32_t nanosec, const std::string & frame = "map")
 {
   geometry_msgs::msg::PoseStamped p;
   p.header.frame_id = frame;
@@ -55,7 +55,9 @@ TEST(SetPathFromTaskBuildPath, ZeroesOuterStampOnNonEmptyResult)
 TEST(SetPathFromTaskBuildPath, PreservesOuterFrameId)
 {
   auto poses = stalePoses();
-  for(auto& p : poses) p.header.frame_id = "odom";
+  for(auto & p : poses) {
+    p.header.frame_id = "odom";
+  }
   auto path = SetPathFromTask::buildPath(poses, 0, -1);
   EXPECT_EQ(path.header.frame_id, "odom");
 }

--- a/marine_nav_behavior_tree/test/test_set_path_from_task.cpp
+++ b/marine_nav_behavior_tree/test/test_set_path_from_task.cpp
@@ -1,0 +1,125 @@
+// Unit tests for SetPathFromTask::buildPath — the static helper that copies
+// a pose index-range into a Path. Guards the TF-extrapolation fix from #23:
+// the outer header.stamp must be zero ("latest" in TF lookups), the outer
+// frame_id round-trips, and per-pose stamps stay untouched (downstream
+// crabbing_path_follower and marine_nav_utilities rely on them).
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "marine_nav_behavior_tree/plugins/action/set_path_from_task.h"
+#include "nav_msgs/msg/path.hpp"
+
+using marine_nav_behavior_tree::SetPathFromTask;
+
+namespace
+{
+
+geometry_msgs::msg::PoseStamped makePose(
+  double x, int32_t sec, uint32_t nanosec, const std::string& frame = "map")
+{
+  geometry_msgs::msg::PoseStamped p;
+  p.header.frame_id = frame;
+  p.header.stamp.sec = sec;
+  p.header.stamp.nanosec = nanosec;
+  p.pose.position.x = x;
+  return p;
+}
+
+// Three poses with deliberately stale, distinct stamps — the canonical
+// "task uploaded minutes ago, now line 3 of the survey" shape.
+std::vector<geometry_msgs::msg::PoseStamped> stalePoses()
+{
+  return {
+    makePose(0.0, 1000, 111),
+    makePose(1.0, 1001, 222),
+    makePose(2.0, 1002, 333),
+  };
+}
+
+}  // namespace
+
+// Core fix: outer stamp must be zero ("latest" in TF lookups) — not the stale
+// first-pose stamp the legacy code copied.
+TEST(SetPathFromTaskBuildPath, ZeroesOuterStampOnNonEmptyResult)
+{
+  auto path = SetPathFromTask::buildPath(stalePoses(), 0, -1);
+  EXPECT_EQ(path.header.stamp.sec, 0);
+  EXPECT_EQ(path.header.stamp.nanosec, 0u);
+}
+
+// Spatial reference is real and must round-trip — only the stamp is "latest".
+TEST(SetPathFromTaskBuildPath, PreservesOuterFrameId)
+{
+  auto poses = stalePoses();
+  for(auto& p : poses) p.header.frame_id = "odom";
+  auto path = SetPathFromTask::buildPath(poses, 0, -1);
+  EXPECT_EQ(path.header.frame_id, "odom");
+}
+
+// Per-pose stamps are load-bearing downstream (crabbing segment timing,
+// utilities trajectory computation). The fix must NOT zero them.
+TEST(SetPathFromTaskBuildPath, PerPoseStampsUntouched)
+{
+  auto path = SetPathFromTask::buildPath(stalePoses(), 0, -1);
+  ASSERT_EQ(path.poses.size(), 3u);
+  EXPECT_EQ(path.poses[0].header.stamp.sec, 1000);
+  EXPECT_EQ(path.poses[0].header.stamp.nanosec, 111u);
+  EXPECT_EQ(path.poses[1].header.stamp.sec, 1001);
+  EXPECT_EQ(path.poses[2].header.stamp.sec, 1002);
+}
+
+// Negative end_index counts from the end — preserve original behaviour.
+TEST(SetPathFromTaskBuildPath, NegativeEndIndexNormalizes)
+{
+  EXPECT_EQ(SetPathFromTask::buildPath(stalePoses(), 0, -1).poses.size(), 3u);
+  EXPECT_EQ(SetPathFromTask::buildPath(stalePoses(), 0, -2).poses.size(), 2u);
+}
+
+// Sub-range [1, 2] selects the middle and last pose.
+TEST(SetPathFromTaskBuildPath, SubRangeSelectsCorrectly)
+{
+  auto path = SetPathFromTask::buildPath(stalePoses(), 1, 2);
+  ASSERT_EQ(path.poses.size(), 2u);
+  EXPECT_DOUBLE_EQ(path.poses[0].pose.position.x, 1.0);
+  EXPECT_DOUBLE_EQ(path.poses[1].pose.position.x, 2.0);
+}
+
+// Single-pose range [start == end] returns exactly one pose.
+TEST(SetPathFromTaskBuildPath, SinglePoseRange)
+{
+  auto path = SetPathFromTask::buildPath(stalePoses(), 1, 1);
+  ASSERT_EQ(path.poses.size(), 1u);
+  EXPECT_DOUBLE_EQ(path.poses[0].pose.position.x, 1.0);
+  EXPECT_EQ(path.poses[0].header.stamp.sec, 1001);   // per-pose preserved
+  EXPECT_EQ(path.header.stamp.sec, 0);               // outer zeroed
+}
+
+// Empty input → default-constructed Path: the `if(!path.poses.empty())`
+// guard skips the header assignment, so frame_id stays empty and stamp zero.
+TEST(SetPathFromTaskBuildPath, EmptyInputReturnsZeroHeaderPath)
+{
+  auto path = SetPathFromTask::buildPath({}, 0, -1);
+  EXPECT_TRUE(path.poses.empty());
+  EXPECT_EQ(path.header.stamp.sec, 0);
+  EXPECT_EQ(path.header.stamp.nanosec, 0u);
+  EXPECT_TRUE(path.header.frame_id.empty());
+}
+
+// Inverted range (start > end) returns an empty path with a default header.
+TEST(SetPathFromTaskBuildPath, InvertedRangeReturnsEmpty)
+{
+  auto path = SetPathFromTask::buildPath(stalePoses(), 2, 1);
+  EXPECT_TRUE(path.poses.empty());
+  EXPECT_EQ(path.header.stamp.sec, 0);
+  EXPECT_TRUE(path.header.frame_id.empty());
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Closes #23

## Implementation Summary

- **Commits on `feature/issue-23`**:
  - `40b8f3f` — fix: zero outer `path.header.stamp` in `SetPathFromTask` + `GetSubPath`; extract static `buildPath` / `buildSubPath` helpers; 16 GTest cases; plan amended inline (causal chain, line drift, test-fixture strategy, `FixPathOrientations` pass-through note)
  - `c8c8e1c` — style: apply uncrustify to new test files (whitespace; new files only — pre-existing package-wide drift left alone, mirroring PR #37's choice)
  - `54c8c61` — fix: guard `buildPath` / `buildSubPath` against signed/unsigned wrap (round-2 hardening from cross-model adversarial review — both Claude and Copilot independently flagged that very-negative `end_index` left it negative after normalization, then `static_cast<size_t>` wrapped to a huge value and the loop copied the whole vector). 4 additional GTest cases.
  - `c7c9bfb` — progress: implementation + local review entries
- **Tests**: 31/31 `marine_nav_behavior_tree` gtests pass (`test_set_path_from_task` 10/10, `test_get_sub_path` 10/10, existing 11/11).
- **Local Review (pre-push)**: approved at `54c8c61`; 1 must-fix + 3 suggestions addressed inline. Single-source null-deref finding declined (no current call site puts null in `{current_task}`; trust the BT framework's contract rather than defensive-validate).
- **Deferred — bag/sim validation (plan step 6)**: the 2026-04-27 gabby bag replay was the additional field-event validation step; not blocking. The unit-test assertion matrix (outer stamp zero, outer frame_id preserved, per-pose stamps untouched, empty / single / inverted / very-negative ranges) covers the structural fix as a pure-function contract.
- **Step 1 grep finding (issue body's "preserved on purpose?" caveat)**: across `unh_marine_navigation`, `unh_marine_autonomy`, `unh_echoboats_project11` — **zero in-repo consumers** of the outer `path.header.stamp`. Only Nav2's external TF lookup reads it. Caveat resolved.
- **Out-of-scope sibling worth a future ticket**: `set_polygon_from_task.cpp:63` has the same anti-pattern on `PolygonStamped` (known; not in this PR).

---

# Plan: marine_nav: TF extrapolation error on multi-line survey goals (stale header.stamp on per-line goals)

## Issue

https://github.com/rolker/unh_marine_navigation/issues/23

## Context

Multi-line survey goals carry a stale `header.stamp` from task-upload time, so Nav2's `FollowPath` then does `lookupTransform(..., path.header.stamp)` with a time outside the TF buffer (~10 s default) → extrapolation error → goal aborts at the line transition. Real-world repro: `unh_echoboats_project11/docs/logs/2026/2026-04-27_dev_logs.md:421` — "weird turn onto 3rd line" on a live multi-line survey, bag at `~/data/logs/bizzyboat/` on gabby.

**Two producers, identical bug shape** — both inherit the path's outer header from the first pose's stale stamp:

- `marine_nav_behavior_tree/src/plugins/action/set_path_from_task.cpp:71` — `path.header = path.poses.front().header;` (builds `{survey_path}` for SurveyLine). **Load-bearing**: `{survey_path}` is fed directly to `FollowPath` in the `SurveyLine` subtree — this is the actual TF-extrapolation repro path.
- `marine_nav_behavior_tree/src/plugins/action/get_sub_path.cpp:49` — `output_path.header = output_path.poses.front().header;` (builds `{transit_path}` for TransitAndSurveyLine at `run_tasks.xml:373`). **Defense-in-depth**: the `{transit_path}` flow goes through `FixPathOrientations` (pass-through for the outer header) → `PathToPoseVector` (drops the outer header — extracts a pose vector) → `ComputePathThroughPoses` (Nav2 plans a fresh path) → `FollowPath`, so the stale stamp never reaches Nav2's TF lookup directly. Still right to fix — same buggy shape, prevents a regression if downstream wiring changes.

`clear_path.cpp` is fine — it emits a default-constructed empty `Path()` (zero stamp). The codebase already has the idiomatic fix in `marine_nav_behavior_tree/src/plugins/action/path_to_pose_vector.cpp:33`: `p.header.stamp = builtin_interfaces::msg::Time();   // zero stamp = "latest" in TF lookups`. Mirror that (applied here to the outer Path header rather than per-pose stamps — same idiom, different field).

**Per-pose stamps are load-bearing** — `marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp:347–348` reads `p1.header.stamp` / `p2.header.stamp` as `segment_start_time` / `segment_end_time`, and `marine_nav_utilities/src/utilities.cpp:22` advances per-pose stamps by `distance/speed`. The fix touches only the outer `path.header.stamp` — per-pose stamps stay untouched.

## Approach

1. **Verify the "preserved on purpose?" caveat.** Grep across `unh_marine_navigation`, `unh_marine_autonomy`, `unh_echoboats_project11` for consumers of `path.header.stamp` (the outer one, not per-pose). Result: **zero in-repo consumers**; only Nav2's TF lookup. Issue-body caveat resolved.
2. **Pull the 2026-04-27 bag** from gabby `~/data/logs/bizzyboat/`; identify the line-3 transition window from the dev log. Canonical offline repro for pre/post validation. *Deferred — see Implementation Summary above; unit-test contract covers the structural fix.*
3. **Apply the fix in both producers, via a static helper.** Extract a `static buildPath(...)` / `buildSubPath(...)` helper on each class — mirrors `PredictStoppingPose::projectStoppingPose` (the in-repo testability precedent). `tick()` becomes a thin BT-blackboard wrapper around the helper. The helper performs the index-range copy and sets the outer header to `frame_id` only + zero stamp:
   ```cpp
   path.header.frame_id = path.poses.front().header.frame_id;
   path.header.stamp = builtin_interfaces::msg::Time();   // zero = "latest" in tf2 (same idiom as path_to_pose_vector.cpp:33, applied here to the outer header); for #23
   ```
   Per-pose stamps in `path.poses` are unchanged.
4. **Add regression tests.** Two new GTest files mirroring `test_predict_stopping_pose.cpp` (static-helper style; no BT-tick fixture):
   - `marine_nav_behavior_tree/test/test_set_path_from_task.cpp` (10 cases).
   - `marine_nav_behavior_tree/test/test_get_sub_path.cpp` (10 cases).
   - Assertion matrix: outer `path.header.stamp` is zero; outer `frame_id` preserved (non-empty round-trip); per-pose stamps **not** zeroed; empty range returns default-constructed `Path`; single-pose range; inverted range; negative `end_index` normalizes; very-negative `end_index` returns empty (signed/unsigned guard); negative `start_index` returns empty (signed/unsigned guard).
   - Update `marine_nav_behavior_tree/CMakeLists.txt` with two new `ament_add_gtest` blocks (link `${PROJECT_NAME}_bt_plugins`; `ament_target_dependencies`: `behaviortree_cpp`, `geometry_msgs`, `nav_msgs`, `rclcpp`).
5. **Build + run all `marine_nav_behavior_tree` tests.** All gtests pass (31/31). Pre-existing uncrustify 0.78.1 drift left untouched (sibling files not modified by this PR) — mirrors PR #37's choice.
6. **Offline-validate against the bag (or sim repro).** *Deferred — see Implementation Summary.*
7. **Pre-push self-review via `/review-code`.** Standard tier (BT plugin + Nav2/tf2 interaction). 1 must-fix (bounds guard) + 3 suggestions addressed inline in `54c8c61`. PR flipped from `[PLAN]` draft to ready.

## Files Changed

| File | Change |
|------|--------|
| `marine_nav_behavior_tree/include/marine_nav_behavior_tree/plugins/action/set_path_from_task.h` | Add `static buildPath(...)` declaration. |
| `marine_nav_behavior_tree/src/plugins/action/set_path_from_task.cpp` | Implement `buildPath` (frame_id + zero-stamp + bounds guard); `tick()` is now a thin blackboard wrapper. |
| `marine_nav_behavior_tree/include/marine_nav_behavior_tree/plugins/action/get_sub_path.h` | Add `static buildSubPath(...)` declaration. |
| `marine_nav_behavior_tree/src/plugins/action/get_sub_path.cpp` | Implement `buildSubPath` (same shape). |
| `marine_nav_behavior_tree/test/test_set_path_from_task.cpp` | New: 10 GTest cases for `buildPath`. |
| `marine_nav_behavior_tree/test/test_get_sub_path.cpp` | New: 10 GTest cases for `buildSubPath`. |
| `marine_nav_behavior_tree/CMakeLists.txt` | Register the two new `ament_add_gtest` blocks. |

## ADR Compliance

| ADR | Triggered | How addressed |
|---|---|---|
| 0002 — Worktree isolation | Yes | Work in `layers/worktrees/issue-unh_marine_navigation-23/`. |
| 0008 — ROS 2 conventions | Yes (lightly) | `builtin_interfaces::msg::Time()` zero-stamp = "latest" is the standard tf2 idiom; mirrors in-repo precedent. |
| 0013 — `progress.md` vocabulary | Yes | Lifecycle: Issue Review → Plan Authored → Plan Review → Implementation → Local Review (Pre-Push) → Integrated Review (post-PR). |

## Consequences

| If we change... | Also update... | Status |
|---|---|---|
| Outer `path.header.stamp` emitted by `SetPathFromTask` / `GetSubPath` | Any consumer of the outer stamp other than Nav2 FollowPath | Done — step 1 grep verifies none exist. |
| Per-pose `header.stamp` | (intentionally not changed) — `crabbing_path_follower:347–348`, `utilities.cpp:22` rely on them | Verified untouched by the fix. |
| Test target list | `marine_nav_behavior_tree/CMakeLists.txt` `ament_add_gtest` blocks | Done. |

## Coordination

Coordinate with [#35 (PR #36)](https://github.com/rolker/unh_marine_navigation/pull/36) — same producer file (`set_path_from_task.cpp`); land this first since #35 is still plan-only. Also adjacent to [#28 (PR #40)](https://github.com/rolker/unh_marine_navigation/pull/40), which references the same 2026-04-27 field event with a different mechanism (`CancelFollowPath` FCU watchdog vs TF extrapolation).

## Test plan

- [x] 31/31 `marine_nav_behavior_tree` gtests pass (new + existing).
- [x] `ament_uncrustify` clean on the new test files and pre-existing-clean on the rest (no new drift).
- [ ] Bag replay against 2026-04-27 gabby bag — deferred (requires gabby access); not blocking.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
