### PR TITLE
fix(hover): recompute hover target on re-entry + same-type re-command (#46)

### DIFF
--- a/.agent/work-plans/issue-46/plan.md
+++ b/.agent/work-plans/issue-46/plan.md
@@ -1,0 +1,98 @@
+# Plan: Hover sticks to first-evoked location — SequenceWithMemory never re-ticks PredictStoppingPose on re-entry
+
+## Issue
+
+https://github.com/rolker/unh_marine_navigation/issues/46
+
+## Context
+
+`HoverTask` (`run_tasks.xml:64-95`) wraps `[Fallback, PredictStoppingPose, Script, Hover]`
+in `SequenceWithMemory`. In BT.CPP 4.9.0 that node resets its child index only on
+`SUCCESS`, and its `halt()` deliberately does not reset it. `Hover` is a perpetual
+station-keep that never returns `SUCCESS` (`hover.cpp:205`), so the index never resets:
+after the first engagement the node parks at the `Hover` child and every later re-entry
+(via `Switch5` halting/re-selecting on `current_task_type`) resumes straight at `Hover`,
+**skipping `PredictStoppingPose`**. `{hover_target}` is therefore computed once — the
+first time hover is evoked (at activation that's the launch point, since `done_hover` is
+the only task) — and reused forever. `PredictStoppingPose` and the hover server are both
+correct in isolation; the defect is the control-node choice. The XML comment at
+`run_tasks.xml:79-84` documents the opposite of the actual behavior.
+
+## Approach
+
+**Phase 1 (this PR) — end-of-task / `done_hover` fix + regression test**
+
+1. **Swap `SequenceWithMemory` → `Sequence` in `HoverTask`** (`run_tasks.xml`). Plain
+   `Sequence::halt()` resets the index to 0, so each re-entry re-runs `Fallback` +
+   `PredictStoppingPose` (fresh stop point), while a *continuous* hold still resumes at the
+   RUNNING `Hover` child (no per-tick recompute — important: recomputing every tick would
+   chase the drifting boat, which is why the stop point must be captured once *per entry*).
+2. **Rewrite the `run_tasks.xml:79-84` comment** to state the real contract: stop point is
+   recomputed once per entry because plain `Sequence` resets on halt; do **not** restore
+   `SequenceWithMemory` (links the failure mode to this issue).
+3. **Add a regression gtest** that pins the BT-mechanics contract this fix depends on:
+   minimal tree `Sequence[counting-sync-action, never-succeeding(RUNNING)-leaf]`, then
+   tick → `haltTree` → tick, asserting the counting action ran **twice**. The same test
+   built with `SequenceWithMemory` asserts it runs **once** (documents why the swap is
+   load-bearing). No ROS fixture needed.
+
+**Phase 2 — same-type re-command (`hover_override`) — see Open Questions for bundle-vs-stack**
+
+4. The pure same-type re-command (operator re-hovers while already hovering; `current_task_type`
+   stays `hover`, so `Switch5` never halts) is **not** fixed by Phase 1 and **not** fixed by
+   re-reading the target port alone: with no halt the `Sequence` stays parked at `Hover`, so
+   `Fallback`/`PredictStoppingPose` never re-tick and `{hover_target}`/`{goal_poses}` never
+   refresh. The real lever is **forcing HoverTask re-entry when `current_task_id` changes**
+   (a reactive id-latch guard in the BT), paired with making `HoverAction` reactive
+   (`on_wait_for_result` re-reads `target`, sets `goal_updated_` → `send_new_goal()`, the
+   #35/FollowPath pattern) so a re-entry recomputed target is actually re-sent mid-RUNNING.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml` | P1: `SequenceWithMemory`→`Sequence` in `HoverTask`; correct comment. P2: reactive id-latch guard. |
+| `marine_nav_bt_task_navigator/test/test_hover_reentry.cpp` (new) | P1: re-entry re-ticks regression test (Sequence vs SequenceWithMemory). |
+| `marine_nav_bt_task_navigator/CMakeLists.txt` | Register the new gtest. |
+| `marine_nav_behavior_tree/src/plugins/action/hover_action.{cpp,h}` | P2 only: override `on_wait_for_result` for reactive target re-send. |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Quality Standard — fix completely, add the test | Phase 1 ships the fix + a regression test that fails on the old node and passes on the new one. |
+| Never circumvent tests; fix code not config | Behavior fix in the tree, not a test/config workaround. |
+| Documentation accuracy | The misleading `run_tasks.xml:79-84` comment is corrected, not left to drift. |
+| Surface scope deferrals | Phase 2 split decision is raised as an Open Question, not silently deferred. |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0013 (progress.md vocabulary) | Yes | Plan/progress entries follow the schema (handled by plan-task skill). |
+| Functional ADRs | No | A BT control-node swap + reactive action node triggers none. |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| `run_tasks.xml` (installed via ament `install(DIRECTORY)`) | Rebuild `marine_nav_bt_task_navigator` — symlink-install does **not** pick up XML data-file edits | Yes — note in test/build steps |
+| `HoverTask` control flow | `marine_autonomy_integration_tests` (`test_mission_navigation_failure.py` exercises `done_hover`) — confirm still green | Yes — run before PR |
+| Hover re-entry semantics | Existing `test_predict_stopping_pose.cpp` (unaffected — node unchanged) | Verified no change |
+
+## Open Questions
+
+- [ ] **Bundle Phase 2 here or stack as a follow-up?** Recommend **stacking** — Phase 1 fully
+      fixes the reported end-of-task symptom and is small/safe; Phase 2 is a distinct
+      reactive-refresh design (re-entry-on-id-change + reactive action node) with its own test
+      matrix, mirroring how #35 was its own change. (Counter: the "bundle related cleanups"
+      preference — your call.)
+- [ ] **Phase 2 mechanism:** acceptable to add a small reactive id-latch in the BT XML, or do
+      you prefer a dedicated custom condition node (`TaskIdChangedCondition`) for clarity/testing?
+- [ ] Should `done_hover` instead carry the last survey pose explicitly, sidestepping the
+      drift-projection path entirely? (Leaning no — drift-to-stop is the intended #33 behavior.)
+
+## Estimated Scope
+
+Phase 1: single small PR (XML one-line swap + comment + one gtest). Phase 2: a second stacked
+PR if approved. Defaulting to Phase 1 this PR pending the bundle-vs-stack answer.

--- a/.agent/work-plans/issue-46/plan.md
+++ b/.agent/work-plans/issue-46/plan.md
@@ -94,19 +94,34 @@ correct in isolation; the defect is the control-node choice. The XML comment at
 | `HoverTask` control flow | **Cross-repo** (`unh_marine_autonomy`, not this repo): `done_hover` is emitted by `mission_manager.py` and exercised by `marine_autonomy_integration_tests/test/test_mission_navigation_failure.py`. The swap doesn't change task semantics, only when `PredictStoppingPose` re-ticks, so no `unh_marine_autonomy` change is expected — but flag a manual cross-repo integration check before merge. | Manual cross-repo check (not in this PR's CI) |
 | Hover re-entry semantics | Existing `test_predict_stopping_pose.cpp` (unaffected — node unchanged) | Verified no change |
 
-## Open Questions
+## Open Questions (resolved 2026-05-29)
 
-- [ ] **Bundle Phase 2 here or stack as a follow-up?** Recommend **stacking** — Phase 1 fully
-      fixes the reported end-of-task symptom and is small/safe; Phase 2 is a distinct
-      reactive-refresh design (re-entry-on-id-change + reactive action node) with its own test
-      matrix, mirroring how #35 was its own change. (Counter: the "bundle related cleanups"
-      preference — your call.)
-- [ ] **Phase 2 mechanism:** acceptable to add a small reactive id-latch in the BT XML, or do
-      you prefer a dedicated custom condition node (`TaskIdChangedCondition`) for clarity/testing?
-- [ ] Should `done_hover` instead carry the last survey pose explicitly, sidestepping the
-      drift-projection path entirely? (Leaning no — drift-to-stop is the intended #33 behavior.)
+- [x] **Bundle Phase 2 here or stack?** → **Bundle** (operator wants one fix for a same-day
+      sim test + deployment).
+- [x] **Phase 2 mechanism?** → **Custom C++ node** (`RestartOnTaskChange` decorator), not inline
+      XML — for unit-testability and to avoid the XML-scripting footgun of routing a failed
+      condition to `SetTaskFailed`.
+- [x] **`done_hover` explicit pose?** → **No.** Keep drift-to-stop (intended #33 behavior).
+
+## Implementation Notes
+
+- Phase 2 restart key is **`{current_task_update_time}`**, not task id: a re-issued
+  `hover_override` keeps the same id ('hover_override') and only its pose changes, so an
+  id-only check would miss it. `Task::update` bumps `last_update_time_` only when the task
+  message actually changes (`task.cpp:44`), so a benign feedback-loop re-send of an identical
+  task does not trigger a spurious restart (which would thrash hover). The quick sim test is
+  the gate that confirms no thrash in practice.
+- The `RestartOnTaskChange` decorator's `haltChild()` + re-tick cancels and re-sends the hover
+  goal on a re-command, so the separately-considered `HoverAction::on_wait_for_result` reactive
+  change was **not needed** — fewer files touched.
+- Regression test placed in `marine_nav_behavior_tree/test/test_hover_reentry.cpp` (existing
+  gtest harness). 5 cases, all green: plain-Sequence re-ticks after halt; SequenceWithMemory
+  does not (documents the bug); plain-Sequence no-recompute during continuous hold; decorator
+  restarts on timestamp change; decorator stable when timestamp unchanged.
+- **Local lint note:** `colcon test` `ament_uncrustify` fails package-wide, including committed
+  files this PR does not touch — a local uncrustify version skew, not introduced here. Not
+  mass-reformatting per the no-circumvent-tests rule; gtests + build are green.
 
 ## Estimated Scope
 
-Phase 1: single small PR (XML one-line swap + comment + one gtest). Phase 2: a second stacked
-PR if approved. Defaulting to Phase 1 this PR pending the bundle-vs-stack answer.
+Single PR, both phases. Implemented and unit-tested; pending quick sim test before merge/deploy.

--- a/.agent/work-plans/issue-46/plan.md
+++ b/.agent/work-plans/issue-46/plan.md
@@ -8,8 +8,12 @@ https://github.com/rolker/unh_marine_navigation/issues/46
 
 `HoverTask` (`run_tasks.xml:64-95`) wraps `[Fallback, PredictStoppingPose, Script, Hover]`
 in `SequenceWithMemory`. In BT.CPP 4.9.0 that node resets its child index only on
-`SUCCESS`, and its `halt()` deliberately does not reset it. `Hover` is a perpetual
-station-keep that never returns `SUCCESS` (`hover.cpp:205`), so the index never resets:
+`SUCCESS`; its `halt()` is understood **not** to reset the index (the documented contract
+that distinguishes it from plain `Sequence`, whose `halt()` resets to 0). Note the
+`halt()` bodies live in the compiled lib — not readable here — so this distinction is
+asserted from BT.CPP's documented behavior and is **pinned by the Phase-1 regression test**
+(step 3), not read from source. `Hover` is a perpetual station-keep that never returns
+`SUCCESS` (`hover.cpp:205`), so the index never resets:
 after the first engagement the node parks at the `Hover` child and every later re-entry
 (via `Switch5` halting/re-selecting on `current_task_type`) resumes straight at `Hover`,
 **skipping `PredictStoppingPose`**. `{hover_target}` is therefore computed once — the
@@ -27,14 +31,24 @@ correct in isolation; the defect is the control-node choice. The XML comment at
    `PredictStoppingPose` (fresh stop point), while a *continuous* hold still resumes at the
    RUNNING `Hover` child (no per-tick recompute — important: recomputing every tick would
    chase the drifting boat, which is why the stop point must be captured once *per entry*).
+   The continuous-hold safety has a load-bearing dependency: it holds because the inner
+   sequence is the **last** child of the outer `ReactiveSequence` (`run_tasks.xml:62`), so
+   ReactiveSequence (which halts only siblings *after* a RUNNING child) never halts it
+   between loops. A future edit that adds a sibling after the sequence would break this —
+   call this out in the comment (step 2).
 2. **Rewrite the `run_tasks.xml:79-84` comment** to state the real contract: stop point is
-   recomputed once per entry because plain `Sequence` resets on halt; do **not** restore
-   `SequenceWithMemory` (links the failure mode to this issue).
-3. **Add a regression gtest** that pins the BT-mechanics contract this fix depends on:
+   recomputed once per entry because plain `Sequence` resets on halt; continuous hold is
+   safe only while the sequence stays the last child of the ReactiveSequence; do **not**
+   restore `SequenceWithMemory` (links the failure mode to this issue).
+3. **Add a regression gtest** that pins **both** halves of the contract this fix depends on:
    minimal tree `Sequence[counting-sync-action, never-succeeding(RUNNING)-leaf]`, then
-   tick → `haltTree` → tick, asserting the counting action ran **twice**. The same test
-   built with `SequenceWithMemory` asserts it runs **once** (documents why the swap is
-   load-bearing). No ROS fixture needed.
+   (a) tick → `haltTree` → tick, asserting the counting action ran **twice** (re-entry
+   recompute — the bug); and (b) tick → tick with **no** halt, asserting it ran **once**
+   (continuous-hold no-recompute — the regression guard). The same (a) built with
+   `SequenceWithMemory` asserts **once** (documents why the swap is load-bearing). No ROS
+   fixture needed — pure BT-mechanics test. Place it in `marine_nav_behavior_tree/test/`
+   (which already has a gtest harness — 6 tests), **not** `bt_task_navigator` (which has no
+   test infrastructure at all), to avoid bootstrapping a new test target.
 
 **Phase 2 — same-type re-command (`hover_override`) — see Open Questions for bundle-vs-stack**
 
@@ -52,8 +66,8 @@ correct in isolation; the defect is the control-node choice. The XML comment at
 | File | Change |
 |------|--------|
 | `marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml` | P1: `SequenceWithMemory`→`Sequence` in `HoverTask`; correct comment. P2: reactive id-latch guard. |
-| `marine_nav_bt_task_navigator/test/test_hover_reentry.cpp` (new) | P1: re-entry re-ticks regression test (Sequence vs SequenceWithMemory). |
-| `marine_nav_bt_task_navigator/CMakeLists.txt` | Register the new gtest. |
+| `marine_nav_behavior_tree/test/test_sequence_reentry.cpp` (new) | P1: re-entry-recompute + continuous-hold-no-recompute regression test (Sequence vs SequenceWithMemory). Lives here because this package already has a gtest harness. |
+| `marine_nav_behavior_tree/CMakeLists.txt` | P1: add the new gtest to the existing test block. |
 | `marine_nav_behavior_tree/src/plugins/action/hover_action.{cpp,h}` | P2 only: override `on_wait_for_result` for reactive target re-send. |
 
 ## Principles Self-Check
@@ -76,8 +90,8 @@ correct in isolation; the defect is the control-node choice. The XML comment at
 
 | If we change... | Also update... | Included in plan? |
 |---|---|---|
-| `run_tasks.xml` (installed via ament `install(DIRECTORY)`) | Rebuild `marine_nav_bt_task_navigator` — symlink-install does **not** pick up XML data-file edits | Yes — note in test/build steps |
-| `HoverTask` control flow | `marine_autonomy_integration_tests` (`test_mission_navigation_failure.py` exercises `done_hover`) — confirm still green | Yes — run before PR |
+| `run_tasks.xml` (installed via ament `install(DIRECTORY)`, `CMakeLists.txt:51`) | Rebuild `marine_nav_bt_task_navigator` — symlink-install does **not** pick up XML data-file edits | Yes — note in test/build steps |
+| `HoverTask` control flow | **Cross-repo** (`unh_marine_autonomy`, not this repo): `done_hover` is emitted by `mission_manager.py` and exercised by `marine_autonomy_integration_tests/test/test_mission_navigation_failure.py`. The swap doesn't change task semantics, only when `PredictStoppingPose` re-ticks, so no `unh_marine_autonomy` change is expected — but flag a manual cross-repo integration check before merge. | Manual cross-repo check (not in this PR's CI) |
 | Hover re-entry semantics | Existing `test_predict_stopping_pose.cpp` (unaffected — node unchanged) | Verified no change |
 
 ## Open Questions

--- a/.agent/work-plans/issue-46/progress.md
+++ b/.agent/work-plans/issue-46/progress.md
@@ -33,3 +33,26 @@ issue: 46
 - [x] (must-fix) Consequences cited `marine_autonomy_integration_tests`/`done_hover` as local; they live in the separate `unh_marine_autonomy` repo — relabeled as a cross-repo manual check. — `plan.md` Consequences
 - [x] (must-fix) `bt_task_navigator` has no test infra; moved the regression gtest to `marine_nav_behavior_tree` (existing harness), dropped the bootstrap. — `plan.md` Files to Change
 - [ ] (confirmed) Phase 2 reasoning (re-read port insufficient; re-entry-on-id-change is the lever) verified against `hover_action.cpp:35-41` + `bt_action_node.hpp:237-250`.
+
+## Implementation
+**Status**: complete (pending sim test)
+**When**: 2026-05-29 10:40 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Commit**: `51855a8` on `feature/issue-46`
+**Decision**: both phases bundled (operator: same-day sim test + deployment).
+
+- Phase 1: `SequenceWithMemory` → plain `Sequence` in `HoverTask` (`run_tasks.xml`).
+- Phase 2: new `RestartOnTaskChange` decorator (custom C++ node, Option B) keyed on
+  `{current_task_update_time}`; wrapped around the hover `Sequence`; registered +
+  TreeNodesModel entry. Restart key is update_time (not id) so a re-issued same-id
+  `hover_override` is caught; `Task::update` bumps it only on real change → no thrash.
+- `done_hover`: kept drift-to-stop (no explicit pose).
+- Test: `test_hover_reentry.cpp`, 5 cases — **all gtests green** (47 across the package, 0 failures).
+- Build: `marine_nav_behavior_tree` + `marine_nav_bt_task_navigator` build clean.
+
+### Notes
+- [ ] Local `ament_uncrustify` fails package-wide incl. untouched committed files (version
+      skew) — not mass-reformatting per no-circumvent-tests; CI is the canonical gate.
+- [ ] Next: quick sim test (activate, survey offset from launch, confirm end-of-mission hover
+      settles at survey end, not launch; re-command hover and confirm it moves), then deploy.

--- a/.agent/work-plans/issue-46/progress.md
+++ b/.agent/work-plans/issue-46/progress.md
@@ -1,0 +1,19 @@
+---
+issue: 46
+---
+
+# Issue #46 — Hover sticks to first-evoked location — SequenceWithMemory never re-ticks PredictStoppingPose on re-entry
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-05-29 10:01 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Plan**: `.agent/work-plans/issue-46/plan.md` at `9f20785`
+**PR**: https://github.com/rolker/unh_marine_navigation/pull/47 (`[PLAN]` prefix)
+**Phases**: 2 (Phase 1 = node swap + regression test this PR; Phase 2 = reactive re-command, stack pending decision)
+
+### Open questions
+- [ ] Bundle Phase 2 (same-type re-command reactive fix) here or stack as a follow-up? Recommend stacking.
+- [ ] Phase 2 mechanism: inline reactive id-latch in BT XML vs. a dedicated custom condition node?
+- [ ] Should `done_hover` carry the last survey pose explicitly instead of relying on drift projection? (Leaning no.)

--- a/.agent/work-plans/issue-46/progress.md
+++ b/.agent/work-plans/issue-46/progress.md
@@ -17,3 +17,19 @@ issue: 46
 - [ ] Bundle Phase 2 (same-type re-command reactive fix) here or stack as a follow-up? Recommend stacking.
 - [ ] Phase 2 mechanism: inline reactive id-latch in BT XML vs. a dedicated custom condition node?
 - [ ] Should `done_hover` carry the last survey pose explicitly instead of relying on drift projection? (Leaning no.)
+
+## Plan Review
+**Status**: complete
+**When**: 2026-05-29 10:09 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context)) — independent fresh-context sub-agent review (not author self-review)
+
+**Plan**: `.agent/work-plans/issue-46/plan.md` at `68d0971`
+**PR**: https://github.com/rolker/unh_marine_navigation/pull/47
+**Verdict**: changes-requested → all must-fix addressed inline (plan re-committed at `68d0971`)
+
+### Findings
+- [x] (must-fix) `halt()`-reset claim was stated as fact though unreadable from source — softened prose, noted it is pinned by the Phase-1 gtest. — `plan.md` Context
+- [x] (must-fix) Continuous-hold no-recompute path was unpinned; added test arm (b) tick→tick→assert once, and documented the ReactiveSequence-last-child dependency. — `plan.md` Approach step 3
+- [x] (must-fix) Consequences cited `marine_autonomy_integration_tests`/`done_hover` as local; they live in the separate `unh_marine_autonomy` repo — relabeled as a cross-repo manual check. — `plan.md` Consequences
+- [x] (must-fix) `bt_task_navigator` has no test infra; moved the regression gtest to `marine_nav_behavior_tree` (existing harness), dropped the bootstrap. — `plan.md` Files to Change
+- [ ] (confirmed) Phase 2 reasoning (re-read port insufficient; re-entry-on-id-change is the lever) verified against `hover_action.cpp:35-41` + `bt_action_node.hpp:237-250`.

--- a/marine_nav_behavior_tree/CMakeLists.txt
+++ b/marine_nav_behavior_tree/CMakeLists.txt
@@ -91,6 +91,7 @@ add_library(${PROJECT_NAME}_bt_plugins SHARED
   src/plugins/condition/all_tasks_done.cpp
   src/plugins/condition/has_sub_tasks.cpp
   src/plugins/condition/path_empty.cpp
+  src/plugins/decorator/restart_on_task_change.cpp
 )
 
 list(APPEND plugin_libs ${PROJECT_NAME}_bt_plugins)
@@ -275,6 +276,22 @@ if(BUILD_TESTING)
       behaviortree_cpp
       geometry_msgs
       nav_msgs
+    )
+  endif()
+
+  ament_add_gtest(test_hover_reentry
+    test/test_hover_reentry.cpp
+  )
+  if(TARGET test_hover_reentry)
+    target_include_directories(test_hover_reentry PRIVATE
+      "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    )
+    target_link_libraries(test_hover_reentry
+      ${PROJECT_NAME}_bt_plugins
+    )
+    ament_target_dependencies(test_hover_reentry
+      behaviortree_cpp
+      rclcpp
     )
   endif()
 endif()

--- a/marine_nav_behavior_tree/include/marine_nav_behavior_tree/plugins/decorator/restart_on_task_change.h
+++ b/marine_nav_behavior_tree/include/marine_nav_behavior_tree/plugins/decorator/restart_on_task_change.h
@@ -1,0 +1,52 @@
+#ifndef MARINE_NAV_BEHAVIOR_TREE__PLUGINS__DECORATOR__RESTART_ON_TASK_CHANGE_H_
+#define MARINE_NAV_BEHAVIOR_TREE__PLUGINS__DECORATOR__RESTART_ON_TASK_CHANGE_H_
+
+#include <string>
+
+#include "behaviortree_cpp/decorator_node.h"
+#include "rclcpp/time.hpp"
+
+namespace marine_nav_behavior_tree
+{
+
+/**
+ * @brief Decorator that restarts its child (halt + re-tick from the top) when a
+ * watched task-update timestamp changes while the child is RUNNING.
+ *
+ * Motivation (#46): HoverTask is dispatched by a Switch keyed on task *type*. A
+ * same-type re-command — a new hover_override, or a fresh hover task with a
+ * different id — does not change the type, so the Switch never halts the hover
+ * branch. The (plain Sequence) hover subtree then stays parked at its RUNNING
+ * Hover child and never re-runs the goal-set Fallback / PredictStoppingPose, so
+ * {hover_target} is never refreshed and the boat holds the stale spot. Wrapping
+ * the hover Sequence in this decorator forces a clean re-entry (recompute the
+ * target, re-send the hover goal) the moment the operator commands a new or
+ * updated hover.
+ *
+ * The watched value is {current_task_update_time}. Task::update bumps that stamp
+ * only when the task message actually changes (see marine_nav_tasks task.cpp), so
+ * a benign feedback-loop re-send of an identical task does NOT trigger a restart.
+ *
+ * The baseline timestamp is (re)adopted on the first tick of each fresh entry —
+ * i.e. after the node has been halted (type-change dispatch) or after the child
+ * completed — so a type-driven re-entry never spuriously restarts on its own.
+ */
+class RestartOnTaskChange : public BT::DecoratorNode
+{
+public:
+  RestartOnTaskChange(const std::string & name, const BT::NodeConfig & config);
+
+  static BT::PortsList providedPorts();
+
+  void halt() override;
+
+private:
+  BT::NodeStatus tick() override;
+
+  bool have_baseline_{false};
+  rclcpp::Time baseline_;
+};
+
+}  // namespace marine_nav_behavior_tree
+
+#endif  // MARINE_NAV_BEHAVIOR_TREE__PLUGINS__DECORATOR__RESTART_ON_TASK_CHANGE_H_

--- a/marine_nav_behavior_tree/src/bt_register_nodes.cpp
+++ b/marine_nav_behavior_tree/src/bt_register_nodes.cpp
@@ -25,6 +25,8 @@
 #include "marine_nav_behavior_tree/plugins/condition/has_sub_tasks.h"
 #include "marine_nav_behavior_tree/plugins/condition/path_empty.h"
 
+#include "marine_nav_behavior_tree/plugins/decorator/restart_on_task_change.h"
+
 BT_REGISTER_NODES(factory)
 {
   factory.registerNodeType<marine_nav_behavior_tree::AddSubTask>("AddSubTask");
@@ -88,5 +90,7 @@ BT_REGISTER_NODES(factory)
   factory.registerNodeType<marine_nav_behavior_tree::AllTasksDone>("AllTasksDoneCondition");
   factory.registerNodeType<marine_nav_behavior_tree::HasSubTasks>("HasSubTasksCondition");
   factory.registerNodeType<marine_nav_behavior_tree::PathEmpty>("PathEmptyCondition");
+
+  factory.registerNodeType<marine_nav_behavior_tree::RestartOnTaskChange>("RestartOnTaskChange");
 
 }

--- a/marine_nav_behavior_tree/src/plugins/decorator/restart_on_task_change.cpp
+++ b/marine_nav_behavior_tree/src/plugins/decorator/restart_on_task_change.cpp
@@ -31,23 +31,31 @@ void RestartOnTaskChange::halt()
 
 BT::NodeStatus RestartOnTaskChange::tick()
 {
-  rclcpp::Time current;
-  const bool have_input = static_cast<bool>(getInput("task_update_time", current));
+  // task_update_time is a required input: fail fast on a missing/unwired port
+  // rather than silently no-op'ing (which would leave the decorator ineffective
+  // and mask the wiring error). In correct trees UpdateCurrentTask always
+  // populates {current_task_update_time} before HoverTask runs, so this fires
+  // only on a wiring/type regression — deterministically, at bring-up. Matches
+  // the throw-on-missing-required-port convention of the other nodes here.
+  const auto input = getInput<rclcpp::Time>("task_update_time");
+  if (!input) {
+    throw BT::RuntimeError(
+      name(), " missing required input [task_update_time]: ", input.error());
+  }
+  const rclcpp::Time current = input.value();
 
-  if (have_input) {
-    if (!have_baseline_) {
-      // Fresh entry (first tick, or first after a halt / completed child):
-      // adopt the current stamp as the baseline; do not restart.
-      baseline_ = current;
-      have_baseline_ = true;
-    } else if (current != baseline_) {
-      // The task changed under us without a type-driven halt (same-type
-      // re-command). Force a clean re-entry of the child subtree: haltChild()
-      // resets a plain Sequence to its first child and cancels any running
-      // action, so the subsequent tick recomputes the goal and re-sends it.
-      baseline_ = current;
-      haltChild();
-    }
+  if (!have_baseline_) {
+    // Fresh entry (first tick, or first after a halt / completed child):
+    // adopt the current stamp as the baseline; do not restart.
+    baseline_ = current;
+    have_baseline_ = true;
+  } else if (current != baseline_) {
+    // The task changed under us without a type-driven halt (same-type
+    // re-command). Force a clean re-entry of the child subtree: haltChild()
+    // resets a plain Sequence to its first child and cancels any running
+    // action, so the subsequent tick recomputes the goal and re-sends it.
+    baseline_ = current;
+    haltChild();
   }
 
   setStatus(BT::NodeStatus::RUNNING);

--- a/marine_nav_behavior_tree/src/plugins/decorator/restart_on_task_change.cpp
+++ b/marine_nav_behavior_tree/src/plugins/decorator/restart_on_task_change.cpp
@@ -1,0 +1,65 @@
+#include "marine_nav_behavior_tree/plugins/decorator/restart_on_task_change.h"
+
+namespace marine_nav_behavior_tree
+{
+
+RestartOnTaskChange::RestartOnTaskChange(
+  const std::string & name, const BT::NodeConfig & config)
+: BT::DecoratorNode(name, config)
+{
+}
+
+BT::PortsList RestartOnTaskChange::providedPorts()
+{
+  return {
+    BT::InputPort<rclcpp::Time>(
+      "task_update_time",
+      "Timestamp of the current task's last update (wire to "
+      "{current_task_update_time}). When it changes while the child is RUNNING, "
+      "the child is halted and re-ticked from the top so a same-type task "
+      "re-command takes effect.")
+  };
+}
+
+void RestartOnTaskChange::halt()
+{
+  // Drop the baseline so the next fresh entry re-adopts the then-current stamp
+  // rather than comparing against a stale one from a prior engagement.
+  have_baseline_ = false;
+  BT::DecoratorNode::halt();
+}
+
+BT::NodeStatus RestartOnTaskChange::tick()
+{
+  rclcpp::Time current;
+  const bool have_input = static_cast<bool>(getInput("task_update_time", current));
+
+  if (have_input) {
+    if (!have_baseline_) {
+      // Fresh entry (first tick, or first after a halt / completed child):
+      // adopt the current stamp as the baseline; do not restart.
+      baseline_ = current;
+      have_baseline_ = true;
+    } else if (current != baseline_) {
+      // The task changed under us without a type-driven halt (same-type
+      // re-command). Force a clean re-entry of the child subtree: haltChild()
+      // resets a plain Sequence to its first child and cancels any running
+      // action, so the subsequent tick recomputes the goal and re-sends it.
+      baseline_ = current;
+      haltChild();
+    }
+  }
+
+  setStatus(BT::NodeStatus::RUNNING);
+  const BT::NodeStatus child_status = child_node_->executeTick();
+
+  // Once the child settles (SUCCESS/FAILURE), forget the baseline so a later
+  // re-engagement adopts a fresh one instead of comparing across a gap.
+  if (child_status != BT::NodeStatus::RUNNING) {
+    have_baseline_ = false;
+  }
+
+  return child_status;
+}
+
+}  // namespace marine_nav_behavior_tree

--- a/marine_nav_behavior_tree/test/test_hover_reentry.cpp
+++ b/marine_nav_behavior_tree/test/test_hover_reentry.cpp
@@ -1,0 +1,187 @@
+// Regression tests for the #46 hover-target latch fix.
+//
+// Two things are pinned here:
+//
+//  1. The BT-mechanics contract the HoverTask fix depends on: a plain `Sequence`
+//     re-ticks its first child after a halt/re-entry, whereas `SequenceWithMemory`
+//     does NOT (it keeps its child index). Because the real `Hover` action never
+//     returns SUCCESS, SequenceWithMemory never reset and so never re-ran
+//     PredictStoppingPose — freezing the hover target at the first value ever
+//     computed. The same test also pins the no-regression direction: a *continuous*
+//     hold (tick → tick, no halt) must NOT re-tick the first child (recomputing the
+//     stop point every tick would chase the drifting boat).
+//
+//  2. The `RestartOnTaskChange` decorator: it forces a child re-entry when the
+//     watched timestamp changes (a same-type hover re-command, which the dispatch
+//     Switch does not halt on), and leaves the child untouched while the timestamp
+//     is stable (no thrash on benign feedback re-sends).
+//
+// Pure BT-mechanics — no ROS fixture. A counting leaf stands in for
+// "Fallback + PredictStoppingPose" and a perpetually-RUNNING leaf for `Hover`.
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "behaviortree_cpp/bt_factory.h"
+#include "marine_nav_behavior_tree/plugins/decorator/restart_on_task_change.h"
+#include "rclcpp/time.hpp"
+
+namespace
+{
+
+// Counts how many times it is ticked. Stands in for the work that must re-run on
+// each hover entry (goal-set Fallback + PredictStoppingPose).
+class CountingAction : public BT::SyncActionNode
+{
+public:
+  CountingAction(const std::string & name, const BT::NodeConfig & config)
+  : BT::SyncActionNode(name, config) {}
+
+  static BT::PortsList providedPorts() { return {}; }
+
+  static int count;
+
+  BT::NodeStatus tick() override
+  {
+    ++count;
+    return BT::NodeStatus::SUCCESS;
+  }
+};
+int CountingAction::count = 0;
+
+// Always RUNNING, cleanly haltable. Stands in for the perpetual-station-keep
+// `Hover` action that never returns SUCCESS.
+class RunningLeaf : public BT::StatefulActionNode
+{
+public:
+  RunningLeaf(const std::string & name, const BT::NodeConfig & config)
+  : BT::StatefulActionNode(name, config) {}
+
+  static BT::PortsList providedPorts() { return {}; }
+
+  BT::NodeStatus onStart() override { return BT::NodeStatus::RUNNING; }
+  BT::NodeStatus onRunning() override { return BT::NodeStatus::RUNNING; }
+  void onHalted() override {}
+};
+
+BT::BehaviorTreeFactory makeFactory()
+{
+  BT::BehaviorTreeFactory factory;
+  factory.registerNodeType<CountingAction>("Counter");
+  factory.registerNodeType<RunningLeaf>("RunningLeaf");
+  factory.registerNodeType<marine_nav_behavior_tree::RestartOnTaskChange>(
+    "RestartOnTaskChange");
+  return factory;
+}
+
+const rclcpp::Time T1(10, 0, RCL_ROS_TIME);
+const rclcpp::Time T2(20, 0, RCL_ROS_TIME);
+
+}  // namespace
+
+// --- 1. BT-mechanics contract -------------------------------------------------
+
+// Plain Sequence re-ticks the first child after a halt → re-entry recomputes.
+// This is the behaviour the HoverTask fix relies on.
+TEST(HoverReentry, PlainSequenceReticksFirstChildAfterHalt)
+{
+  CountingAction::count = 0;
+  auto factory = makeFactory();
+  auto tree = factory.createTreeFromText(
+    R"(<root BTCPP_format="4"><BehaviorTree ID="MainTree">
+         <Sequence><Counter/><RunningLeaf/></Sequence>
+       </BehaviorTree></root>)");
+
+  tree.tickOnce();                       // Counter (1), RunningLeaf RUNNING
+  EXPECT_EQ(CountingAction::count, 1);
+  tree.haltTree();                       // plain Sequence resets to child 0
+  tree.tickOnce();                       // Counter re-ticked (2)
+  EXPECT_EQ(CountingAction::count, 2);
+}
+
+// SequenceWithMemory does NOT re-tick after a halt — documents the bug: with the
+// never-succeeding RunningLeaf the node never resets, so the Counter runs once.
+TEST(HoverReentry, SequenceWithMemoryDoesNotRetickAfterHalt)
+{
+  CountingAction::count = 0;
+  auto factory = makeFactory();
+  auto tree = factory.createTreeFromText(
+    R"(<root BTCPP_format="4"><BehaviorTree ID="MainTree">
+         <SequenceWithMemory><Counter/><RunningLeaf/></SequenceWithMemory>
+       </BehaviorTree></root>)");
+
+  tree.tickOnce();
+  EXPECT_EQ(CountingAction::count, 1);
+  tree.haltTree();                       // SequenceWithMemory KEEPS its index
+  tree.tickOnce();                       // resumes at RunningLeaf; Counter skipped
+  EXPECT_EQ(CountingAction::count, 1);
+}
+
+// Continuous hold (no halt) must NOT re-tick the first child — guards against a
+// regression where the stop point would be recomputed every tick.
+TEST(HoverReentry, PlainSequenceDoesNotRetickDuringContinuousHold)
+{
+  CountingAction::count = 0;
+  auto factory = makeFactory();
+  auto tree = factory.createTreeFromText(
+    R"(<root BTCPP_format="4"><BehaviorTree ID="MainTree">
+         <Sequence><Counter/><RunningLeaf/></Sequence>
+       </BehaviorTree></root>)");
+
+  for (int i = 0; i < 5; ++i) {
+    tree.tickOnce();                     // no halt between ticks
+  }
+  EXPECT_EQ(CountingAction::count, 1);   // resumed at RunningLeaf each time
+}
+
+// --- 2. RestartOnTaskChange decorator ----------------------------------------
+
+// A changed timestamp forces the child to re-enter (Counter re-runs); a stable
+// timestamp does not.
+TEST(RestartOnTaskChange, RestartsWhenTimestampChanges)
+{
+  CountingAction::count = 0;
+  auto factory = makeFactory();
+  auto tree = factory.createTreeFromText(
+    R"(<root BTCPP_format="4"><BehaviorTree ID="MainTree">
+         <RestartOnTaskChange task_update_time="{t}">
+           <Sequence><Counter/><RunningLeaf/></Sequence>
+         </RestartOnTaskChange>
+       </BehaviorTree></root>)");
+
+  tree.rootBlackboard()->set("t", T1);
+  tree.tickOnce();                       // baseline T1; Counter (1)
+  EXPECT_EQ(CountingAction::count, 1);
+
+  tree.tickOnce();                       // t unchanged → no restart
+  EXPECT_EQ(CountingAction::count, 1);
+
+  tree.rootBlackboard()->set("t", T2);
+  tree.tickOnce();                       // t changed → restart; Counter (2)
+  EXPECT_EQ(CountingAction::count, 2);
+}
+
+TEST(RestartOnTaskChange, NoRestartWhileTimestampStable)
+{
+  CountingAction::count = 0;
+  auto factory = makeFactory();
+  auto tree = factory.createTreeFromText(
+    R"(<root BTCPP_format="4"><BehaviorTree ID="MainTree">
+         <RestartOnTaskChange task_update_time="{t}">
+           <Sequence><Counter/><RunningLeaf/></Sequence>
+         </RestartOnTaskChange>
+       </BehaviorTree></root>)");
+
+  tree.rootBlackboard()->set("t", T1);
+  for (int i = 0; i < 5; ++i) {
+    tree.tickOnce();
+  }
+  EXPECT_EQ(CountingAction::count, 1);   // never restarted
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml
+++ b/marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml
@@ -78,8 +78,11 @@
              would chase the drifting boat). SequenceWithMemory kept its index
              across halts and — because Hover never returns SUCCESS — never
              re-ticked PredictStoppingPose, freezing {hover_target} at the first
-             value ever computed (#46). Continuous-hold safety relies on this
-             Sequence staying the last child of the outer ReactiveSequence. -->
+             value ever computed (#46). Continuous-hold safety relies on the
+             enclosing RestartOnTaskChange decorator (this Sequence's parent)
+             staying the LAST child of the outer ReactiveSequence: a sibling
+             added after it would make the ReactiveSequence halt this subtree
+             every tick, recomputing the stop point and chasing the boat. -->
         <Sequence>
           <Fallback name="SetHoverGoalFallback">
             <Inverter>

--- a/marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml
+++ b/marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml
@@ -61,38 +61,58 @@
   <BehaviorTree ID="HoverTask">
     <ReactiveSequence>
       <ScriptCondition code="current_task_type == &apos;hover&apos;"/>
-      <SequenceWithMemory>
-        <Fallback name="SetHoverGoalFallback">
-          <Inverter>
-            <SetPathFromTask end_index="-1"
-                             path="{goal_poses}"
-                             start_index="0"
-                             task="{current_task}"/>
-          </Inverter>
-          <IfThenElse>
-            <PathEmptyCondition path="{goal_poses}"/>
-            <AlwaysSuccess/>
-            <SubTree ID="GotoPose"
-                     _autoremap="true"/>
-          </IfThenElse>
-        </Fallback>
-        <!-- Hold the momentum-coasting stop point instead of the live pose, so
-             a boat arriving at survey speed decelerates into the point rather
-             than overshooting and driving back (#33). Run on both paths: after
-             a transit (location given) the boat is ~stopped so this ≈ the
-             current pose; computing it on every entry also keeps {hover_target}
-             fresh, avoiding a stale target leaking from a previous hover. -->
-        <PredictStoppingPose deceleration="{default_deceleration}"
-                             pose="{hover_target}"/>
-        <Script code="navigation_state := &apos;hover&apos;"/>
-        <Hover target="{hover_target}"
-               maximum_radius="0.000000"
-               maximum_speed="0.000000"
-               error_code_id="{hover_error_code}"
-               server_timeout="1000"
-               minimum_radius="0.000000"
-               server_name="hover"/>
-      </SequenceWithMemory>
+      <!-- RestartOnTaskChange forces a clean re-entry of the hover Sequence
+           whenever {current_task_update_time} changes (a new or updated hover
+           task). The Switch that dispatches HoverTask keys on task *type*, so a
+           same-type re-command (a new hover_override, or a different hover id)
+           does NOT halt this branch on its own; without this decorator the
+           Sequence would stay parked at the RUNNING Hover child and never
+           recompute the target. Task::update bumps current_task_update_time only
+           on a real message change, so benign feedback re-sends don't restart.
+           For #46. -->
+      <RestartOnTaskChange task_update_time="{current_task_update_time}">
+        <!-- Plain Sequence (NOT SequenceWithMemory): Sequence::halt() resets the
+             child index to 0, so every entry re-runs the goal-set Fallback and
+             PredictStoppingPose for a fresh stop point, while a continuous hold
+             still resumes at the RUNNING Hover child (no per-tick recompute that
+             would chase the drifting boat). SequenceWithMemory kept its index
+             across halts and — because Hover never returns SUCCESS — never
+             re-ticked PredictStoppingPose, freezing {hover_target} at the first
+             value ever computed (#46). Continuous-hold safety relies on this
+             Sequence staying the last child of the outer ReactiveSequence. -->
+        <Sequence>
+          <Fallback name="SetHoverGoalFallback">
+            <Inverter>
+              <SetPathFromTask end_index="-1"
+                               path="{goal_poses}"
+                               start_index="0"
+                               task="{current_task}"/>
+            </Inverter>
+            <IfThenElse>
+              <PathEmptyCondition path="{goal_poses}"/>
+              <AlwaysSuccess/>
+              <SubTree ID="GotoPose"
+                       _autoremap="true"/>
+            </IfThenElse>
+          </Fallback>
+          <!-- Hold the momentum-coasting stop point instead of the live pose, so
+               a boat arriving at survey speed decelerates into the point rather
+               than overshooting and driving back (#33). After a transit (location
+               given) the boat is ~stopped so this ≈ the current pose. Recomputed
+               once per entry (see Sequence note above) to avoid a stale target
+               leaking from a previous hover. -->
+          <PredictStoppingPose deceleration="{default_deceleration}"
+                               pose="{hover_target}"/>
+          <Script code="navigation_state := &apos;hover&apos;"/>
+          <Hover target="{hover_target}"
+                 maximum_radius="0.000000"
+                 maximum_speed="0.000000"
+                 error_code_id="{hover_error_code}"
+                 server_timeout="1000"
+                 minimum_radius="0.000000"
+                 server_name="hover"/>
+        </Sequence>
+      </RestartOnTaskChange>
     </ReactiveSequence>
   </BehaviorTree>
 
@@ -187,6 +207,7 @@
                    current_task_type="{current_task_type}"
                    navigation_state="{navigation_state}"
                    current_task="{current_task}"
+                   current_task_update_time="{current_task_update_time}"
                    _autoremap="true"/>
           <SetTaskFailed name="HoverFailed" task="{current_task}" reason="hover_failed"/>
         </Fallback>
@@ -695,6 +716,10 @@
     </Action>
     <Decorator ID="RateController">
       <input_port name="hz">Rate</input_port>
+    </Decorator>
+    <Decorator ID="RestartOnTaskChange">
+      <input_port name="task_update_time"
+                  type="rclcpp::Time">Timestamp of the current task's last update (wire to {current_task_update_time}); when it changes while the child is RUNNING, the child is halted and re-ticked from the top</input_port>
     </Decorator>
     <Action ID="RemovePassedGoals">
       <input_port name="input_goals">Input goals to remove if passed</input_port>


### PR DESCRIPTION
Closes #46

# Plan: Hover sticks to first-evoked location — SequenceWithMemory never re-ticks PredictStoppingPose on re-entry

## Issue

https://github.com/rolker/unh_marine_navigation/issues/46

## Context

`HoverTask` (`run_tasks.xml:64-95`) wraps `[Fallback, PredictStoppingPose, Script, Hover]`
in `SequenceWithMemory`. In BT.CPP 4.9.0 that node resets its child index only on
`SUCCESS`; its `halt()` is understood **not** to reset the index (the documented contract
that distinguishes it from plain `Sequence`, whose `halt()` resets to 0). Note the
`halt()` bodies live in the compiled lib — not readable here — so this distinction is
asserted from BT.CPP's documented behavior and is **pinned by the Phase-1 regression test**
(step 3), not read from source. `Hover` is a perpetual station-keep that never returns
`SUCCESS` (`hover.cpp:205`), so the index never resets:
after the first engagement the node parks at the `Hover` child and every later re-entry
(via `Switch5` halting/re-selecting on `current_task_type`) resumes straight at `Hover`,
**skipping `PredictStoppingPose`**. `{hover_target}` is therefore computed once — the
first time hover is evoked (at activation that's the launch point, since `done_hover` is
the only task) — and reused forever. `PredictStoppingPose` and the hover server are both
correct in isolation; the defect is the control-node choice. The XML comment at
`run_tasks.xml:79-84` documents the opposite of the actual behavior.

## Approach

**Phase 1 (this PR) — end-of-task / `done_hover` fix + regression test**

1. **Swap `SequenceWithMemory` → `Sequence` in `HoverTask`** (`run_tasks.xml`). Plain
   `Sequence::halt()` resets the index to 0, so each re-entry re-runs `Fallback` +
   `PredictStoppingPose` (fresh stop point), while a *continuous* hold still resumes at the
   RUNNING `Hover` child (no per-tick recompute — important: recomputing every tick would
   chase the drifting boat, which is why the stop point must be captured once *per entry*).
   The continuous-hold safety has a load-bearing dependency: it holds because the inner
   sequence is the **last** child of the outer `ReactiveSequence` (`run_tasks.xml:62`), so
   ReactiveSequence (which halts only siblings *after* a RUNNING child) never halts it
   between loops. A future edit that adds a sibling after the sequence would break this —
   call this out in the comment (step 2).
2. **Rewrite the `run_tasks.xml:79-84` comment** to state the real contract: stop point is
   recomputed once per entry because plain `Sequence` resets on halt; continuous hold is
   safe only while the sequence stays the last child of the ReactiveSequence; do **not**
   restore `SequenceWithMemory` (links the failure mode to this issue).
3. **Add a regression gtest** that pins **both** halves of the contract this fix depends on:
   minimal tree `Sequence[counting-sync-action, never-succeeding(RUNNING)-leaf]`, then
   (a) tick → `haltTree` → tick, asserting the counting action ran **twice** (re-entry
   recompute — the bug); and (b) tick → tick with **no** halt, asserting it ran **once**
   (continuous-hold no-recompute — the regression guard). The same (a) built with
   `SequenceWithMemory` asserts **once** (documents why the swap is load-bearing). No ROS
   fixture needed — pure BT-mechanics test. Place it in `marine_nav_behavior_tree/test/`
   (which already has a gtest harness — 6 tests), **not** `bt_task_navigator` (which has no
   test infrastructure at all), to avoid bootstrapping a new test target.

**Phase 2 — same-type re-command (`hover_override`) — see Open Questions for bundle-vs-stack**

4. The pure same-type re-command (operator re-hovers while already hovering; `current_task_type`
   stays `hover`, so `Switch5` never halts) is **not** fixed by Phase 1 and **not** fixed by
   re-reading the target port alone: with no halt the `Sequence` stays parked at `Hover`, so
   `Fallback`/`PredictStoppingPose` never re-tick and `{hover_target}`/`{goal_poses}` never
   refresh. The real lever is **forcing HoverTask re-entry when `current_task_id` changes**
   (a reactive id-latch guard in the BT), paired with making `HoverAction` reactive
   (`on_wait_for_result` re-reads `target`, sets `goal_updated_` → `send_new_goal()`, the
   #35/FollowPath pattern) so a re-entry recomputed target is actually re-sent mid-RUNNING.

## Files to Change

| File | Change |
|------|--------|
| `marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml` | P1: `SequenceWithMemory`→`Sequence` in `HoverTask`; correct comment. P2: reactive id-latch guard. |
| `marine_nav_behavior_tree/test/test_sequence_reentry.cpp` (new) | P1: re-entry-recompute + continuous-hold-no-recompute regression test (Sequence vs SequenceWithMemory). Lives here because this package already has a gtest harness. |
| `marine_nav_behavior_tree/CMakeLists.txt` | P1: add the new gtest to the existing test block. |
| `marine_nav_behavior_tree/src/plugins/action/hover_action.{cpp,h}` | P2 only: override `on_wait_for_result` for reactive target re-send. |

## Principles Self-Check

| Principle | Consideration |
|---|---|
| Quality Standard — fix completely, add the test | Phase 1 ships the fix + a regression test that fails on the old node and passes on the new one. |
| Never circumvent tests; fix code not config | Behavior fix in the tree, not a test/config workaround. |
| Documentation accuracy | The misleading `run_tasks.xml:79-84` comment is corrected, not left to drift. |
| Surface scope deferrals | Phase 2 split decision is raised as an Open Question, not silently deferred. |

## ADR Compliance

| ADR | Triggered | How addressed |
|---|---|---|
| 0013 (progress.md vocabulary) | Yes | Plan/progress entries follow the schema (handled by plan-task skill). |
| Functional ADRs | No | A BT control-node swap + reactive action node triggers none. |

## Consequences

| If we change... | Also update... | Included in plan? |
|---|---|---|
| `run_tasks.xml` (installed via ament `install(DIRECTORY)`, `CMakeLists.txt:51`) | Rebuild `marine_nav_bt_task_navigator` — symlink-install does **not** pick up XML data-file edits | Yes — note in test/build steps |
| `HoverTask` control flow | **Cross-repo** (`unh_marine_autonomy`, not this repo): `done_hover` is emitted by `mission_manager.py` and exercised by `marine_autonomy_integration_tests/test/test_mission_navigation_failure.py`. The swap doesn't change task semantics, only when `PredictStoppingPose` re-ticks, so no `unh_marine_autonomy` change is expected — but flag a manual cross-repo integration check before merge. | Manual cross-repo check (not in this PR's CI) |
| Hover re-entry semantics | Existing `test_predict_stopping_pose.cpp` (unaffected — node unchanged) | Verified no change |

## Open Questions

- [ ] **Bundle Phase 2 here or stack as a follow-up?** Recommend **stacking** — Phase 1 fully
      fixes the reported end-of-task symptom and is small/safe; Phase 2 is a distinct
      reactive-refresh design (re-entry-on-id-change + reactive action node) with its own test
      matrix, mirroring how #35 was its own change. (Counter: the "bundle related cleanups"
      preference — your call.)
- [ ] **Phase 2 mechanism:** acceptable to add a small reactive id-latch in the BT XML, or do
      you prefer a dedicated custom condition node (`TaskIdChangedCondition`) for clarity/testing?
- [ ] Should `done_hover` instead carry the last survey pose explicitly, sidestepping the
      drift-projection path entirely? (Leaning no — drift-to-stop is the intended #33 behavior.)

## Estimated Scope

Phase 1: single small PR (XML one-line swap + comment + one gtest). Phase 2: a second stacked
PR if approved. Defaulting to Phase 1 this PR pending the bundle-vs-stack answer.
