### PR TITLE
Reactive corridor path-adjuster for surveying around obstacles

### DIFF
--- a/.agent/work-plans/issue-30/plan.md
+++ b/.agent/work-plans/issue-30/plan.md
@@ -1,0 +1,144 @@
+# Plan: Plan around obstacles while running survey lines
+
+## Issue
+
+https://github.com/rolker/unh_marine_navigation/issues/30
+
+> **Reframing — supersedes the issue body.** Issue #30 proposes pre-decomposing
+> tracklines into short, individually skippable segments plus a deferred-segment
+> set, a return-pass scheduler, and coverage bookkeeping. Design discussion
+> converged on a simpler approach with the same goal — keep covering a survey
+> line around an obstacle instead of losing/abandoning it — and far less
+> machinery. This plan implements that approach. **Action for a human:** the #30
+> body still describes the old segment-decomposition design; reconcile the issue
+> text (or close-as-superseded and re-title) so the tracker matches.
+
+## Context
+
+Verified against the deployed stack:
+
+- **Survey lines bypass the planner.** The `SurveyLine` subtree in
+  `marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml` runs
+  `SetPathFromTask` → `FollowPath` directly. `SmacPlannerHybrid` is only used by
+  `GotoPose`/`NavigateThroughWaypoints`. So obstacle-avoidance cannot be added by
+  tuning the planner — the trackline goes straight to the controller as a fixed path.
+- **Controller is a pure tracker** — `marine_nav_crabbing_path_follower::CrabbingPathFollower`
+  (minimizes XTE via crab angle). Keep it a pure tracker; do not load avoidance
+  into it (consistent with the #29 split).
+- **The obstacle field already exists** as `local_costmap/costmap_raw`
+  (`nav2_msgs/Costmap`, 0–254): rolling 400×400 @ 0.25 m = 100 m robot-centred
+  window, frame `<tf_prefix>/map_tide`, layers `chart`(S57) + sea_surface +
+  obstacle + inflation (`inflation_radius: 150.0`).
+  Config: `seafloor_echoboat_project11/.../config/nav2_params.base.yaml`.
+- BT nodes obtain an `rclcpp::Node` from blackboard key `"node"` (see
+  `set_controller_speed.cpp`, `set_task_done.cpp`).
+
+## Approach
+
+Add one reactive BT node that reshapes the survey path around obstacles **before**
+it reaches `FollowPath`, as a Frenet-frame corridor optimizer where the cross-track
+offset `d` **is** the cross-track error — so the XTE term is analytic (`w_xte·d²`),
+never rasterized, and never competes with the costmap's `uint8` budget. Obstacle
+cost is *sampled* from the existing costmap; no new grid is created anywhere.
+
+1. **`AdjustPathForObstacles` (BT `SyncActionNode`)** in `marine_nav_behavior_tree`.
+   Ports: `nominal_path`(in `Path`), `path`(out `Path`), `costmap_topic`
+   (default `local_costmap/costmap_raw`), `max_xte`, `lateral_step`(~0.5 m),
+   `station_step`(~2 m), `w_xte`, `w_obs`, `w_smooth`, `w_temporal`,
+   `max_lateral_rate`. Constructor grabs `node` from the blackboard, opens a
+   costmap subscription (latest cached under a mutex) + a TF buffer.
+2. **tick()** — pass-through fast path when `nominal_path` is empty or no costmap
+   yet. Otherwise: resample nominal into stations that are **ahead of the boat and
+   inside the costmap window**; clamp first & last active station to `d=0` (anchor
+   ends → a true detour that returns to the line). For each station, offsets
+   `d ∈ [−max_xte, +max_xte]` at `lateral_step`; world point `on_line(s) + d·left_normal(s)`
+   (in `map_tide`); `node_cost = INF` if lethal else `w_xte·d² + w_obs·g(cost)`.
+3. **DP over stations** (this is the whole "planner"): transition cost
+   `w_smooth·(dᵢ−dₖ)² + w_temporal·(dᵢ−d_prev_tick(sᵢ))²`, pruning transitions
+   that exceed `max_lateral_rate`. O(stations·offsets²), microseconds. Backtrack
+   `d(s)`, weld reshaped stations onto the untouched tail, set headings along the
+   path tangent, mirror `buildPath`'s zero-outer-stamp / keep-per-pose-stamp idiom
+   (#23). Always returns `SUCCESS` — it's a transformer, not a gate.
+4. **Blocked corridor → output nominal unchanged.** If min DP cost is `INF` (or no
+   improvement beyond a republish deadband), emit the nominal path. This degrades
+   to today's behaviour: Collision-Monitor reflex stop → `FollowPath` ABORT →
+   existing `RecoveryNode` → `SetTaskFailed` → pilot. No new blockage logic.
+5. **Wire into the BT** — in the `SurveyLine` `ReactiveSequence`, `SetPathFromTask`
+   writes `{nominal_survey_path}`; insert `AdjustPathForObstacles` reading it and
+   writing `{survey_path}`; `FollowPath` unchanged. The `ReactiveSequence` re-tick
+   IS the monitor — a new obstacle reshapes the path next loop and `FollowPath`
+   preempts on the changed path (the #35 `on_wait_for_result` mechanism). No
+   separate watcher node.
+6. **Register + manifest** — add the node to `bt_register_nodes.cpp` and the BT
+   nodes manifest; declare it in the `.btproj`/groot palette if applicable.
+7. **Unit-test the DP as a free function** (no ROS), `test_set_path_from_task.cpp`
+   style: clear costmap → output identical to nominal; single blob → bounded
+   detour that re-anchors to the line at both ends; full wall → pass-through.
+
+### Scope for v1 (Roland's call)
+
+No gap tracking, no coverage-state node, no deferred list, no return scheduler.
+The pilot handles any holes — which makes **operator visibility** the substitute:
+publish the nominal and deviated paths so the bulge is eyeballable. The display
+work lives in `rolker/unh_echoboats_project11#183` (CA-awareness CAMP
+overlay/annunciator), not here; this plan only ensures both paths are observable.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `marine_nav_behavior_tree/src/plugins/action/adjust_path_for_obstacles.cpp` | New node: subscription, Frenet lattice + DP, tick() |
+| `marine_nav_behavior_tree/include/.../adjust_path_for_obstacles.h` | New header; DP exposed as a free function for testing |
+| `marine_nav_behavior_tree/src/bt_register_nodes.cpp` | Register `AdjustPathForObstacles` |
+| `marine_nav_behavior_tree/CMakeLists.txt` | Add source + test target |
+| BT nodes manifest / `.btproj` | Declare the new node |
+| `marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml` | One insert + one port rename in `SurveyLine` |
+| `marine_nav_behavior_tree/test/test_adjust_path_for_obstacles.cpp` | New: clear / blob / wall cases |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Only what's needed | v1 drops the coverage node / deferred list / scheduler from #30; one BT node + one XML edit. Minimal corridor DP, not Hybrid-A*. |
+| Test what breaks | DP is a pure free function with clear/blob/wall regression tests; covers the failure mode (obstacle on the line) directly. |
+| A change includes its consequences | Node registration, manifest, CMake test target, BT wiring, and the #183 visibility dependency are all in-plan. |
+| Capture decisions, not just implementations | This plan records the supersession of #30's segment-decomposition design and *why* (survey lines bypass the planner; XTE is analytic). |
+| Improve incrementally | Leaves planner_server, controller, and the #28/#35 preemption flow untouched. |
+| Human control and transparency | "Pilot handles holes" only holds if the deviation is visible → explicit #183 tie. |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| ADR-0008 (ROS 2 conventions) | Yes | BT `SyncActionNode` + plugin registration + manifest per nav2/BehaviorTree.CPP conventions; ament test target. |
+| ADR-0002 (worktree isolation) | Yes | Work in the `feature/issue-30` layer worktree; PR to `unh_marine_navigation`. |
+| ADR-0013 (`progress.md` vocabulary) | Yes | Plan + subsequent work logged with standard entry types. |
+
+## Consequences
+
+| If we change... | Also update... | Included? |
+|---|---|---|
+| `run_tasks.xml` `SurveyLine` ports | the installed copy under `core_ws/install` is build-generated — rebuild, don't hand-edit | Yes |
+| Add a BT node | `bt_register_nodes.cpp` + manifest + `.btproj` palette | Yes |
+| Reshape the followed path | operator must see nominal vs deviated → `unh_echoboats_project11#183` | Tracked there (not this PR) |
+| New costmap subscription in a BT node | confirm the blackboard `node` is spun (Open Q3) | Yes — open question |
+
+## Open Questions
+
+- **max_xte source** — per-line task field set from survey spec, a node param, or
+  reuse of the crab follower's existing XTE config? It is the one
+  survey-meaningful number; do not guess.
+- **Survey-line pose frame** — confirm it is `map_tide` (no TF) vs needs a
+  transform into the costmap frame.
+- **Spin of the blackboard node** — other BT nodes only *call services* in tick;
+  confirm a cached costmap *subscription* is serviced by the navigator's executor,
+  else spin a dedicated callback group or poll a costmap service.
+- **Inflation-tail handling** — with `inflation_radius: 150 m`, obstacle cost is
+  nonzero almost everywhere near a hazard. `g(cost)` must key off the
+  inscribed/obstacle + sea_surface bands (or subtract a baseline) so the line does
+  not bow away from distant inflation. (Design constraint, resolve during impl.)
+
+## Estimated Scope
+
+Single PR: one new BT node + its unit test, registration/manifest, and a one-line
+`SurveyLine` wiring edit. Operator-visibility display is out of scope (#183).

--- a/.agent/work-plans/issue-30/plan.md
+++ b/.agent/work-plans/issue-30/plan.md
@@ -46,7 +46,15 @@ cost is *sampled* from the existing costmap; no new grid is created anywhere.
    (default `local_costmap/costmap_raw`), `max_xte`, `lateral_step`(~0.5 m),
    `station_step`(~2 m), `w_xte`, `w_obs`, `w_smooth`, `w_temporal`,
    `max_lateral_rate`. Constructor grabs `node` from the blackboard, opens a
-   costmap subscription (latest cached under a mutex) + a TF buffer.
+   costmap subscription + a TF buffer. **Subscription is sound (resolved):** the
+   blackboard `node` is nav2's `BtActionServer` client node, externally spun on a
+   dedicated executor thread (`set_controller_speed.cpp` relies on exactly this),
+   so the cached-subscription callback fires. It is, however, the first
+   subscription-bearing BT node in this repo. The callback runs on the
+   bt_navigator executor thread — **distinct** from the BT tick thread — so the
+   cache mutex is load-bearing: store the latest costmap as a `shared_ptr` and do a
+   pointer-swap under the lock; the DP reads its own snapshot lock-free (don't hold
+   the lock across the O(stations·offsets²) loop).
    **`max_xte` (resolved):** node param is the baseline; an optional per-line
    override is read from the task when present. Wire only the node side now
    (param + read-override-if-present) — no task-message / CAMP plumbing in this PR.
@@ -55,7 +63,10 @@ cost is *sampled* from the existing costmap; no new grid is created anywhere.
    inside the costmap window**; clamp first & last active station to `d=0` (anchor
    ends → a true detour that returns to the line). For each station, offsets
    `d ∈ [−max_xte, +max_xte]` at `lateral_step`; world point `on_line(s) + d·left_normal(s)`
-   (in `map_tide`); `node_cost = INF` if at/above inscribed/lethal else
+   built in the nominal path's frame, then **transformed into the costmap frame
+   before sampling** (default to transforming; short-circuit only when the path's
+   `frame_id` already equals the costmap frame — `TaskInformation.poses` carry the
+   publisher's frame, not a forced `map_tide`); `node_cost = INF` if at/above inscribed/lethal else
    `w_xte·d² + w_obs·g(cost)`, with `g(cost)` the **raw graded cost — no baseline
    subtraction, no threshold** (resolved). The `w_xte·d²` term is a restoring
    spring on the line, and a per-station *uniform* obstacle-cost offset does not
@@ -68,20 +79,35 @@ cost is *sampled* from the existing costmap; no new grid is created anywhere.
    `w_smooth·(dᵢ−dₖ)² + w_temporal·(dᵢ−d_prev_tick(sᵢ))²`, pruning transitions
    that exceed `max_lateral_rate`. O(stations·offsets²), microseconds. Backtrack
    `d(s)`, weld reshaped stations onto the untouched tail, set headings along the
-   path tangent, mirror `buildPath`'s zero-outer-stamp / keep-per-pose-stamp idiom
-   (#23). Always returns `SUCCESS` — it's a transformer, not a gate.
+   path tangent, mirror `buildPath`'s zero-outer-stamp idiom (#23). Per-pose stamps
+   are **not** load-bearing for `CrabbingPathFollower` (it times off the robot pose
+   stamp and selects segments geometrically), so resampled stations — which have no
+   meaningful original stamp — need not carry one; pass through the tail's stamps as
+   hygiene only. Always returns `SUCCESS` — it's a transformer, not a gate.
 4. **Blocked corridor → output nominal unchanged.** If min DP cost is `INF` (or no
    improvement beyond a republish deadband), emit the nominal path. This degrades
    to today's behaviour: Collision-Monitor reflex stop → `FollowPath` ABORT →
    existing `RecoveryNode` → `SetTaskFailed` → pilot. No new blockage logic.
-5. **Wire into the BT** — in the `SurveyLine` `ReactiveSequence`, `SetPathFromTask`
-   writes `{nominal_survey_path}`; insert `AdjustPathForObstacles` reading it and
-   writing `{survey_path}`; `FollowPath` unchanged. The `ReactiveSequence` re-tick
-   IS the monitor — a new obstacle reshapes the path next loop and `FollowPath`
-   preempts on the changed path (the #35 `on_wait_for_result` mechanism). No
-   separate watcher node.
-6. **Register + manifest** — add the node to `bt_register_nodes.cpp` and the BT
-   nodes manifest; declare it in the `.btproj`/groot palette if applicable.
+5. **Wire into the BT — the *right* tree.** `run_tasks.xml` has two survey trees;
+   target the executed one: `BehaviorTree ID="SurveyLine"` (≈:389), whose **inner
+   `<ReactiveSequence>`** (≈:397) holds the `SetPathFromTask` that writes
+   `{survey_path}` (≈:410) and the `RecoveryNode`-wrapped `FollowPath` reading
+   `{survey_path}` (≈:423). Rename **that** `SetPathFromTask`'s output to
+   `{nominal_survey_path}`; insert `AdjustPathForObstacles` reading
+   `{nominal_survey_path}` → writing `{survey_path}`; leave `FollowPath` untouched.
+   Do **not** touch the separate `BehaviorTree ID="SurveyLineTask"` (≈:487) or its
+   `SetPathFromTask` (≈:491) — confirm during impl it isn't a second
+   survey-following site before deciding it needs no change. The inner
+   `ReactiveSequence` re-tick IS the monitor — a new obstacle reshapes the path
+   next loop and `FollowPath` preempts on the changed `{survey_path}` (the #35
+   `on_wait_for_result` mechanism). A `SyncActionNode` returning `SUCCESS` each
+   tick preserves the reactive re-read semantics. No separate watcher node.
+6. **Register + Groot palette** — register the node in `bt_register_nodes.cpp`
+   (this regenerates the build-time `marine_nav_behavior_tree_nodes.xml` manifest
+   — do **not** hand-edit that generated file). Hand-add the node to the two
+   maintained-by-hand model lists: the `nav2.btproj` `<TreeNodesModel>` (Groot
+   palette) and the inline `<TreeNodesModel>` inside `run_tasks.xml` (≈:544-822),
+   with its `<Action>` ports.
 7. **Unit-test the DP as a free function** (no ROS), `test_set_path_from_task.cpp`
    style: clear costmap → output identical to nominal; single blob → bounded
    detour that re-anchors to the line at both ends; full wall → pass-through.
@@ -101,9 +127,9 @@ overlay/annunciator), not here; this plan only ensures both paths are observable
 | `marine_nav_behavior_tree/src/plugins/action/adjust_path_for_obstacles.cpp` | New node: subscription, Frenet lattice + DP, tick() |
 | `marine_nav_behavior_tree/include/.../adjust_path_for_obstacles.h` | New header; DP exposed as a free function for testing |
 | `marine_nav_behavior_tree/src/bt_register_nodes.cpp` | Register `AdjustPathForObstacles` |
-| `marine_nav_behavior_tree/CMakeLists.txt` | Add source + test target |
-| BT nodes manifest / `.btproj` | Declare the new node |
-| `marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml` | One insert + one port rename in `SurveyLine` |
+| `marine_nav_behavior_tree/CMakeLists.txt` | Add `.cpp` to the `bt_plugins` lib + a new `ament_add_gtest` block (nodes manifest regenerates — not hand-edited) |
+| `marine_nav_bt_task_navigator/behavior_trees/nav2.btproj` | Add node to Groot `<TreeNodesModel>` palette |
+| `marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml` | Insert node + rename one port in inner `SurveyLine` ReactiveSequence (≈:397/410); add `<Action>` to inline `<TreeNodesModel>` (≈:544-822) |
 | `marine_nav_behavior_tree/test/test_adjust_path_for_obstacles.cpp` | New: clear / blob / wall cases |
 
 ## Principles Self-Check
@@ -130,9 +156,9 @@ overlay/annunciator), not here; this plan only ensures both paths are observable
 | If we change... | Also update... | Included? |
 |---|---|---|
 | `run_tasks.xml` `SurveyLine` ports | the installed copy under `core_ws/install` is build-generated — rebuild, don't hand-edit | Yes |
-| Add a BT node | `bt_register_nodes.cpp` + manifest + `.btproj` palette | Yes |
+| Add a BT node | `bt_register_nodes.cpp` (regenerates manifest) + `nav2.btproj` palette + run_tasks.xml `<TreeNodesModel>` | Yes |
 | Reshape the followed path | operator must see nominal vs deviated → `unh_echoboats_project11#183` | Tracked there (not this PR) |
-| New costmap subscription in a BT node | confirm the blackboard `node` is spun (Open Questions) | Yes — open question |
+| New costmap subscription in a BT node | blackboard `node` is externally spun (verified) → cached-subscription is sound; mutex snapshot across the two threads | Yes — resolved |
 
 ## Resolved Decisions
 
@@ -142,16 +168,20 @@ overlay/annunciator), not here; this plan only ensures both paths are observable
   threshold; `INF` floor at inscribed/lethal. The `w_xte·d²` spring means only the
   obstacle-cost *gradient* (not a uniform offset) moves the path, so distant
   inflation can't bow the line. Tune the `w_xte : w_obs` ratio.
+- **Costmap access** — cached subscription on the blackboard `node` (verified
+  externally spun via the `BtActionServer` executor — `set_controller_speed.cpp`
+  relies on it). Callback runs on the bt_navigator executor thread, distinct from
+  the tick thread → `shared_ptr` pointer-swap snapshot under a mutex.
+- **Pose frame** — de-risked by defaulting to TF-transform into the costmap frame
+  (short-circuit only when `frame_id` already equals it), since `TaskInformation.poses`
+  carry the publisher's frame. (Still worth confirming the actual frame during impl
+  to know whether the transform is the hot path or the short-circuit is.)
 
-## Open Questions (verify in code during implementation)
+## Open Questions
 
-- **Survey-line pose frame** — confirm it is `map_tide` (sample directly) vs needs
-  a TF transform into the costmap frame. Trace where survey-line task poses are
-  populated and what `frame_id` they carry.
-- **Spin of the blackboard node** — other BT nodes only *call services* in tick;
-  confirm the navigator's executor services a cached costmap *subscription* on the
-  blackboard `node`. If yes → cached subscription; if no → dedicated callback group
-  or poll a costmap service. Verify before committing to the subscription design.
+- None blocking. Remaining items are impl-time confirmations folded into Resolved
+  Decisions above (actual pose frame; `w_xte:w_obs` and inflation `cost_scaling_factor`
+  tuning values — set during sim).
 
 ## Estimated Scope
 

--- a/.agent/work-plans/issue-30/plan.md
+++ b/.agent/work-plans/issue-30/plan.md
@@ -47,12 +47,23 @@ cost is *sampled* from the existing costmap; no new grid is created anywhere.
    `station_step`(~2 m), `w_xte`, `w_obs`, `w_smooth`, `w_temporal`,
    `max_lateral_rate`. Constructor grabs `node` from the blackboard, opens a
    costmap subscription (latest cached under a mutex) + a TF buffer.
+   **`max_xte` (resolved):** node param is the baseline; an optional per-line
+   override is read from the task when present. Wire only the node side now
+   (param + read-override-if-present) — no task-message / CAMP plumbing in this PR.
 2. **tick()** — pass-through fast path when `nominal_path` is empty or no costmap
    yet. Otherwise: resample nominal into stations that are **ahead of the boat and
    inside the costmap window**; clamp first & last active station to `d=0` (anchor
    ends → a true detour that returns to the line). For each station, offsets
    `d ∈ [−max_xte, +max_xte]` at `lateral_step`; world point `on_line(s) + d·left_normal(s)`
-   (in `map_tide`); `node_cost = INF` if lethal else `w_xte·d² + w_obs·g(cost)`.
+   (in `map_tide`); `node_cost = INF` if at/above inscribed/lethal else
+   `w_xte·d² + w_obs·g(cost)`, with `g(cost)` the **raw graded cost — no baseline
+   subtraction, no threshold** (resolved). The `w_xte·d²` term is a restoring
+   spring on the line, and a per-station *uniform* obstacle-cost offset does not
+   move the DP's argmin — only the obstacle-cost **gradient** across the corridor
+   does. So the 150 m inflation tails can't bow the line; it deviates only where
+   cost steepens near a real hazard enough to overcome the spring. Tune the single
+   `w_xte : w_obs` ratio (against the inflation `cost_scaling_factor`); the `INF`
+   floor guarantees it never plans into the obstacle body regardless of the spring.
 3. **DP over stations** (this is the whole "planner"): transition cost
    `w_smooth·(dᵢ−dₖ)² + w_temporal·(dᵢ−d_prev_tick(sᵢ))²`, pruning transitions
    that exceed `max_lateral_rate`. O(stations·offsets²), microseconds. Backtrack
@@ -121,22 +132,26 @@ overlay/annunciator), not here; this plan only ensures both paths are observable
 | `run_tasks.xml` `SurveyLine` ports | the installed copy under `core_ws/install` is build-generated — rebuild, don't hand-edit | Yes |
 | Add a BT node | `bt_register_nodes.cpp` + manifest + `.btproj` palette | Yes |
 | Reshape the followed path | operator must see nominal vs deviated → `unh_echoboats_project11#183` | Tracked there (not this PR) |
-| New costmap subscription in a BT node | confirm the blackboard `node` is spun (Open Q3) | Yes — open question |
+| New costmap subscription in a BT node | confirm the blackboard `node` is spun (Open Questions) | Yes — open question |
 
-## Open Questions
+## Resolved Decisions
 
-- **max_xte source** — per-line task field set from survey spec, a node param, or
-  reuse of the crab follower's existing XTE config? It is the one
-  survey-meaningful number; do not guess.
-- **Survey-line pose frame** — confirm it is `map_tide` (no TF) vs needs a
-  transform into the costmap frame.
+- **max_xte** — node param baseline + optional per-line task-field override; only
+  the node side is wired in this PR (no task-message/CAMP plumbing).
+- **Obstacle cost `g(cost)`** — raw graded cost, no baseline subtraction, no
+  threshold; `INF` floor at inscribed/lethal. The `w_xte·d²` spring means only the
+  obstacle-cost *gradient* (not a uniform offset) moves the path, so distant
+  inflation can't bow the line. Tune the `w_xte : w_obs` ratio.
+
+## Open Questions (verify in code during implementation)
+
+- **Survey-line pose frame** — confirm it is `map_tide` (sample directly) vs needs
+  a TF transform into the costmap frame. Trace where survey-line task poses are
+  populated and what `frame_id` they carry.
 - **Spin of the blackboard node** — other BT nodes only *call services* in tick;
-  confirm a cached costmap *subscription* is serviced by the navigator's executor,
-  else spin a dedicated callback group or poll a costmap service.
-- **Inflation-tail handling** — with `inflation_radius: 150 m`, obstacle cost is
-  nonzero almost everywhere near a hazard. `g(cost)` must key off the
-  inscribed/obstacle + sea_surface bands (or subtract a baseline) so the line does
-  not bow away from distant inflation. (Design constraint, resolve during impl.)
+  confirm the navigator's executor services a cached costmap *subscription* on the
+  blackboard `node`. If yes → cached subscription; if no → dedicated callback group
+  or poll a costmap service. Verify before committing to the subscription design.
 
 ## Estimated Scope
 

--- a/.agent/work-plans/issue-30/plan.md
+++ b/.agent/work-plans/issue-30/plan.md
@@ -187,3 +187,25 @@ overlay/annunciator), not here; this plan only ensures both paths are observable
 
 Single PR: one new BT node + its unit test, registration/manifest, and a one-line
 `SurveyLine` wiring edit. Operator-visibility display is out of scope (#183).
+
+## Implementation Notes
+
+- **Pure core is `Station`/`makeLateralOffsets`/`resampleStations`/`solveCorridorOffsets`**
+  (free functions in the header) so the DP is unit-tested with a hand-built cost
+  matrix, no ROS. `tick()` only does costmap sampling, TF, robot-pose clipping,
+  and reconstruction. 8 gtests pass (clear→on-line, blob→bounded re-anchored
+  detour, wall→infeasible, lateral-rate limit, offset/resample helpers).
+- **Costmap source**: subscribes to `nav2_msgs/Costmap` (`costmap_raw`, 0–254) so
+  the inscribed/lethal `INF` floor and `NO_INFORMATION`→free mapping are exact;
+  no `nav2_costmap_2d` dependency (raw index math). Added `nav2_msgs` + `nav_msgs`
+  to CMake/package.xml.
+- **Build gotcha (worktree + new BT node)**: `marine_nav_behavior_tree` runs a
+  POST_BUILD `generate_..._nodes_xml` step that loads the freshly-built plugin
+  `.so`. In a worktree the package is *overridden* (it also lives in the sourced
+  main merged install), and the loader picks the stale main `.so` by SONAME —
+  which lacks the new node's symbols → `undefined symbol: …AdjustPathForObstacles…`.
+  Existing-package builds never hit this (the stale `.so` has all symbols); only a
+  *new* node exposes it. Workaround used: prepend the package's own build dir to
+  `LD_LIBRARY_PATH` before building so the generate step loads the fresh `.so`:
+  `export LD_LIBRARY_PATH="$PWD/build/marine_nav_behavior_tree:$LD_LIBRARY_PATH"`.
+  The same prepend is needed to run the unit test binary in a worktree.

--- a/.agent/work-plans/issue-30/progress.md
+++ b/.agent/work-plans/issue-30/progress.md
@@ -51,3 +51,28 @@ issue: 30
 ### Notes
 - [ ] Build gotcha: new BT node in a worktree trips the POST_BUILD nodes-xml generator (overridden-package SONAME shadow). Workaround: prepend the package build dir to LD_LIBRARY_PATH. See plan.md Implementation Notes.
 - [ ] Not yet field/sim-tuned: w_xte:w_obs, max_xte, max_lateral_rate are defaults pending sim.
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-06-01 08:41 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**PR**: #51 at `0659e74`
+**Sources**: 2 (Copilot R1 @ `0659e74`, local `## Plan Review` @ `420ada8`)
+**Cross-source confirmations**: 0
+**CI**: all-pass (copilot-pull-request-reviewer success)
+
+### Findings
+- None actionable. Copilot reviewed 10/10 changed files and generated **0 comments** (overview-only review body). The prior `## Plan Review` changes-requested findings are all verified-resolved in the committed implementation:
+  - (must-fix, Plan Review) Insert into executed `SurveyLine` tree + rename output — resolved: `run_tasks.xml:410` `{nominal_survey_path}`, node `:420`
+  - (must-fix, Plan Review) Hand-edit Groot palette + inline `<TreeNodesModel>` — resolved: `nav2.btproj:12`, `run_tasks.xml:755`
+  - (must-fix, Plan Review) Always TF into costmap frame, short-circuit on frame match — resolved: `adjust_path_for_obstacles.cpp:336` (identity when equal), passthrough on TF failure
+  - (suggestion, Plan Review) pointer-swap snapshot / no per-pose stamp dependency / tight snapshot pattern — all followed
+
+### Not review findings (outstanding from plan Open Questions — for the human)
+- Reconcile the #30 issue body (still describes old segment-decomposition design) — needs human re-title.
+- Sim-tune `w_xte:w_obs`, `max_xte`, `max_lateral_rate` (defaults pending).
+- Confirm deployed survey-line pose frame vs costmap `map_tide`.
+
+### False positives
+- None.

--- a/.agent/work-plans/issue-30/progress.md
+++ b/.agent/work-plans/issue-30/progress.md
@@ -38,3 +38,16 @@ issue: 30
 - [ ] (suggestion) Commit to the cached-subscription design (node IS spun — `set_controller_speed.cpp` proves it); note the callback runs on the bt_navigator executor thread (distinct from the tick thread) so the mutex is load-bearing — use a pointer-swap snapshot, don't hold the lock across the DP.
 - [ ] (suggestion) #23 per-pose stamps are NOT load-bearing for CrabbingPathFollower (it times off the robot pose stamp, selects segments geometrically); don't block path synthesis on preserving per-pose stamps for resampled stations.
 - [ ] (suggestion) First subscription-bearing BT node in the repo — sound but unprecedented; keep the snapshot pattern tight.
+
+## Implementation
+**Status**: complete
+**When**: 2026-06-01 00:15 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Commits**: `6a6d7b2` (node + 8 unit tests + CMake/package.xml/register), `a794fcb` (SurveyLine BT wiring + Groot palette)
+**Build**: marine_nav_behavior_tree + marine_nav_bt_task_navigator build clean; node in generated manifest; run_tasks.xml + nav2.btproj well-formed.
+**Tests**: 8/8 gtest pass (clear→on-line, blob→bounded re-anchored detour, wall→infeasible, lateral-rate limit, offsets/resample helpers).
+
+### Notes
+- [ ] Build gotcha: new BT node in a worktree trips the POST_BUILD nodes-xml generator (overridden-package SONAME shadow). Workaround: prepend the package build dir to LD_LIBRARY_PATH. See plan.md Implementation Notes.
+- [ ] Not yet field/sim-tuned: w_xte:w_obs, max_xte, max_lateral_rate are defaults pending sim.

--- a/.agent/work-plans/issue-30/progress.md
+++ b/.agent/work-plans/issue-30/progress.md
@@ -115,3 +115,42 @@ issue: 30
 **Build/Test**: marine_nav_behavior_tree builds clean; 9/9 gtest pass (8 prior + new LethalAnchorIsInfeasible).
 **Must-fix #3 (uncrustify)**: not applied — reclassified as a local-tooling false positive (see Local Review False positives). Surface to human before merge if CI uncrustify behaviour is in doubt.
 **Suggestions (8)**: deferred — none are live defects (temporal term dormant at `w_temporal=0.0`; the rest are defensive guards / docs). Candidates for a follow-up hardening pass.
+
+## CAMP Visualization + Hardening
+**Status**: complete
+**When**: 2026-06-01 10:05 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Commit**: `fcd02af` (CAMP obstacle-avoidance MarkerArray + 3 robustness guards)
+**Build/Test**: marine_nav_behavior_tree clean; 9/9 gtest pass; no warnings from the file.
+
+### Operator feedback (the headline)
+Investigated what CAMP shows about obstacle reaction (see below), then added a
+`visualization_msgs/MarkerArray` publisher on `survey_obstacle_avoidance`,
+published only while deviating: faint nominal line + bright adjusted path + red
+avoiding band + "AVOIDING" text flag; DELETEALL clears it on avoiding→clear.
+CAMP's `MarkersManager` auto-discovers any MarkerArray (markers_manager.cpp), so
+no CAMP-side change is needed. Design chosen by Roland (path + avoiding highlight).
+
+**Pre-existing visualization findings (for the human):**
+- CrabbingPathFollower already publishes `received_global_plan` (Path) +
+  `path_follower_visualization` (MarkerArray, auto-shown in CAMP) — `crabbing_path_follower.cpp:170,176`.
+- **Topic-name bug**: CAMP subscribes to `received_global_**path**` (`platform.cpp:103`)
+  but the follower publishes `received_global_**plan**` — nothing publishes
+  `received_global_path` (no remap found). CAMP's dedicated path renderer is dead;
+  the marker layer compensates. Worth a separate fix (CAMP or a remap).
+- The local costmap IS visible in CAMP: nav2 publishes `local_costmap/costmap`
+  (OccupancyGrid) and CAMP's GridManager auto-discovers any OccupancyGrid by type
+  with no namespace filter (`grid_manager.cpp:30`). Operator toggles the grid layer.
+
+### Hardening (review suggestions #5/#6/#7/#9 — the "cheap" set Roland approved)
+- [x] (#5) Costmap-metadata validation before sampling (resolution>0, non-empty, data==size_x*size_y) — passthrough on malformed.
+- [x] (#6) Identity origin-orientation guard (axis-aligned assumption) — passthrough on rotated/relayed grid.
+- [x] (#7) Pose-lookup failure → passthrough (don't reshape from index 0 / astern) + throttled warn.
+- [x] (#9) Temporal-term `prev` ref bound to a shared empty lvalue — drops a per-tick vector copy.
+
+### Still deferred (not done)
+- (#4) Temporal-term arclength reprojection — dormant at `w_temporal=0.0`; do before enabling.
+- (#8) Document the single-contiguous-in-window-run limitation.
+- (#10) OOB sentinel → `std::optional<double>` refactor.
+- (#11) `std::isfinite` validation on numeric BT ports — low (static XML literals).

--- a/.agent/work-plans/issue-30/progress.md
+++ b/.agent/work-plans/issue-30/progress.md
@@ -169,8 +169,30 @@ no CAMP-side change is needed. Design chosen by Roland (path + avoiding highligh
 - [x] (cross-confirmed Copilot R2 + Local Review) Pinned anchors skip lethal check — `adjust_path_for_obstacles.cpp:109` — already FIXED `e0ae769`
 - [x] (cross-confirmed Copilot R2 + Local Review) Callback captures raw `this` → teardown UAF — `adjust_path_for_obstacles.cpp:385` — already FIXED `c6ba027`
 - [x] (cross-confirmed Copilot R2 + Local Review) Ternary prvalue copies prev_offsets_ per tick — `adjust_path_for_obstacles.cpp:577` — already FIXED `fcd02af`
-- [ ] (valid, Copilot R2+R3) Test missing `<algorithm>`/`<string>` (uses std::max + std::string via transitive includes) — `test_adjust_path_for_obstacles.cpp:9-10` — trivial, do it
-- [ ] (suggestion, Copilot R3) resampleStations re-scans all segments per station → O(stations×segments); low impact (survey lines are typically straight, 2 poses → 1 segment) — `adjust_path_for_obstacles.cpp:213`
+- [x] (valid, Copilot R2+R3) Test missing `<algorithm>`/`<string>` — FIXED `996ecd8`
+- [x] (suggestion, Copilot R3) resampleStations O(stations×segments) → single-pass O(segments+stations) — FIXED `996ecd8`
 
 ### False positives
 - None — all Copilot findings legitimate (3 already fixed, 2 open).
+
+## Review Follow-ups + Optional Slowdown
+**Status**: complete
+**When**: 2026-06-01 11:40 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Commits**: `996ecd8` (Copilot review: resample single-pass + test includes), `90380bd` (optional avoidance slowdown)
+**Build/Test**: marine_nav_behavior_tree clean; 11/11 gtest pass (9 prior + 2 ApplyAvoidanceSlowdown); XML well-formed.
+
+### Copilot review (#4, #6) — done
+- #4 test `<algorithm>`/`<string>` includes; #6 resampleStations single-pass walk.
+
+### Optional slow-down through avoidance (#3 — Roland-requested, beyond original scope)
+- New `avoid_speed` port (default 0.0 = off). `applyAvoidanceSlowdown()` stamps the
+  deviating run so CrabbingPathFollower commands `avoid_speed` there (it derives
+  per-segment speed from distance/Δstamp — `crabbing_path_follower.cpp:347-353`).
+  **Corrects** the earlier "per-pose stamps not load-bearing" read — the follower
+  DOES use them for speed (geometric segment *selection* was the only part that
+  was stamp-independent). Port wired into TreeNodesModel + nav2.btproj; default-off
+  so deployments opt in.
+
+### Still deferred (unchanged): suggestions #4(temporal)/#8/#10/#11 from Local Review (Pre-Push).

--- a/.agent/work-plans/issue-30/progress.md
+++ b/.agent/work-plans/issue-30/progress.md
@@ -90,9 +90,9 @@ issue: 30
 **Sources**: 3 (Claude adversarial, Copilot adversarial, lead/static)
 
 ### Findings
-- [ ] (must-fix, cross-confirmed Claude+Copilot) Subscription callback captures raw `this`; teardown race / potential UAF on tree-reload/shutdown — capture costmap state in a `shared_ptr<State>` by value — `adjust_path_for_obstacles.cpp:281-286`
-- [ ] (must-fix, Copilot verified) Pinned anchor endpoints skip the lethal-cost check (line 97 unreachable when pinned); lethal cell at `active_begin`/`active_end-1` reported as a clear corridor — return `kInf` when zero-col is lethal — `adjust_path_for_obstacles.cpp:92-99`
-- [ ] (must-fix, static) New `ament_uncrustify` divergence (lambda-body indent) regresses the package's green uncrustify lint test — `ament_uncrustify --reformat` — `adjust_path_for_obstacles.cpp` ~85-104
+- [x] (must-fix, cross-confirmed Claude+Copilot) Subscription callback captures raw `this`; teardown race / potential UAF on tree-reload/shutdown — capture costmap state in a `shared_ptr<State>` by value — `adjust_path_for_obstacles.cpp:281-286` — **FIXED** `c6ba027` (CostmapCache held by shared_ptr, captured by value)
+- [x] (must-fix, Copilot verified) Pinned anchor endpoints skip the lethal-cost check (line 97 unreachable when pinned); lethal cell at `active_begin`/`active_end-1` reported as a clear corridor — return `kInf` when zero-col is lethal — `adjust_path_for_obstacles.cpp:92-99` — **FIXED** `e0ae769` (+ LethalAnchorIsInfeasible test)
+- [~] (must-fix → reclassified FALSE POSITIVE, static) "New `ament_uncrustify` divergence" was a **local-tooling artifact**, not a real CI regression. On re-check, the local `ament_uncrustify` (uncrustify 0.78.1) flags *every committed header* in the package with namespace-indentation + `std::vector < double >` template spacing — neither of which the committed, CI-merged codebase uses. If CI enforced the local tool's output no file would pass. The `.cpp` flag was lambda-body indentation, but this file is the first in the package to use auto-assigned lambdas (no committed precedent), entangled with the same unreliable tool. The file already matches the committed ament style; `--reformat` would mangle it inconsistent with the whole package. Not applied. See review note below.
 - [ ] (suggestion, 3 sources: me+Claude+Copilot) Temporal term keyed by station ordinal while path re-resampled each tick; dormant at `w_temporal=0.0` — reproject by arclength / invalidate on path change before enabling — `adjust_path_for_obstacles.cpp:80,100-104,435`
 - [ ] (suggestion, Copilot) Defensive costmap-metadata validation (`resolution>0`, `data.size()==size_x*size_y`) before sampling — `adjust_path_for_obstacles.cpp:349-361`
 - [ ] (suggestion, Claude) Sampling ignores `origin.orientation`; add identity-orientation guard (nav2 costmap is axis-aligned today) — `adjust_path_for_obstacles.cpp:352-355`
@@ -104,3 +104,14 @@ issue: 30
 
 ### False positives
 - (static) cpplint `legal/copyright` + `build/header_guard` on the new files — sibling `clear_path.h` produces the identical 5 hits; pre-existing package-wide convention, not introduced here. The new file correctly matches existing style.
+- (static) `ament_uncrustify` "divergence" on the new files — local uncrustify 0.78.1 produces non-ament output (indents namespace bodies, spaces templates) and flags all committed package files; it disagrees with the CI-merged ament style. Local-tooling artifact, not a code defect. Open item for the human: confirm the project repo's CI uncrustify is green on jazzy (it must be, since the package is merged) and, if desired, file a separate issue to reconcile local uncrustify version/config with CI.
+
+## Review Fixes Applied
+**Status**: complete
+**When**: 2026-06-01 09:30 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Commits**: `e0ae769` (lethal-anchor reject + test), `c6ba027` (callback-lifetime UAF)
+**Build/Test**: marine_nav_behavior_tree builds clean; 9/9 gtest pass (8 prior + new LethalAnchorIsInfeasible).
+**Must-fix #3 (uncrustify)**: not applied — reclassified as a local-tooling false positive (see Local Review False positives). Surface to human before merge if CI uncrustify behaviour is in doubt.
+**Suggestions (8)**: deferred — none are live defects (temporal term dormant at `w_temporal=0.0`; the rest are defensive guards / docs). Candidates for a follow-up hardening pass.

--- a/.agent/work-plans/issue-30/progress.md
+++ b/.agent/work-plans/issue-30/progress.md
@@ -196,3 +196,19 @@ no CAMP-side change is needed. Design chosen by Roland (path + avoiding highligh
   so deployments opt in.
 
 ### Still deferred (unchanged): suggestions #4(temporal)/#8/#10/#11 from Local Review (Pre-Push).
+
+## avoid_speed as a live ROS parameter
+**Status**: complete
+**When**: 2026-06-01 12:10 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Commit**: `190e414`
+**Build/Test**: marine_nav_behavior_tree clean; 11/11 gtest pass; XML well-formed.
+
+- `avoid_speed` BT port now seeds a dynamic ROS param `survey_avoidance_speed` on
+  the bt_navigator node (declared once, has_parameter-guarded; descriptor for
+  rqt_reconfigure). Read each tick → tunable live:
+  `ros2 param set <bt_navigator> survey_avoidance_speed <m/s>`. Port = startup
+  seed; param authoritative thereafter (yaml override honoured). Aids sim/field tuning.
+- Same pattern could expose the corridor weights (w_xte/w_obs/max_xte/…) as live
+  params for the pending sim-tune — offered to Roland, not yet done.

--- a/.agent/work-plans/issue-30/progress.md
+++ b/.agent/work-plans/issue-30/progress.md
@@ -154,3 +154,23 @@ no CAMP-side change is needed. Design chosen by Roland (path + avoiding highligh
 - (#8) Document the single-contiguous-in-window-run limitation.
 - (#10) OOB sentinel → `std::optional<double>` refactor.
 - (#11) `std::isfinite` validation on numeric BT ports — low (static XML literals).
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-06-01 11:12 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**PR**: #51 at `14ea99c`
+**Sources**: 4 (Copilot R1 @ `0659e74`, R2 @ `402edff`, R3 @ `14ea99c`, local Local Review (Pre-Push) @ `f5a3c99`)
+**Cross-source confirmations**: 3
+**CI**: all-pass (copilot-pull-request-reviewer success)
+
+### Findings
+- [x] (cross-confirmed Copilot R2 + Local Review) Pinned anchors skip lethal check — `adjust_path_for_obstacles.cpp:109` — already FIXED `e0ae769`
+- [x] (cross-confirmed Copilot R2 + Local Review) Callback captures raw `this` → teardown UAF — `adjust_path_for_obstacles.cpp:385` — already FIXED `c6ba027`
+- [x] (cross-confirmed Copilot R2 + Local Review) Ternary prvalue copies prev_offsets_ per tick — `adjust_path_for_obstacles.cpp:577` — already FIXED `fcd02af`
+- [ ] (valid, Copilot R2+R3) Test missing `<algorithm>`/`<string>` (uses std::max + std::string via transitive includes) — `test_adjust_path_for_obstacles.cpp:9-10` — trivial, do it
+- [ ] (suggestion, Copilot R3) resampleStations re-scans all segments per station → O(stations×segments); low impact (survey lines are typically straight, 2 poses → 1 segment) — `adjust_path_for_obstacles.cpp:213`
+
+### False positives
+- None — all Copilot findings legitimate (3 already fixed, 2 open).

--- a/.agent/work-plans/issue-30/progress.md
+++ b/.agent/work-plans/issue-30/progress.md
@@ -232,3 +232,20 @@ no CAMP-side change is needed. Design chosen by Roland (path + avoiding highligh
   survey_avoidance.avoid_speed. Ports + Groot palette updated to match.
 - This directly enables the pending sim-tune (open question): the w_xte:w_obs ratio is now
   line_following_weight:obstacle_avoidance_weight, both live.
+
+## jazzy merge + Copilot R-final fixes
+**Status**: complete
+**When**: 2026-06-01 13:15 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Commits**: `18ad20e` (merge origin/jazzy — PR #53 RobotOnPath/goto; CMakeLists test-block conflict resolved keeping all 3), `09c0771` (Copilot review fixes)
+**Build/Test**: marine_nav_behavior_tree clean; 12/12 adjust_path gtest pass; 23 package tests / 0 failures post-merge.
+
+### Copilot review (post slowdown/param commits)
+- 6 earlier findings re-surfaced against head — all verified still FIXED (lethal-anchor, UAF, ternary, test-includes ×2, resample-perf).
+- [x] (valid) makeLateralOffsets could exceed max_deviation when not a multiple of lateral_resolution (round→overshoot) — now floor; sub-step corridor → {0.0}. + NeverExceedsMaxXteForNonMultiple test. Newly relevant now that tunables are live params.
+- [x] (nit) Avoiding-band LINE_STRIP joined separate deviating runs — now LINE_LIST of consecutive pairs.
+- [x] (nit) DELETEALL marker empty header — set frame_id (robot_frame) + stamp.
+
+### Merge-readiness
+- PR #51 mergeable/clean after jazzy merge. Remaining caveat: runtime/integration parts (live params, stamp-slowdown, marker publishing) are unit-tested but not sim/field-exercised — sim shakeout recommended before field reliance.

--- a/.agent/work-plans/issue-30/progress.md
+++ b/.agent/work-plans/issue-30/progress.md
@@ -21,3 +21,20 @@ issue: 30
 - [ ] Confirm survey-line pose frame == map_tide (else TF into costmap frame)
 - [ ] Confirm blackboard "node" is spun so a cached costmap subscription fires (else callback group / poll)
 - [ ] Inflation-tail handling — g(cost) keys off inscribed/obstacle+sea_surface bands, not 150 m inflation tails
+
+## Plan Review
+**Status**: complete
+**When**: 2026-05-31 23:27 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context)) (fresh-context sub-agent review, orchestrated by plan author)
+
+**Plan**: `.agent/work-plans/issue-30/plan.md` at `420ada8`
+**PR**: https://github.com/rolker/unh_marine_navigation/pull/51
+**Verdict**: changes-requested
+
+### Findings
+- [ ] (must-fix) Insert into the right tree: there are two — `SurveyLine` (run_tasks.xml:389, inner ReactiveSequence:397, the executed one) and `SurveyLineTask` (:487); rename the `SetPathFromTask` output at :410, not :491. Confirm SurveyLineTask isn't a second survey-following site.
+- [ ] (must-fix) "BT nodes manifest" is build-generated (CMake `generate_..._nodes_xml`) — not hand-edited; registering in `bt_register_nodes.cpp` regenerates it. Strike that non-task; instead hand-edit `nav2.btproj` palette + the `<TreeNodesModel>` inside run_tasks.xml (:544-822).
+- [ ] (must-fix) Pose frame: `TaskInformation.poses` carry the publisher's (CAMP) frame_id, not forced map_tide; default to ALWAYS transform into the costmap frame and short-circuit only when frame_id already equals it.
+- [ ] (suggestion) Commit to the cached-subscription design (node IS spun — `set_controller_speed.cpp` proves it); note the callback runs on the bt_navigator executor thread (distinct from the tick thread) so the mutex is load-bearing — use a pointer-swap snapshot, don't hold the lock across the DP.
+- [ ] (suggestion) #23 per-pose stamps are NOT load-bearing for CrabbingPathFollower (it times off the robot pose stamp, selects segments geometrically); don't block path synthesis on preserving per-pose stamps for resampled stations.
+- [ ] (suggestion) First subscription-bearing BT node in the repo — sound but unprecedented; keep the snapshot pattern tight.

--- a/.agent/work-plans/issue-30/progress.md
+++ b/.agent/work-plans/issue-30/progress.md
@@ -212,3 +212,23 @@ no CAMP-side change is needed. Design chosen by Roland (path + avoiding highligh
   seed; param authoritative thereafter (yaml override honoured). Aids sim/field tuning.
 - Same pattern could expose the corridor weights (w_xte/w_obs/max_xte/…) as live
   params for the pending sim-tune — offered to Roland, not yet done.
+
+## All tunables live + clearer names
+**Status**: complete
+**When**: 2026-06-01 12:35 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Commit**: `380f87a`
+**Build/Test**: marine_nav_behavior_tree clean; 11/11 gtest pass; XML well-formed.
+
+- Every tunable is now a live ROS param under `survey_avoidance.*` (kParamSeeds
+  table; seeded from the BT port on first tick, authoritative thereafter). Tune the
+  whole avoider in sim/field without redeploying:
+  `ros2 param set <bt_navigator> survey_avoidance.<name> <value>` / rqt_reconfigure.
+- Renamed for clarity (Roland-approved; internal CorridorParams math fields kept terse):
+  w_obs→obstacle_avoidance_weight, w_xte→line_following_weight, w_smooth→smoothness_weight,
+  w_temporal→chatter_damping_weight, max_xte→max_deviation, max_lateral_rate→max_lateral_change,
+  station_step→along_track_spacing, lateral_step→lateral_resolution; avoid_speed param now
+  survey_avoidance.avoid_speed. Ports + Groot palette updated to match.
+- This directly enables the pending sim-tune (open question): the w_xte:w_obs ratio is now
+  line_following_weight:obstacle_avoidance_weight, both live.

--- a/.agent/work-plans/issue-30/progress.md
+++ b/.agent/work-plans/issue-30/progress.md
@@ -1,0 +1,23 @@
+---
+issue: 30
+---
+
+# Issue #30 — Decompose tracklines into short, skippable segments (partial coverage-planner port)
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-05-31 22:50 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Plan**: `.agent/work-plans/issue-30/plan.md` at `fd32bc9`
+**PR**: https://github.com/rolker/unh_marine_navigation/pull/51 (`[PLAN]` prefix)
+**Phases**: single
+
+> Note: plan supersedes the issue-body design (segment decomposition → reactive
+> Frenet corridor path-adjuster BT node). Issue text needs human reconciliation.
+
+### Open questions
+- [ ] max_xte source — per-line task field (survey spec) vs node param vs crab-follower XTE config
+- [ ] Confirm survey-line pose frame == map_tide (else TF into costmap frame)
+- [ ] Confirm blackboard "node" is spun so a cached costmap subscription fires (else callback group / poll)
+- [ ] Inflation-tail handling — g(cost) keys off inscribed/obstacle+sea_surface bands, not 150 m inflation tails

--- a/.agent/work-plans/issue-30/progress.md
+++ b/.agent/work-plans/issue-30/progress.md
@@ -76,3 +76,31 @@ issue: 30
 
 ### False positives
 - None.
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-01 09:04 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: changes-requested
+
+**Branch**: feature/issue-30 at `f5a3c99`
+**Mode**: pre-push
+**Depth**: Deep (reason: new subscription-bearing BT node, cross-thread concurrency, cross-layer BT wiring)
+**Must-fix**: 3 | **Suggestions**: 8
+**Sources**: 3 (Claude adversarial, Copilot adversarial, lead/static)
+
+### Findings
+- [ ] (must-fix, cross-confirmed Claude+Copilot) Subscription callback captures raw `this`; teardown race / potential UAF on tree-reload/shutdown — capture costmap state in a `shared_ptr<State>` by value — `adjust_path_for_obstacles.cpp:281-286`
+- [ ] (must-fix, Copilot verified) Pinned anchor endpoints skip the lethal-cost check (line 97 unreachable when pinned); lethal cell at `active_begin`/`active_end-1` reported as a clear corridor — return `kInf` when zero-col is lethal — `adjust_path_for_obstacles.cpp:92-99`
+- [ ] (must-fix, static) New `ament_uncrustify` divergence (lambda-body indent) regresses the package's green uncrustify lint test — `ament_uncrustify --reformat` — `adjust_path_for_obstacles.cpp` ~85-104
+- [ ] (suggestion, 3 sources: me+Claude+Copilot) Temporal term keyed by station ordinal while path re-resampled each tick; dormant at `w_temporal=0.0` — reproject by arclength / invalidate on path change before enabling — `adjust_path_for_obstacles.cpp:80,100-104,435`
+- [ ] (suggestion, Copilot) Defensive costmap-metadata validation (`resolution>0`, `data.size()==size_x*size_y`) before sampling — `adjust_path_for_obstacles.cpp:349-361`
+- [ ] (suggestion, Claude) Sampling ignores `origin.orientation`; add identity-orientation guard (nav2 costmap is axis-aligned today) — `adjust_path_for_obstacles.cpp:352-355`
+- [ ] (suggestion, Claude) `getCurrentPose` failure starts active range at index 0 (possibly behind boat); prefer passthrough/clamp + throttled log — `adjust_path_for_obstacles.cpp:371-387`
+- [ ] (suggestion, Claude) Only first contiguous in-window run optimised; document the limitation — `adjust_path_for_obstacles.cpp:400-406`
+- [ ] (suggestion, Claude) `prev` ternary copies the full vector every tick when temporal on; use if/pointer — `adjust_path_for_obstacles.cpp:423-424`
+- [ ] (suggestion, Claude+me) OOB sentinel uses exact double-equality on `-1.0`; latent trap if `sample()` ever does arithmetic — consider `std::optional<double>` — `adjust_path_for_obstacles.cpp:36,392,402,419`
+- [ ] (suggestion, Copilot) `std::isfinite` validation on numeric BT ports — low priority (static XML literals under our control) — `adjust_path_for_obstacles.cpp:309-317`
+
+### False positives
+- (static) cpplint `legal/copyright` + `build/header_guard` on the new files — sibling `clear_path.h` produces the identical 5 hits; pre-existing package-wide convention, not introduced here. The new file correctly matches existing style.

--- a/marine_nav_behavior_tree/CMakeLists.txt
+++ b/marine_nav_behavior_tree/CMakeLists.txt
@@ -24,6 +24,7 @@ find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(std_msgs REQUIRED)
+find_package(visualization_msgs REQUIRED)
 
 
 add_library(${PROJECT_NAME} SHARED
@@ -122,6 +123,7 @@ ament_target_dependencies(${PROJECT_NAME}_bt_plugins
   tf2
   tf2_geometry_msgs
   tf2_ros
+  visualization_msgs
 )
 
 target_compile_definitions(${PROJECT_NAME}_bt_plugins PRIVATE BT_PLUGIN_EXPORT)

--- a/marine_nav_behavior_tree/CMakeLists.txt
+++ b/marine_nav_behavior_tree/CMakeLists.txt
@@ -15,7 +15,9 @@ find_package(geometry_msgs REQUIRED)
 find_package(marine_nav_interfaces REQUIRED)
 find_package(marine_nav_tasks REQUIRED)
 find_package(nav2_behavior_tree REQUIRED)
+find_package(nav2_msgs REQUIRED)
 find_package(nav2_util REQUIRED)
+find_package(nav_msgs REQUIRED)
 find_package(rcl_interfaces REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(tf2 REQUIRED)
@@ -68,6 +70,7 @@ install (
 
 add_library(${PROJECT_NAME}_bt_plugins SHARED
   src/bt_register_nodes.cpp
+  src/plugins/action/adjust_path_for_obstacles.cpp
   src/plugins/action/add_sub_task.cpp
   src/plugins/action/clear_path.cpp
   src/plugins/action/fix_path_orientations.cpp
@@ -111,7 +114,9 @@ ament_target_dependencies(${PROJECT_NAME}_bt_plugins
   geometry_msgs
   marine_nav_interfaces
   nav2_behavior_tree
+  nav2_msgs
   nav2_util
+  nav_msgs
   rcl_interfaces
   rclcpp
   tf2
@@ -292,6 +297,24 @@ if(BUILD_TESTING)
     ament_target_dependencies(test_hover_reentry
       behaviortree_cpp
       rclcpp
+    )
+  endif()
+
+  ament_add_gtest(test_adjust_path_for_obstacles
+    test/test_adjust_path_for_obstacles.cpp
+  )
+  if(TARGET test_adjust_path_for_obstacles)
+    target_include_directories(test_adjust_path_for_obstacles PRIVATE
+      "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    )
+    target_link_libraries(test_adjust_path_for_obstacles
+      ${PROJECT_NAME}_bt_plugins
+    )
+    ament_target_dependencies(test_adjust_path_for_obstacles
+      behaviortree_cpp
+      geometry_msgs
+      nav2_msgs
+      nav_msgs
     )
   endif()
 endif()

--- a/marine_nav_behavior_tree/include/marine_nav_behavior_tree/plugins/action/adjust_path_for_obstacles.h
+++ b/marine_nav_behavior_tree/include/marine_nav_behavior_tree/plugins/action/adjust_path_for_obstacles.h
@@ -70,6 +70,20 @@ struct Station
 std::vector<Station> resampleStations(
   const std::vector<geometry_msgs::msg::PoseStamped> & poses, double step);
 
+// Optionally slow the boat through the avoidance manoeuvre by writing per-pose
+// timestamps on the contiguous deviating run of `path`. CrabbingPathFollower
+// derives per-segment speed from segment_distance / Δstamp when both endpoint
+// stamps are non-zero and increasing, so stamps spaced by distance/`avoid_speed`
+// command `avoid_speed` (m/s) there. `offsets_d[i]` is the cross-track offset of
+// `path.poses[i]`; |offset| >= `deviation_epsilon` marks a deviating pose. No-op
+// when `avoid_speed` <= 0, sizes mismatch, or the deviating run is < 2 poses;
+// poses outside the run keep their (zero) stamps so the controller uses its
+// default speed. Timestamps are geometry-derived (fixed base, no wall clock) so a
+// held detour does not re-trigger FollowPath preemption.
+void applyAvoidanceSlowdown(
+  nav_msgs::msg::Path & path, const std::vector<double> & offsets_d,
+  double avoid_speed, double deviation_epsilon);
+
 // Shared costmap cache. Held by both the node and the subscription callback so
 // that an in-flight callback running on the executor thread keeps the cache
 // alive even if the BT node is destroyed mid-callback (tree reload / shutdown).

--- a/marine_nav_behavior_tree/include/marine_nav_behavior_tree/plugins/action/adjust_path_for_obstacles.h
+++ b/marine_nav_behavior_tree/include/marine_nav_behavior_tree/plugins/action/adjust_path_for_obstacles.h
@@ -13,6 +13,7 @@
 #include "nav_msgs/msg/path.hpp"
 #include "nav2_msgs/msg/costmap.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include "visualization_msgs/msg/marker_array.hpp"
 
 namespace marine_nav_behavior_tree
 {
@@ -104,6 +105,13 @@ private:
   std::shared_ptr<CostmapCache> costmap_cache_ = std::make_shared<CostmapCache>();
   rclcpp::Subscription<nav2_msgs::msg::Costmap>::SharedPtr costmap_sub_;
   std::string costmap_topic_;
+
+  // Operator-feedback markers (auto-discovered by CAMP): nominal line, adjusted
+  // path, the deviating "avoiding" band, and a text flag. Published only while
+  // deviating; cleared with a DELETEALL on the avoiding->clear transition, which
+  // was_avoiding_ tracks so an idle tree doesn't republish every tick.
+  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr viz_pub_;
+  bool was_avoiding_ = false;
 
   // Previous tick's per-station offsets, for the temporal (chatter) term.
   std::vector<double> prev_offsets_;

--- a/marine_nav_behavior_tree/include/marine_nav_behavior_tree/plugins/action/adjust_path_for_obstacles.h
+++ b/marine_nav_behavior_tree/include/marine_nav_behavior_tree/plugins/action/adjust_path_for_obstacles.h
@@ -69,6 +69,16 @@ struct Station
 std::vector<Station> resampleStations(
   const std::vector<geometry_msgs::msg::PoseStamped> & poses, double step);
 
+// Shared costmap cache. Held by both the node and the subscription callback so
+// that an in-flight callback running on the executor thread keeps the cache
+// alive even if the BT node is destroyed mid-callback (tree reload / shutdown).
+// The callback captures a shared_ptr to this — never the node's `this`.
+struct CostmapCache
+{
+  std::mutex mutex;
+  std::shared_ptr<nav2_msgs::msg::Costmap> costmap;
+};
+
 // Reactive corridor path-adjuster. Sits between SetPathFromTask and FollowPath
 // in the SurveyLine inner ReactiveSequence: reads the nominal trackline, samples
 // the existing local costmap, and reshapes the followed path around obstacles
@@ -88,10 +98,10 @@ public:
 
 private:
   // Latest costmap, swapped in by the subscription callback (executor thread)
-  // and read by tick() (BT thread). Guarded by costmap_mutex_; tick takes a
-  // shared_ptr snapshot under the lock and releases it before the DP runs.
-  std::shared_ptr<nav2_msgs::msg::Costmap> costmap_;
-  std::mutex costmap_mutex_;
+  // and read by tick() (BT thread). Lives in a shared cache the callback owns a
+  // reference to (see CostmapCache) so callback and node lifetimes are decoupled.
+  // tick() takes a shared_ptr snapshot under the lock and releases it before the DP.
+  std::shared_ptr<CostmapCache> costmap_cache_ = std::make_shared<CostmapCache>();
   rclcpp::Subscription<nav2_msgs::msg::Costmap>::SharedPtr costmap_sub_;
   std::string costmap_topic_;
 

--- a/marine_nav_behavior_tree/include/marine_nav_behavior_tree/plugins/action/adjust_path_for_obstacles.h
+++ b/marine_nav_behavior_tree/include/marine_nav_behavior_tree/plugins/action/adjust_path_for_obstacles.h
@@ -1,0 +1,104 @@
+#ifndef MARINE_NAV_BEHAVIOR_TREE_ACTIONS_ADJUST_PATH_FOR_OBSTACLES_H
+#define MARINE_NAV_BEHAVIOR_TREE_ACTIONS_ADJUST_PATH_FOR_OBSTACLES_H
+
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <behaviortree_cpp/bt_factory.h>  // NOLINT(build/include_order) cpplint misclassifies third-party .h headers as "C system" by extension.
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "nav_msgs/msg/path.hpp"
+#include "nav2_msgs/msg/costmap.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+namespace marine_nav_behavior_tree
+{
+
+// Tunables for the corridor solver. Cross-track offset `d` is the cross-track
+// error by construction, so the XTE term is analytic (w_xte * d^2) and never
+// shares the costmap's cost budget. See .agent/work-plans/issue-30/plan.md.
+struct CorridorParams
+{
+  double max_xte = 6.0;            // corridor half-width (m); also the give-up bound
+  double lateral_step = 0.5;       // cross-track offset resolution (m)
+  double w_xte = 1.0;              // restoring-spring weight on d^2
+  double w_obs = 0.02;             // weight on graded obstacle cost [0..252]
+  double w_smooth = 2.0;           // weight on (d_i - d_{i-1})^2 between stations
+  double w_temporal = 0.0;         // weight on (d - prev_tick_d)^2 (chatter damping)
+  double max_lateral_rate = 1.0;   // max |d_i - d_{i-1}| between adjacent stations (m)
+  double lethal_cost = 253.0;      // sampled cost >= this is impassable (INSCRIBED/LETHAL)
+};
+
+// Build the symmetric set of candidate lateral offsets, guaranteed to include
+// exactly 0.0 at the centre index. e.g. max_xte=1.0, step=0.5 -> {-1,-0.5,0,0.5,1}.
+std::vector<double> makeLateralOffsets(double max_xte, double lateral_step);
+
+// Pure corridor dynamic program — no ROS, unit-testable with a hand-built cost
+// matrix. `obstacle_costs[i][j]` is the sampled costmap cost at station i,
+// offset column j (must match `offsets` size); a value >= params.lethal_cost is
+// impassable. `offsets` is the output of makeLateralOffsets (centre == 0).
+// `prev_offsets` feeds the temporal term (empty => treated as all-zero, term off).
+// Stations in [active_begin, active_end) are optimised; the rest, plus the two
+// active endpoints themselves, are pinned to d=0 so the result is a true detour
+// that re-anchors to the line. Returns the chosen offset per station, or
+// std::nullopt when no finite-cost path exists (corridor blocked).
+std::optional<std::vector<double>> solveCorridorOffsets(
+  const std::vector<std::vector<double>> & obstacle_costs,
+  const std::vector<double> & offsets,
+  const CorridorParams & params,
+  const std::vector<double> & prev_offsets,
+  std::size_t active_begin,
+  std::size_t active_end);
+
+// A 2D centreline station: position + unit left-normal, both in the path frame.
+struct Station
+{
+  double x = 0.0;
+  double y = 0.0;
+  double nx = 0.0;   // unit left-normal x (90deg CCW from tangent)
+  double ny = 0.0;   // unit left-normal y
+  double yaw = 0.0;  // tangent heading
+};
+
+// Resample a pose polyline into stations spaced ~`step` metres along arclength,
+// carrying the per-segment tangent and left-normal. Fewer than 2 input poses
+// yields an empty result.
+std::vector<Station> resampleStations(
+  const std::vector<geometry_msgs::msg::PoseStamped> & poses, double step);
+
+// Reactive corridor path-adjuster. Sits between SetPathFromTask and FollowPath
+// in the SurveyLine inner ReactiveSequence: reads the nominal trackline, samples
+// the existing local costmap, and reshapes the followed path around obstacles
+// while staying anchored to the line. Pure tracker downstream (CrabbingPathFollower)
+// is untouched. When clear it passes the nominal path through unchanged; when the
+// corridor is fully blocked it also passes nominal through, degrading to the
+// existing reflex-stop / RecoveryNode path. Always returns SUCCESS — it is a path
+// transformer, not a gate. See .agent/work-plans/issue-30/plan.md.
+class AdjustPathForObstacles : public BT::SyncActionNode
+{
+public:
+  AdjustPathForObstacles(const std::string & name, const BT::NodeConfig & config);
+
+  static BT::PortsList providedPorts();
+
+  BT::NodeStatus tick() override;
+
+private:
+  // Latest costmap, swapped in by the subscription callback (executor thread)
+  // and read by tick() (BT thread). Guarded by costmap_mutex_; tick takes a
+  // shared_ptr snapshot under the lock and releases it before the DP runs.
+  std::shared_ptr<nav2_msgs::msg::Costmap> costmap_;
+  std::mutex costmap_mutex_;
+  rclcpp::Subscription<nav2_msgs::msg::Costmap>::SharedPtr costmap_sub_;
+  std::string costmap_topic_;
+
+  // Previous tick's per-station offsets, for the temporal (chatter) term.
+  std::vector<double> prev_offsets_;
+};
+
+}  // namespace marine_nav_behavior_tree
+
+#endif  // MARINE_NAV_BEHAVIOR_TREE_ACTIONS_ADJUST_PATH_FOR_OBSTACLES_H

--- a/marine_nav_behavior_tree/package.xml
+++ b/marine_nav_behavior_tree/package.xml
@@ -23,6 +23,7 @@
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
+  <depend>visualization_msgs</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/marine_nav_behavior_tree/package.xml
+++ b/marine_nav_behavior_tree/package.xml
@@ -14,7 +14,9 @@
   <depend>marine_nav_interfaces</depend>
   <depend>marine_nav_tasks</depend>
   <depend>nav2_behavior_tree</depend>
+  <depend>nav2_msgs</depend>
   <depend>nav2_util</depend>
+  <depend>nav_msgs</depend>
   <depend>rcl_interfaces</depend>
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>

--- a/marine_nav_behavior_tree/src/bt_register_nodes.cpp
+++ b/marine_nav_behavior_tree/src/bt_register_nodes.cpp
@@ -1,5 +1,6 @@
 #include "behaviortree_cpp/bt_factory.h"
 
+#include "marine_nav_behavior_tree/plugins/action/adjust_path_for_obstacles.h"
 #include "marine_nav_behavior_tree/plugins/action/add_sub_task.h"
 #include "marine_nav_behavior_tree/plugins/action/clear_path.h"
 #include "marine_nav_behavior_tree/plugins/action/fix_path_orientations.h"
@@ -29,6 +30,7 @@
 
 BT_REGISTER_NODES(factory)
 {
+  factory.registerNodeType<marine_nav_behavior_tree::AdjustPathForObstacles>("AdjustPathForObstacles");
   factory.registerNodeType<marine_nav_behavior_tree::AddSubTask>("AddSubTask");
   factory.registerNodeType<marine_nav_behavior_tree::ClearPath>("ClearPath");
   factory.registerNodeType<marine_nav_behavior_tree::FixPathOrientations>("FixPathOrientations");

--- a/marine_nav_behavior_tree/src/plugins/action/adjust_path_for_obstacles.cpp
+++ b/marine_nav_behavior_tree/src/plugins/action/adjust_path_for_obstacles.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "builtin_interfaces/msg/time.hpp"
+#include "visualization_msgs/msg/marker_array.hpp"
 
 #include <tf2/LinearMath/Quaternion.h>  // NOLINT(build/include_order)
 #include <tf2/LinearMath/Transform.h>  // NOLINT(build/include_order)
@@ -34,6 +35,11 @@ constexpr uint8_t kNoInformation = 255;
 // so forbid deviating there (impassable), but a centreline miss just bounds the
 // active range.
 constexpr double kOutOfBounds = -1.0;
+// Marker namespace for the operator-feedback MarkerArray (CAMP auto-discovers it).
+constexpr char kVizNamespace[] = "survey_obstacle_avoidance";
+// Empty stand-in for the temporal term's "previous offsets" when there is no
+// matching prior tick — an lvalue, so the DP-input ref binds without a per-tick copy.
+const std::vector<double> kEmptyOffsets;
 }  // namespace
 
 std::vector<double> makeLateralOffsets(double max_xte, double lateral_step)
@@ -237,6 +243,93 @@ std::vector<Station> resampleStations(
   return stations;
 }
 
+namespace
+{
+// Build the operator-feedback overlay for a deviating tick: the nominal survey
+// line (faint), the adjusted path the boat will follow (bright), the deviating
+// stretch highlighted (red), and an "AVOIDING" flag at the peak deviation. All
+// in the path frame; CAMP auto-discovers any visualization_msgs/MarkerArray.
+visualization_msgs::msg::MarkerArray buildAvoidanceMarkers(
+  const rclcpp::Time & stamp, const std::string & frame,
+  const nav_msgs::msg::Path & nominal,
+  const std::vector<Station> & stations,
+  const std::vector<double> & offsets_d)
+{
+  visualization_msgs::msg::MarkerArray arr;
+  const auto lifetime = rclcpp::Duration::from_seconds(2.0);
+
+  auto base = [&](int id, int32_t type, double width,
+      double r, double g, double b, double a) {
+      visualization_msgs::msg::Marker m;
+      m.header.frame_id = frame;
+      m.header.stamp = stamp;
+      m.ns = kVizNamespace;
+      m.id = id;
+      m.type = type;
+      m.action = visualization_msgs::msg::Marker::ADD;
+      m.pose.orientation.w = 1.0;
+      m.scale.x = width;
+      m.color.r = r;
+      m.color.g = g;
+      m.color.b = b;
+      m.color.a = a;
+      m.lifetime = lifetime;
+      return m;
+    };
+
+  auto adjusted_point = [&](std::size_t i) {
+      geometry_msgs::msg::Point pt;
+      pt.x = stations[i].x + offsets_d[i] * stations[i].nx;
+      pt.y = stations[i].y + offsets_d[i] * stations[i].ny;
+      return pt;
+    };
+
+  // 1) Nominal survey line (faint gray) — context for how far we deviated.
+  auto nominal_m = base(0, visualization_msgs::msg::Marker::LINE_STRIP, 0.4,
+      0.6, 0.6, 0.6, 0.4);
+  for (const auto & p : nominal.poses) {
+    nominal_m.points.push_back(p.pose.position);
+  }
+  arr.markers.push_back(nominal_m);
+
+  // 2) Adjusted path the boat follows (bright cyan).
+  auto adjusted_m = base(1, visualization_msgs::msg::Marker::LINE_STRIP, 1.0,
+      0.0, 0.9, 1.0, 0.95);
+  std::size_t peak_i = 0;
+  double peak = 0.0;
+  for (std::size_t i = 0; i < stations.size(); ++i) {
+    adjusted_m.points.push_back(adjusted_point(i));
+    if (std::abs(offsets_d[i]) > peak) {
+      peak = std::abs(offsets_d[i]);
+      peak_i = i;
+    }
+  }
+  arr.markers.push_back(adjusted_m);
+
+  // 3) Avoiding band: the deviating stretch, red and thick, drawn on top.
+  auto band_m = base(2, visualization_msgs::msg::Marker::LINE_STRIP, 1.6,
+      1.0, 0.15, 0.1, 0.9);
+  for (std::size_t i = 0; i < stations.size(); ++i) {
+    if (std::abs(offsets_d[i]) >= kDeviationEpsilon) {
+      band_m.points.push_back(adjusted_point(i));
+    }
+  }
+  if (band_m.points.size() >= 2) {  // a 1-point LINE_STRIP renders nothing
+    arr.markers.push_back(band_m);
+  }
+
+  // 4) "AVOIDING" flag at the peak-deviation point (red, view-facing text).
+  auto text_m = base(3, visualization_msgs::msg::Marker::TEXT_VIEW_FACING, 1.0,
+      1.0, 0.2, 0.15, 1.0);
+  text_m.scale.z = 3.0;  // text height (m)
+  text_m.text = "AVOIDING";
+  text_m.pose.position = adjusted_point(peak_i);
+  arr.markers.push_back(text_m);
+
+  return arr;
+}
+}  // namespace
+
 AdjustPathForObstacles::AdjustPathForObstacles(
   const std::string & name, const BT::NodeConfig & config)
 : BT::SyncActionNode(name, config)
@@ -296,9 +389,26 @@ BT::NodeStatus AdjustPathForObstacles::tick()
         std::lock_guard<std::mutex> lock(cache->mutex);
         cache->costmap = msg;
       });
+    viz_pub_ = node->create_publisher<visualization_msgs::msg::MarkerArray>(
+      "survey_obstacle_avoidance", rclcpp::QoS(1));
   }
 
+  // Wipe the avoidance overlay once on the avoiding->clear transition (idle ticks
+  // then publish nothing, rather than spamming a DELETEALL every loop).
+  auto clear_viz = [&]() {
+    if (was_avoiding_ && viz_pub_) {
+      visualization_msgs::msg::MarkerArray arr;
+      visualization_msgs::msg::Marker del;
+      del.ns = kVizNamespace;
+      del.action = visualization_msgs::msg::Marker::DELETEALL;
+      arr.markers.push_back(del);
+      viz_pub_->publish(arr);
+    }
+    was_avoiding_ = false;
+  };
+
   auto passthrough = [&]() {
+    clear_viz();
     setOutput("path", nominal);
     prev_offsets_.clear();
     return BT::NodeStatus::SUCCESS;
@@ -316,6 +426,31 @@ BT::NodeStatus AdjustPathForObstacles::tick()
   }
   if (!costmap) {
     return passthrough();  // no costmap yet
+  }
+
+  // Guard the axis-aligned indexing assumptions before sampling: positive
+  // resolution, non-empty grid, a data buffer matching size_x*size_y, and an
+  // identity origin orientation. nav2's costmap_2d always emits such a grid, but
+  // a malformed or rotated relayed source would otherwise misregister every
+  // sample. Degrade to passthrough (reflex layer remains the backstop).
+  {
+    const auto & m = costmap->metadata;
+    const auto & q = m.origin.orientation;
+    const bool axis_aligned =
+      std::abs(q.x) < 1e-6 && std::abs(q.y) < 1e-6 && std::abs(q.z) < 1e-6 &&
+      std::abs(std::abs(q.w) - 1.0) < 1e-6;
+    if (m.resolution <= 0.0 || m.size_x == 0 || m.size_y == 0 ||
+      costmap->data.size() != static_cast<std::size_t>(m.size_x) * m.size_y ||
+      !axis_aligned)
+    {
+      RCLCPP_WARN_THROTTLE(
+        node->get_logger(), *node->get_clock(), 2000,
+        "AdjustPathForObstacles: unusable costmap (resolution=%.3f size=%ux%u "
+        "data=%zu axis_aligned=%d); passing nominal path.",
+        m.resolution, m.size_x, m.size_y, costmap->data.size(),
+        static_cast<int>(axis_aligned));
+      return passthrough();
+    }
   }
 
   const double station_step = getInput<double>("station_step").value_or(2.0);
@@ -377,23 +512,29 @@ BT::NodeStatus AdjustPathForObstacles::tick()
     return static_cast<double>(c);
   };
 
-  // Robot's station index (clip the active range to ahead-of-boat). Non-fatal:
-  // if the pose is unavailable, start the active range at the first in-window
-  // station instead.
+  // Robot's station index, used to clip the active range to ahead-of-boat.
+  // Without a pose we can't tell which stations are astern, and reshaping behind
+  // the boat can tug a nearest-segment follower backward — so a pose-lookup
+  // failure passes the nominal path through for this tick rather than guessing.
   std::size_t robot_station = 0;
   {
     auto robot_frame = config().blackboard->get<std::string>("robot_frame");
     geometry_msgs::msg::PoseStamped robot;
-    if (nav2_util::getCurrentPose(robot, *tf_buffer, path_frame, robot_frame, 0.1)) {
-      double best_d = kInf;
-      for (std::size_t i = 0; i < n; ++i) {
-        const double d = std::hypot(
-          stations[i].x - robot.pose.position.x,
-          stations[i].y - robot.pose.position.y);
-        if (d < best_d) {
-          best_d = d;
-          robot_station = i;
-        }
+    if (!nav2_util::getCurrentPose(robot, *tf_buffer, path_frame, robot_frame, 0.1)) {
+      RCLCPP_WARN_THROTTLE(
+        node->get_logger(), *node->get_clock(), 2000,
+        "AdjustPathForObstacles: robot pose (%s->%s) unavailable; passing nominal path.",
+        path_frame.c_str(), robot_frame.c_str());
+      return passthrough();
+    }
+    double best_d = kInf;
+    for (std::size_t i = 0; i < n; ++i) {
+      const double d = std::hypot(
+        stations[i].x - robot.pose.position.x,
+        stations[i].y - robot.pose.position.y);
+      if (d < best_d) {
+        best_d = d;
+        robot_station = i;
       }
     }
   }
@@ -433,7 +574,7 @@ BT::NodeStatus AdjustPathForObstacles::tick()
   }
 
   const std::vector<double> & prev =
-    (prev_offsets_.size() == n) ? prev_offsets_ : std::vector<double>{};
+    (prev_offsets_.size() == n) ? prev_offsets_ : kEmptyOffsets;
   const auto solved = solveCorridorOffsets(
     costs, offsets, params, prev, active_begin, active_end);
   if (!solved) {
@@ -446,6 +587,7 @@ BT::NodeStatus AdjustPathForObstacles::tick()
   }
   prev_offsets_ = *solved;
   if (peak < kDeviationEpsilon) {
+    clear_viz();  // back on the line: wipe any stale avoidance overlay
     setOutput("path", nominal);  // no meaningful deviation: keep nominal exactly
     return BT::NodeStatus::SUCCESS;
   }
@@ -466,6 +608,15 @@ BT::NodeStatus AdjustPathForObstacles::tick()
     out.poses.push_back(p);
   }
   setOutput("path", out);
+
+  // Operator feedback: show the deviation in CAMP (nominal line, adjusted path,
+  // the avoiding band, and an "AVOIDING" flag). Published only here, on a real
+  // deviation.
+  if (viz_pub_) {
+    viz_pub_->publish(
+      buildAvoidanceMarkers(node->now(), path_frame, nominal, stations, *solved));
+    was_avoiding_ = true;
+  }
   return BT::NodeStatus::SUCCESS;
 }
 

--- a/marine_nav_behavior_tree/src/plugins/action/adjust_path_for_obstacles.cpp
+++ b/marine_nav_behavior_tree/src/plugins/action/adjust_path_for_obstacles.cpp
@@ -201,39 +201,41 @@ std::vector<Station> resampleStations(
     return stations;
   }
 
-  // Per-segment direction + cumulative length.
+  // Per-segment length + total.
+  std::vector<double> seg_len(pts.size(), 0.0);  // seg_len[i] = |pts[i-1]→pts[i]|
   double total = 0.0;
   for (std::size_t i = 1; i < pts.size(); ++i) {
-    total += std::hypot(pts[i][0] - pts[i - 1][0], pts[i][1] - pts[i - 1][1]);
+    seg_len[i] = std::hypot(pts[i][0] - pts[i - 1][0], pts[i][1] - pts[i - 1][1]);
+    total += seg_len[i];
   }
   if (total <= 0.0) {
     return stations;
   }
 
+  // Single forward walk: the sample arclength s is monotonically increasing, so
+  // the active segment index only advances — O(segments + stations) overall
+  // (vs a per-station rescan from the start). `seg_start` is the arclength at
+  // pts[seg-1]; we stay on the last segment for s at/after `total`.
+  std::size_t seg = 1;
+  double seg_start = 0.0;
   auto station_at = [&](double s) -> Station {
-    double acc = 0.0;
-    for (std::size_t i = 1; i < pts.size(); ++i) {
-      const double dx = pts[i][0] - pts[i - 1][0];
-      const double dy = pts[i][1] - pts[i - 1][1];
-      const double len = std::hypot(dx, dy);
-      if (len <= 0.0) {
-        continue;
-      }
-      if (s <= acc + len || i + 1 == pts.size()) {
-        const double t = std::clamp((s - acc) / len, 0.0, 1.0);
-        const double tx = dx / len;
-        const double ty = dy / len;
-        Station st;
-        st.x = pts[i - 1][0] + t * dx;
-        st.y = pts[i - 1][1] + t * dy;
-        st.nx = -ty;  // left normal (90deg CCW from tangent)
-        st.ny = tx;
-        st.yaw = std::atan2(ty, tx);
-        return st;
-      }
-      acc += len;
+    while (seg + 1 < pts.size() && s > seg_start + seg_len[seg]) {
+      seg_start += seg_len[seg];
+      ++seg;
     }
-    return Station{};  // unreachable
+    const double dx = pts[seg][0] - pts[seg - 1][0];
+    const double dy = pts[seg][1] - pts[seg - 1][1];
+    const double len = seg_len[seg];
+    const double t = std::clamp((s - seg_start) / len, 0.0, 1.0);
+    const double tx = dx / len;
+    const double ty = dy / len;
+    Station st;
+    st.x = pts[seg - 1][0] + t * dx;
+    st.y = pts[seg - 1][1] + t * dy;
+    st.nx = -ty;  // left normal (90deg CCW from tangent)
+    st.ny = tx;
+    st.yaw = std::atan2(ty, tx);
+    return st;
   };
 
   for (double s = 0.0; s < total; s += step) {

--- a/marine_nav_behavior_tree/src/plugins/action/adjust_path_for_obstacles.cpp
+++ b/marine_nav_behavior_tree/src/plugins/action/adjust_path_for_obstacles.cpp
@@ -1,0 +1,460 @@
+#include "marine_nav_behavior_tree/plugins/action/adjust_path_for_obstacles.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <limits>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "builtin_interfaces/msg/time.hpp"
+
+#include <tf2/LinearMath/Quaternion.h>  // NOLINT(build/include_order)
+#include <tf2/LinearMath/Transform.h>  // NOLINT(build/include_order)
+#include <tf2/LinearMath/Vector3.h>  // NOLINT(build/include_order)
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+#include "tf2_ros/buffer.h"
+#include "nav2_util/robot_utils.hpp"
+
+namespace marine_nav_behavior_tree
+{
+
+namespace
+{
+constexpr double kInf = std::numeric_limits<double>::infinity();
+// Below this peak |d| (m) the reshaped path is indistinguishable from nominal;
+// pass the nominal path through unchanged so clear water stays byte-identical
+// to today's behaviour (no spurious FollowPath preemption).
+constexpr double kDeviationEpsilon = 0.05;
+// nav2_msgs/Costmap raw values: 255 == NO_INFORMATION (unobserved). Treat as
+// free — for a survey, unobserved cells are open water we simply haven't swept.
+constexpr uint8_t kNoInformation = 255;
+// Sampling a point outside the rolling costmap window: we can't vouch for it,
+// so forbid deviating there (impassable), but a centreline miss just bounds the
+// active range.
+constexpr double kOutOfBounds = -1.0;
+}  // namespace
+
+std::vector<double> makeLateralOffsets(double max_xte, double lateral_step)
+{
+  std::vector<double> offsets;
+  if (lateral_step <= 0.0 || max_xte < 0.0) {
+    offsets.push_back(0.0);
+    return offsets;
+  }
+  const int n_each = static_cast<int>(std::round(max_xte / lateral_step));
+  for (int k = -n_each; k <= n_each; ++k) {
+    offsets.push_back(k * lateral_step);
+  }
+  // Guarantee an exact 0.0 centre even if rounding nudged it.
+  if (n_each >= 0) {
+    offsets[n_each] = 0.0;
+  }
+  return offsets;
+}
+
+std::optional<std::vector<double>> solveCorridorOffsets(
+  const std::vector<std::vector<double>> & obstacle_costs,
+  const std::vector<double> & offsets,
+  const CorridorParams & params,
+  const std::vector<double> & prev_offsets,
+  std::size_t active_begin,
+  std::size_t active_end)
+{
+  const std::size_t n = obstacle_costs.size();
+  const std::size_t m = offsets.size();
+  if (n == 0 || m == 0) {
+    return std::nullopt;
+  }
+
+  // Centre column (d == 0) — the pin target for inactive stations and anchors.
+  std::size_t zero_col = 0;
+  for (std::size_t j = 0; j < m; ++j) {
+    if (std::abs(offsets[j]) < std::abs(offsets[zero_col])) {
+      zero_col = j;
+    }
+  }
+
+  const bool use_temporal =
+    params.w_temporal > 0.0 && prev_offsets.size() == n;
+
+  // A station is "free to choose" only inside [active_begin, active_end), and
+  // never at the two active endpoints (anchored to d=0 so the detour returns).
+  auto pinned_to_zero = [&](std::size_t i) {
+    if (i < active_begin || i + 1 > active_end) {
+      return true;  // outside the active range
+    }
+    return i == active_begin || i + 1 == active_end;  // the anchored endpoints
+  };
+
+  // node_cost(i, j): finite only for admissible (station, offset) pairs.
+  auto node_cost = [&](std::size_t i, std::size_t j) -> double {
+    if (pinned_to_zero(i)) {
+      return j == zero_col ? 0.0 : kInf;
+    }
+    const double cost = obstacle_costs[i][j];
+    if (cost >= params.lethal_cost) {
+      return kInf;
+    }
+    double c = params.w_xte * offsets[j] * offsets[j] + params.w_obs * cost;
+    if (use_temporal) {
+      const double dt = offsets[j] - prev_offsets[i];
+      c += params.w_temporal * dt * dt;
+    }
+    return c;
+  };
+
+  // Forward DP. best[j] = min cost to reach station i at offset column j.
+  std::vector<double> best(m, kInf);
+  std::vector<std::vector<int>> parent(n, std::vector<int>(m, -1));
+
+  for (std::size_t j = 0; j < m; ++j) {
+    best[j] = node_cost(0, j);
+  }
+
+  for (std::size_t i = 1; i < n; ++i) {
+    std::vector<double> cur(m, kInf);
+    for (std::size_t j = 0; j < m; ++j) {
+      const double nc = node_cost(i, j);
+      if (!std::isfinite(nc)) {
+        continue;
+      }
+      for (std::size_t k = 0; k < m; ++k) {
+        if (!std::isfinite(best[k])) {
+          continue;
+        }
+        const double step = offsets[j] - offsets[k];
+        if (std::abs(step) > params.max_lateral_rate + 1e-9) {
+          continue;  // exceeds the per-station lateral-rate limit
+        }
+        const double trans = params.w_smooth * step * step;
+        const double total = best[k] + trans + nc;
+        if (total < cur[j]) {
+          cur[j] = total;
+          parent[i][j] = static_cast<int>(k);
+        }
+      }
+    }
+    best.swap(cur);
+  }
+
+  // Best terminal column (the last station is pinned, so this is zero_col).
+  std::size_t end_col = 0;
+  double end_cost = kInf;
+  for (std::size_t j = 0; j < m; ++j) {
+    if (best[j] < end_cost) {
+      end_cost = best[j];
+      end_col = j;
+    }
+  }
+  if (!std::isfinite(end_cost)) {
+    return std::nullopt;  // corridor blocked — no finite-cost path
+  }
+
+  std::vector<double> result(n, 0.0);
+  std::size_t col = end_col;
+  for (std::size_t ii = n; ii-- > 0;) {
+    result[ii] = offsets[col];
+    const int p = parent[ii][col];
+    if (p < 0) {
+      break;
+    }
+    col = static_cast<std::size_t>(p);
+  }
+  return result;
+}
+
+std::vector<Station> resampleStations(
+  const std::vector<geometry_msgs::msg::PoseStamped> & poses, double step)
+{
+  std::vector<Station> stations;
+  if (poses.size() < 2 || step <= 0.0) {
+    return stations;
+  }
+
+  // Collapse consecutive duplicate points.
+  std::vector<std::array<double, 2>> pts;
+  for (const auto & p : poses) {
+    const double x = p.pose.position.x;
+    const double y = p.pose.position.y;
+    if (pts.empty() || std::hypot(x - pts.back()[0], y - pts.back()[1]) > 1e-6) {
+      pts.push_back({x, y});
+    }
+  }
+  if (pts.size() < 2) {
+    return stations;
+  }
+
+  // Per-segment direction + cumulative length.
+  double total = 0.0;
+  for (std::size_t i = 1; i < pts.size(); ++i) {
+    total += std::hypot(pts[i][0] - pts[i - 1][0], pts[i][1] - pts[i - 1][1]);
+  }
+  if (total <= 0.0) {
+    return stations;
+  }
+
+  auto station_at = [&](double s) -> Station {
+    double acc = 0.0;
+    for (std::size_t i = 1; i < pts.size(); ++i) {
+      const double dx = pts[i][0] - pts[i - 1][0];
+      const double dy = pts[i][1] - pts[i - 1][1];
+      const double len = std::hypot(dx, dy);
+      if (len <= 0.0) {
+        continue;
+      }
+      if (s <= acc + len || i + 1 == pts.size()) {
+        const double t = std::clamp((s - acc) / len, 0.0, 1.0);
+        const double tx = dx / len;
+        const double ty = dy / len;
+        Station st;
+        st.x = pts[i - 1][0] + t * dx;
+        st.y = pts[i - 1][1] + t * dy;
+        st.nx = -ty;  // left normal (90deg CCW from tangent)
+        st.ny = tx;
+        st.yaw = std::atan2(ty, tx);
+        return st;
+      }
+      acc += len;
+    }
+    return Station{};  // unreachable
+  };
+
+  for (double s = 0.0; s < total; s += step) {
+    stations.push_back(station_at(s));
+  }
+  stations.push_back(station_at(total));  // always anchor the endpoint
+  return stations;
+}
+
+AdjustPathForObstacles::AdjustPathForObstacles(
+  const std::string & name, const BT::NodeConfig & config)
+: BT::SyncActionNode(name, config)
+{
+}
+
+BT::PortsList AdjustPathForObstacles::providedPorts()
+{
+  return {
+    BT::InputPort<nav_msgs::msg::Path>(
+      "nominal_path", "{nominal_survey_path}",
+      "Nominal trackline to reshape around obstacles."),
+    BT::OutputPort<nav_msgs::msg::Path>(
+      "path", "{survey_path}",
+      "Reshaped path for FollowPath (nominal pass-through when clear/blocked)."),
+    BT::InputPort<std::string>(
+      "costmap_topic", "local_costmap/costmap_raw",
+      "nav2_msgs/Costmap topic supplying the obstacle field."),
+    BT::InputPort<double>(
+      "max_xte", 6.0,
+      "Corridor half-width (m): max deviation, and the give-up bound. Baseline "
+      "param; wire to a task-derived value for a per-line override."),
+    BT::InputPort<double>("station_step", 2.0, "Along-track resample spacing (m)."),
+    BT::InputPort<double>("lateral_step", 0.5, "Cross-track offset resolution (m)."),
+    BT::InputPort<double>("w_xte", 1.0, "Restoring-spring weight on d^2."),
+    BT::InputPort<double>("w_obs", 0.02, "Weight on graded obstacle cost."),
+    BT::InputPort<double>("w_smooth", 2.0, "Smoothness weight on (d_i - d_{i-1})^2."),
+    BT::InputPort<double>("w_temporal", 0.0, "Chatter-damping weight vs last tick."),
+    BT::InputPort<double>("max_lateral_rate", 1.0, "Max |d| change between stations (m)."),
+  };
+}
+
+BT::NodeStatus AdjustPathForObstacles::tick()
+{
+  auto nominal_bb = getInput<nav_msgs::msg::Path>("nominal_path");
+  if (!nominal_bb) {
+    throw BT::RuntimeError(name(), " missing required input [nominal_path]: ",
+      nominal_bb.error());
+  }
+  const nav_msgs::msg::Path nominal = nominal_bb.value();
+
+  auto node = config().blackboard->get<rclcpp::Node::SharedPtr>("node");
+
+  // Lazy-create the costmap subscription on first tick (the topic port and the
+  // blackboard node are only reliably readable once the tree is wired). The
+  // callback runs on the bt_navigator executor thread, distinct from this tick
+  // thread — hence the mutex + shared_ptr swap.
+  if (!costmap_sub_) {
+    costmap_topic_ = getInput<std::string>("costmap_topic").value_or(
+      "local_costmap/costmap_raw");
+    costmap_sub_ = node->create_subscription<nav2_msgs::msg::Costmap>(
+      costmap_topic_, rclcpp::QoS(1),
+      [this](nav2_msgs::msg::Costmap::SharedPtr msg) {
+        std::lock_guard<std::mutex> lock(costmap_mutex_);
+        costmap_ = msg;
+      });
+  }
+
+  auto passthrough = [&]() {
+    setOutput("path", nominal);
+    prev_offsets_.clear();
+    return BT::NodeStatus::SUCCESS;
+  };
+
+  if (nominal.poses.size() < 2) {
+    return passthrough();
+  }
+
+  // Snapshot the latest costmap (pointer copy under the lock; DP reads it lock-free).
+  std::shared_ptr<nav2_msgs::msg::Costmap> costmap;
+  {
+    std::lock_guard<std::mutex> lock(costmap_mutex_);
+    costmap = costmap_;
+  }
+  if (!costmap) {
+    return passthrough();  // no costmap yet
+  }
+
+  const double station_step = getInput<double>("station_step").value_or(2.0);
+  CorridorParams params;
+  params.max_xte = getInput<double>("max_xte").value_or(6.0);
+  params.lateral_step = getInput<double>("lateral_step").value_or(0.5);
+  params.w_xte = getInput<double>("w_xte").value_or(1.0);
+  params.w_obs = getInput<double>("w_obs").value_or(0.02);
+  params.w_smooth = getInput<double>("w_smooth").value_or(2.0);
+  params.w_temporal = getInput<double>("w_temporal").value_or(0.0);
+  params.max_lateral_rate = getInput<double>("max_lateral_rate").value_or(1.0);
+
+  const auto stations = resampleStations(nominal.poses, station_step);
+  if (stations.size() < 3) {
+    return passthrough();
+  }
+  const std::size_t n = stations.size();
+
+  // Resolve the transform from the path frame into the costmap frame (one lookup,
+  // reused for every sample). Identity when the frames already match.
+  const std::string path_frame = nominal.header.frame_id.empty()
+    ? nominal.poses.front().header.frame_id
+    : nominal.header.frame_id;
+  const std::string costmap_frame = costmap->header.frame_id;
+
+  auto tf_buffer =
+    config().blackboard->get<std::shared_ptr<tf2_ros::Buffer>>("tf_buffer");
+  tf2::Transform to_costmap;
+  try {
+    const auto tf_msg = tf_buffer->lookupTransform(
+      costmap_frame, path_frame, tf2::TimePointZero);
+    tf2::fromMsg(tf_msg.transform, to_costmap);
+  } catch (const tf2::TransformException & ex) {
+    RCLCPP_WARN_THROTTLE(
+      node->get_logger(), *node->get_clock(), 2000,
+      "AdjustPathForObstacles: TF %s -> %s unavailable (%s); passing nominal path.",
+      path_frame.c_str(), costmap_frame.c_str(), ex.what());
+    return passthrough();
+  }
+
+  // Sample the costmap at a path-frame point; returns raw cost mapped so that
+  // out-of-window -> impassable, NO_INFORMATION -> free, else the graded value.
+  const auto & md = costmap->metadata;
+  auto sample = [&](double px, double py) -> double {
+    const tf2::Vector3 w = to_costmap * tf2::Vector3(px, py, 0.0);
+    const int mx = static_cast<int>(
+      std::floor((w.x() - md.origin.position.x) / md.resolution));
+    const int my = static_cast<int>(
+      std::floor((w.y() - md.origin.position.y) / md.resolution));
+    if (mx < 0 || my < 0 ||
+      mx >= static_cast<int>(md.size_x) || my >= static_cast<int>(md.size_y))
+    {
+      return kOutOfBounds;
+    }
+    const uint8_t c = costmap->data[my * md.size_x + mx];
+    if (c == kNoInformation) {
+      return 0.0;
+    }
+    return static_cast<double>(c);
+  };
+
+  // Robot's station index (clip the active range to ahead-of-boat). Non-fatal:
+  // if the pose is unavailable, start the active range at the first in-window
+  // station instead.
+  std::size_t robot_station = 0;
+  {
+    auto robot_frame = config().blackboard->get<std::string>("robot_frame");
+    geometry_msgs::msg::PoseStamped robot;
+    if (nav2_util::getCurrentPose(robot, *tf_buffer, path_frame, robot_frame, 0.1)) {
+      double best_d = kInf;
+      for (std::size_t i = 0; i < n; ++i) {
+        const double d = std::hypot(
+          stations[i].x - robot.pose.position.x,
+          stations[i].y - robot.pose.position.y);
+        if (d < best_d) {
+          best_d = d;
+          robot_station = i;
+        }
+      }
+    }
+  }
+
+  // Active range: contiguous in-window stations starting at/after the boat.
+  std::size_t active_begin = n;
+  for (std::size_t i = robot_station; i < n; ++i) {
+    if (sample(stations[i].x, stations[i].y) != kOutOfBounds) {
+      active_begin = i;
+      break;
+    }
+  }
+  if (active_begin >= n) {
+    return passthrough();  // nothing of the line ahead is in the costmap window
+  }
+  std::size_t active_end = n;
+  for (std::size_t i = active_begin + 1; i < n; ++i) {
+    if (sample(stations[i].x, stations[i].y) == kOutOfBounds) {
+      active_end = i;
+      break;
+    }
+  }
+  if (active_end - active_begin < 3) {
+    return passthrough();  // no interior station to deviate
+  }
+
+  // Build the cost matrix (active rows sampled; inactive rows unused -> zeros).
+  const auto offsets = makeLateralOffsets(params.max_xte, params.lateral_step);
+  std::vector<std::vector<double>> costs(n, std::vector<double>(offsets.size(), 0.0));
+  for (std::size_t i = active_begin; i < active_end; ++i) {
+    for (std::size_t j = 0; j < offsets.size(); ++j) {
+      const double px = stations[i].x + offsets[j] * stations[i].nx;
+      const double py = stations[i].y + offsets[j] * stations[i].ny;
+      const double s = sample(px, py);
+      costs[i][j] = (s == kOutOfBounds) ? params.lethal_cost : s;
+    }
+  }
+
+  const std::vector<double> & prev =
+    (prev_offsets_.size() == n) ? prev_offsets_ : std::vector<double>{};
+  const auto solved = solveCorridorOffsets(
+    costs, offsets, params, prev, active_begin, active_end);
+  if (!solved) {
+    return passthrough();  // corridor blocked -> degrade to reflex/RecoveryNode
+  }
+
+  double peak = 0.0;
+  for (const double d : *solved) {
+    peak = std::max(peak, std::abs(d));
+  }
+  prev_offsets_ = *solved;
+  if (peak < kDeviationEpsilon) {
+    setOutput("path", nominal);  // no meaningful deviation: keep nominal exactly
+    return BT::NodeStatus::SUCCESS;
+  }
+
+  // Emit the reshaped path (path frame; zero outer stamp = "latest" per #23).
+  nav_msgs::msg::Path out;
+  out.header.frame_id = path_frame;
+  out.header.stamp = builtin_interfaces::msg::Time();
+  out.poses.reserve(n);
+  for (std::size_t i = 0; i < n; ++i) {
+    geometry_msgs::msg::PoseStamped p;
+    p.header.frame_id = path_frame;
+    p.pose.position.x = stations[i].x + (*solved)[i] * stations[i].nx;
+    p.pose.position.y = stations[i].y + (*solved)[i] * stations[i].ny;
+    tf2::Quaternion q;
+    q.setRPY(0.0, 0.0, stations[i].yaw);
+    p.pose.orientation = tf2::toMsg(q);
+    out.poses.push_back(p);
+  }
+  setOutput("path", out);
+  return BT::NodeStatus::SUCCESS;
+}
+
+}  // namespace marine_nav_behavior_tree

--- a/marine_nav_behavior_tree/src/plugins/action/adjust_path_for_obstacles.cpp
+++ b/marine_nav_behavior_tree/src/plugins/action/adjust_path_for_obstacles.cpp
@@ -38,10 +38,29 @@ constexpr uint8_t kNoInformation = 255;
 constexpr double kOutOfBounds = -1.0;
 // Marker namespace for the operator-feedback MarkerArray (CAMP auto-discovers it).
 constexpr char kVizNamespace[] = "survey_obstacle_avoidance";
-// Dynamic ROS parameter (declared on the bt_navigator node) for the avoidance
-// speed, so it is tunable live with `ros2 param set` / rqt_reconfigure. The
-// avoid_speed BT port seeds its initial value on first tick.
-constexpr char kAvoidSpeedParam[] = "survey_avoidance_speed";
+
+// Live tunables are declared as ROS params `survey_avoidance.<port>` on the
+// bt_navigator node (grouped so rqt_reconfigure clusters them), seeded from the
+// matching BT port on first tick and authoritative thereafter. The suffix here
+// MUST match the BT port name (the seed is read via getInput(suffix)).
+constexpr char kParamNs[] = "survey_avoidance.";
+struct ParamSeed
+{
+  const char * name;     // BT port name == param suffix
+  double fallback;       // used if the port itself is unset
+  const char * description;
+};
+constexpr ParamSeed kParamSeeds[] = {
+  {"max_deviation", 6.0, "Max metres the line may bend off-course; also the give-up bound."},
+  {"along_track_spacing", 2.0, "Waypoint spacing along the line (m)."},
+  {"lateral_resolution", 0.5, "Cross-track search resolution (m)."},
+  {"line_following_weight", 1.0, "Higher = hug the survey line more strongly."},
+  {"obstacle_avoidance_weight", 0.02, "Higher = deviate more strongly around obstacles."},
+  {"smoothness_weight", 2.0, "Higher = smoother detours (penalise sharp lateral changes)."},
+  {"chatter_damping_weight", 0.0, "Higher = steadier path tick-to-tick (anti-chatter)."},
+  {"max_lateral_change", 1.0, "Max cross-track change between adjacent waypoints (m)."},
+  {"avoid_speed", 0.0, "Speed (m/s) through the manoeuvre via per-pose stamps; 0 = controller default."},
+};
 // Empty stand-in for the temporal term's "previous offsets" when there is no
 // matching prior tick — an lvalue, so the DP-input ref binds without a per-tick copy.
 const std::vector<double> kEmptyOffsets;
@@ -398,22 +417,28 @@ BT::PortsList AdjustPathForObstacles::providedPorts()
     BT::InputPort<std::string>(
       "costmap_topic", "local_costmap/costmap_raw",
       "nav2_msgs/Costmap topic supplying the obstacle field."),
+    // Tunables. Each port seeds the live ROS param `survey_avoidance.<name>` on
+    // first tick; the param is authoritative thereafter (rqt_reconfigure /
+    // `ros2 param set`). See kParamSeeds.
     BT::InputPort<double>(
-      "max_xte", 6.0,
-      "Corridor half-width (m): max deviation, and the give-up bound. Baseline "
-      "param; wire to a task-derived value for a per-line override."),
-    BT::InputPort<double>("station_step", 2.0, "Along-track resample spacing (m)."),
-    BT::InputPort<double>("lateral_step", 0.5, "Cross-track offset resolution (m)."),
-    BT::InputPort<double>("w_xte", 1.0, "Restoring-spring weight on d^2."),
-    BT::InputPort<double>("w_obs", 0.02, "Weight on graded obstacle cost."),
-    BT::InputPort<double>("w_smooth", 2.0, "Smoothness weight on (d_i - d_{i-1})^2."),
-    BT::InputPort<double>("w_temporal", 0.0, "Chatter-damping weight vs last tick."),
-    BT::InputPort<double>("max_lateral_rate", 1.0, "Max |d| change between stations (m)."),
+      "max_deviation", 6.0,
+      "Max metres the line may bend off-course; also the give-up bound."),
+    BT::InputPort<double>("along_track_spacing", 2.0, "Waypoint spacing along the line (m)."),
+    BT::InputPort<double>("lateral_resolution", 0.5, "Cross-track search resolution (m)."),
+    BT::InputPort<double>(
+      "line_following_weight", 1.0, "Higher = hug the survey line more strongly."),
+    BT::InputPort<double>(
+      "obstacle_avoidance_weight", 0.02, "Higher = deviate more strongly around obstacles."),
+    BT::InputPort<double>(
+      "smoothness_weight", 2.0, "Higher = smoother detours (penalise sharp lateral changes)."),
+    BT::InputPort<double>(
+      "chatter_damping_weight", 0.0, "Higher = steadier path tick-to-tick (anti-chatter)."),
+    BT::InputPort<double>(
+      "max_lateral_change", 1.0, "Max cross-track change between adjacent waypoints (m)."),
     BT::InputPort<double>(
       "avoid_speed", 0.0,
-      "Initial speed (m/s) through the avoidance manoeuvre (via per-pose "
-      "timestamps); 0 disables. Seeds the live ROS param 'survey_avoidance_speed' "
-      "on the bt_navigator node, which is authoritative thereafter."),
+      "Speed (m/s) through the avoidance manoeuvre (via per-pose timestamps); "
+      "0 disables (controller default speed)."),
   };
 }
 
@@ -446,18 +471,20 @@ BT::NodeStatus AdjustPathForObstacles::tick()
       });
     viz_pub_ = node->create_publisher<visualization_msgs::msg::MarkerArray>(
       "survey_obstacle_avoidance", rclcpp::QoS(1));
-    // Expose avoid_speed as a live-tunable ROS parameter on the bt_navigator
-    // node, seeded from the BT port. Thereafter the parameter is authoritative
-    // (`ros2 param set <bt_navigator> survey_avoidance_speed <m/s>`), so the
-    // manoeuvre speed can be tuned without redeploying the BT. has_parameter
-    // guards re-declaration across tree reloads / a yaml override.
-    if (!node->has_parameter(kAvoidSpeedParam)) {
-      rcl_interfaces::msg::ParameterDescriptor desc;
-      desc.description =
-        "Speed (m/s) through the survey-line obstacle-avoidance manoeuvre; "
-        "0 disables (controller keeps its default speed).";
-      node->declare_parameter(
-        kAvoidSpeedParam, getInput<double>("avoid_speed").value_or(0.0), desc);
+    // Expose every tunable as a live `survey_avoidance.<name>` ROS parameter on
+    // the bt_navigator node, seeded from the matching BT port. The params are
+    // authoritative thereafter, so the whole avoider tunes without redeploying
+    // the BT (`ros2 param set <bt_navigator> survey_avoidance.<name> <value>` /
+    // rqt_reconfigure). has_parameter guards re-declaration across tree reloads
+    // and honours a params-yaml override.
+    for (const auto & ps : kParamSeeds) {
+      const std::string full = std::string(kParamNs) + ps.name;
+      if (!node->has_parameter(full)) {
+        rcl_interfaces::msg::ParameterDescriptor desc;
+        desc.description = ps.description;
+        node->declare_parameter(
+          full, getInput<double>(ps.name).value_or(ps.fallback), desc);
+      }
     }
   }
 
@@ -521,15 +548,21 @@ BT::NodeStatus AdjustPathForObstacles::tick()
     }
   }
 
-  const double station_step = getInput<double>("station_step").value_or(2.0);
+  // Read the live tunables from the survey_avoidance.* ROS params (declared +
+  // seeded on first tick); the internal CorridorParams keep their terse math
+  // names. get_p resolves `survey_avoidance.<suffix>`.
+  auto get_p = [&](const char * suffix) {
+      return node->get_parameter(std::string(kParamNs) + suffix).as_double();
+    };
+  const double station_step = get_p("along_track_spacing");
   CorridorParams params;
-  params.max_xte = getInput<double>("max_xte").value_or(6.0);
-  params.lateral_step = getInput<double>("lateral_step").value_or(0.5);
-  params.w_xte = getInput<double>("w_xte").value_or(1.0);
-  params.w_obs = getInput<double>("w_obs").value_or(0.02);
-  params.w_smooth = getInput<double>("w_smooth").value_or(2.0);
-  params.w_temporal = getInput<double>("w_temporal").value_or(0.0);
-  params.max_lateral_rate = getInput<double>("max_lateral_rate").value_or(1.0);
+  params.max_xte = get_p("max_deviation");
+  params.lateral_step = get_p("lateral_resolution");
+  params.w_xte = get_p("line_following_weight");
+  params.w_obs = get_p("obstacle_avoidance_weight");
+  params.w_smooth = get_p("smoothness_weight");
+  params.w_temporal = get_p("chatter_damping_weight");
+  params.max_lateral_rate = get_p("max_lateral_change");
 
   const auto stations = resampleStations(nominal.poses, station_step);
   if (stations.size() < 3) {
@@ -678,10 +711,8 @@ BT::NodeStatus AdjustPathForObstacles::tick()
 
   // Optional slow-down through the manoeuvre (off by default): stamp the
   // deviating run so the controller commands the avoidance speed there. Read
-  // from the live ROS parameter (seeded from the avoid_speed port on first tick).
-  double avoid_speed = 0.0;
-  node->get_parameter(kAvoidSpeedParam, avoid_speed);
-  applyAvoidanceSlowdown(out, *solved, avoid_speed, kDeviationEpsilon);
+  // from the live `survey_avoidance.avoid_speed` param (seeded from the port).
+  applyAvoidanceSlowdown(out, *solved, get_p("avoid_speed"), kDeviationEpsilon);
   setOutput("path", out);
 
   // Operator feedback: show the deviation in CAMP (nominal line, adjusted path,

--- a/marine_nav_behavior_tree/src/plugins/action/adjust_path_for_obstacles.cpp
+++ b/marine_nav_behavior_tree/src/plugins/action/adjust_path_for_obstacles.cpp
@@ -91,7 +91,16 @@ std::optional<std::vector<double>> solveCorridorOffsets(
   // node_cost(i, j): finite only for admissible (station, offset) pairs.
   auto node_cost = [&](std::size_t i, std::size_t j) -> double {
     if (pinned_to_zero(i)) {
-      return j == zero_col ? 0.0 : kInf;
+      if (j != zero_col) {
+        return kInf;
+      }
+      // A pinned station is forced to d=0, but it must still respect a lethal
+      // cell there — otherwise an anchor re-joining the line on top of an
+      // obstacle would be reported as a clear corridor. (Out-of-active-range
+      // rows hold 0.0 and are unaffected; the active endpoints carry real
+      // sampled cost.) Lethal anchor => no finite path => caller passes nominal
+      // through and the reflex layer is the backstop.
+      return obstacle_costs[i][zero_col] >= params.lethal_cost ? kInf : 0.0;
     }
     const double cost = obstacle_costs[i][j];
     if (cost >= params.lethal_cost) {

--- a/marine_nav_behavior_tree/src/plugins/action/adjust_path_for_obstacles.cpp
+++ b/marine_nav_behavior_tree/src/plugins/action/adjust_path_for_obstacles.cpp
@@ -283,15 +283,18 @@ BT::NodeStatus AdjustPathForObstacles::tick()
   // Lazy-create the costmap subscription on first tick (the topic port and the
   // blackboard node are only reliably readable once the tree is wired). The
   // callback runs on the bt_navigator executor thread, distinct from this tick
-  // thread — hence the mutex + shared_ptr swap.
+  // thread — hence the mutex + shared_ptr swap. The lambda captures the shared
+  // cache (not `this`), so a callback still in flight on the executor thread when
+  // this node is destroyed (tree reload / shutdown) touches live state, not freed.
   if (!costmap_sub_) {
     costmap_topic_ = getInput<std::string>("costmap_topic").value_or(
       "local_costmap/costmap_raw");
+    auto cache = costmap_cache_;
     costmap_sub_ = node->create_subscription<nav2_msgs::msg::Costmap>(
       costmap_topic_, rclcpp::QoS(1),
-      [this](nav2_msgs::msg::Costmap::SharedPtr msg) {
-        std::lock_guard<std::mutex> lock(costmap_mutex_);
-        costmap_ = msg;
+      [cache](nav2_msgs::msg::Costmap::SharedPtr msg) {
+        std::lock_guard<std::mutex> lock(cache->mutex);
+        cache->costmap = msg;
       });
   }
 
@@ -308,8 +311,8 @@ BT::NodeStatus AdjustPathForObstacles::tick()
   // Snapshot the latest costmap (pointer copy under the lock; DP reads it lock-free).
   std::shared_ptr<nav2_msgs::msg::Costmap> costmap;
   {
-    std::lock_guard<std::mutex> lock(costmap_mutex_);
-    costmap = costmap_;
+    std::lock_guard<std::mutex> lock(costmap_cache_->mutex);
+    costmap = costmap_cache_->costmap;
   }
   if (!costmap) {
     return passthrough();  // no costmap yet

--- a/marine_nav_behavior_tree/src/plugins/action/adjust_path_for_obstacles.cpp
+++ b/marine_nav_behavior_tree/src/plugins/action/adjust_path_for_obstacles.cpp
@@ -245,6 +245,49 @@ std::vector<Station> resampleStations(
   return stations;
 }
 
+void applyAvoidanceSlowdown(
+  nav_msgs::msg::Path & path, const std::vector<double> & offsets_d,
+  double avoid_speed, double deviation_epsilon)
+{
+  const std::size_t n = path.poses.size();
+  if (avoid_speed <= 0.0 || n != offsets_d.size() || n < 2) {
+    return;
+  }
+
+  // Contiguous deviating run [first, last].
+  std::size_t first = n;
+  std::size_t last = 0;
+  for (std::size_t i = 0; i < n; ++i) {
+    if (std::abs(offsets_d[i]) >= deviation_epsilon) {
+      if (first == n) {
+        first = i;
+      }
+      last = i;
+    }
+  }
+  if (first >= last) {
+    return;  // need >= 2 poses to form a stamped segment
+  }
+
+  // Non-zero base (1 s) so the controller treats the stamps as valid; only the
+  // deltas carry meaning, and they are derived from geometry + speed (no wall
+  // clock), so a held detour yields identical stamps tick-to-tick.
+  constexpr int64_t kBaseNs = 1000000000LL;
+  constexpr int64_t kNsPerS = 1000000000LL;
+  double cum_s = 0.0;
+  for (std::size_t i = first; i <= last; ++i) {
+    if (i > first) {
+      const double d = std::hypot(
+        path.poses[i].pose.position.x - path.poses[i - 1].pose.position.x,
+        path.poses[i].pose.position.y - path.poses[i - 1].pose.position.y);
+      cum_s += d / avoid_speed;
+    }
+    const int64_t ns = kBaseNs + static_cast<int64_t>(cum_s * 1e9);
+    path.poses[i].header.stamp.sec = static_cast<int32_t>(ns / kNsPerS);
+    path.poses[i].header.stamp.nanosec = static_cast<uint32_t>(ns % kNsPerS);
+  }
+}
+
 namespace
 {
 // Build the operator-feedback overlay for a deviating tick: the nominal survey
@@ -361,6 +404,10 @@ BT::PortsList AdjustPathForObstacles::providedPorts()
     BT::InputPort<double>("w_smooth", 2.0, "Smoothness weight on (d_i - d_{i-1})^2."),
     BT::InputPort<double>("w_temporal", 0.0, "Chatter-damping weight vs last tick."),
     BT::InputPort<double>("max_lateral_rate", 1.0, "Max |d| change between stations (m)."),
+    BT::InputPort<double>(
+      "avoid_speed", 0.0,
+      "Optional speed (m/s) through the avoidance manoeuvre, applied via per-pose "
+      "timestamps; 0 disables (controller keeps its default speed)."),
   };
 }
 
@@ -609,6 +656,11 @@ BT::NodeStatus AdjustPathForObstacles::tick()
     p.pose.orientation = tf2::toMsg(q);
     out.poses.push_back(p);
   }
+
+  // Optional slow-down through the manoeuvre (off by default): stamp the
+  // deviating run so the controller commands `avoid_speed` there.
+  const double avoid_speed = getInput<double>("avoid_speed").value_or(0.0);
+  applyAvoidanceSlowdown(out, *solved, avoid_speed, kDeviationEpsilon);
   setOutput("path", out);
 
   // Operator feedback: show the deviation in CAMP (nominal line, adjusted path,

--- a/marine_nav_behavior_tree/src/plugins/action/adjust_path_for_obstacles.cpp
+++ b/marine_nav_behavior_tree/src/plugins/action/adjust_path_for_obstacles.cpp
@@ -73,11 +73,17 @@ std::vector<double> makeLateralOffsets(double max_xte, double lateral_step)
     offsets.push_back(0.0);
     return offsets;
   }
-  const int n_each = static_cast<int>(std::round(max_xte / lateral_step));
+  // Floor (not round) so the extreme offset n_each*lateral_step never exceeds
+  // max_xte — max_xte is a hard corridor half-width, and with live params it can
+  // be set to any value, not just a multiple of lateral_step. The +1e-9 guards an
+  // exact multiple from under-flooring on fp error. A corridor narrower than one
+  // lateral_step yields only {0.0} (no deviation) — by design: lower
+  // lateral_resolution to use a sub-step corridor.
+  const int n_each = static_cast<int>(std::floor(max_xte / lateral_step + 1e-9));
   for (int k = -n_each; k <= n_each; ++k) {
     offsets.push_back(k * lateral_step);
   }
-  // Guarantee an exact 0.0 centre even if rounding nudged it.
+  // Guarantee an exact 0.0 centre even if fp nudged it.
   if (n_each >= 0) {
     offsets[n_each] = 0.0;
   }
@@ -375,15 +381,21 @@ visualization_msgs::msg::MarkerArray buildAvoidanceMarkers(
   }
   arr.markers.push_back(adjusted_m);
 
-  // 3) Avoiding band: the deviating stretch, red and thick, drawn on top.
-  auto band_m = base(2, visualization_msgs::msg::Marker::LINE_STRIP, 1.6,
+  // 3) Avoiding band: the deviating stretch(es), red and thick, drawn on top.
+  // LINE_LIST (not LINE_STRIP) of consecutive deviating pairs, so two separate
+  // deviating runs (e.g. two obstacles) aren't joined by a straight line across
+  // the on-line gap between them.
+  auto band_m = base(2, visualization_msgs::msg::Marker::LINE_LIST, 1.6,
       1.0, 0.15, 0.1, 0.9);
-  for (std::size_t i = 0; i < stations.size(); ++i) {
-    if (std::abs(offsets_d[i]) >= kDeviationEpsilon) {
+  for (std::size_t i = 0; i + 1 < stations.size(); ++i) {
+    if (std::abs(offsets_d[i]) >= kDeviationEpsilon &&
+      std::abs(offsets_d[i + 1]) >= kDeviationEpsilon)
+    {
       band_m.points.push_back(adjusted_point(i));
+      band_m.points.push_back(adjusted_point(i + 1));
     }
   }
-  if (band_m.points.size() >= 2) {  // a 1-point LINE_STRIP renders nothing
+  if (!band_m.points.empty()) {
     arr.markers.push_back(band_m);
   }
 
@@ -494,6 +506,10 @@ BT::NodeStatus AdjustPathForObstacles::tick()
     if (was_avoiding_ && viz_pub_) {
       visualization_msgs::msg::MarkerArray arr;
       visualization_msgs::msg::Marker del;
+      // Give the DELETEALL a valid header — some marker consumers (RViz/CAMP)
+      // warn on or drop markers with an empty frame_id even for a delete.
+      del.header.frame_id = config().blackboard->get<std::string>("robot_frame");
+      del.header.stamp = node->now();
       del.ns = kVizNamespace;
       del.action = visualization_msgs::msg::Marker::DELETEALL;
       arr.markers.push_back(del);

--- a/marine_nav_behavior_tree/src/plugins/action/adjust_path_for_obstacles.cpp
+++ b/marine_nav_behavior_tree/src/plugins/action/adjust_path_for_obstacles.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "builtin_interfaces/msg/time.hpp"
+#include "rcl_interfaces/msg/parameter_descriptor.hpp"
 #include "visualization_msgs/msg/marker_array.hpp"
 
 #include <tf2/LinearMath/Quaternion.h>  // NOLINT(build/include_order)
@@ -37,6 +38,10 @@ constexpr uint8_t kNoInformation = 255;
 constexpr double kOutOfBounds = -1.0;
 // Marker namespace for the operator-feedback MarkerArray (CAMP auto-discovers it).
 constexpr char kVizNamespace[] = "survey_obstacle_avoidance";
+// Dynamic ROS parameter (declared on the bt_navigator node) for the avoidance
+// speed, so it is tunable live with `ros2 param set` / rqt_reconfigure. The
+// avoid_speed BT port seeds its initial value on first tick.
+constexpr char kAvoidSpeedParam[] = "survey_avoidance_speed";
 // Empty stand-in for the temporal term's "previous offsets" when there is no
 // matching prior tick — an lvalue, so the DP-input ref binds without a per-tick copy.
 const std::vector<double> kEmptyOffsets;
@@ -406,8 +411,9 @@ BT::PortsList AdjustPathForObstacles::providedPorts()
     BT::InputPort<double>("max_lateral_rate", 1.0, "Max |d| change between stations (m)."),
     BT::InputPort<double>(
       "avoid_speed", 0.0,
-      "Optional speed (m/s) through the avoidance manoeuvre, applied via per-pose "
-      "timestamps; 0 disables (controller keeps its default speed)."),
+      "Initial speed (m/s) through the avoidance manoeuvre (via per-pose "
+      "timestamps); 0 disables. Seeds the live ROS param 'survey_avoidance_speed' "
+      "on the bt_navigator node, which is authoritative thereafter."),
   };
 }
 
@@ -440,6 +446,19 @@ BT::NodeStatus AdjustPathForObstacles::tick()
       });
     viz_pub_ = node->create_publisher<visualization_msgs::msg::MarkerArray>(
       "survey_obstacle_avoidance", rclcpp::QoS(1));
+    // Expose avoid_speed as a live-tunable ROS parameter on the bt_navigator
+    // node, seeded from the BT port. Thereafter the parameter is authoritative
+    // (`ros2 param set <bt_navigator> survey_avoidance_speed <m/s>`), so the
+    // manoeuvre speed can be tuned without redeploying the BT. has_parameter
+    // guards re-declaration across tree reloads / a yaml override.
+    if (!node->has_parameter(kAvoidSpeedParam)) {
+      rcl_interfaces::msg::ParameterDescriptor desc;
+      desc.description =
+        "Speed (m/s) through the survey-line obstacle-avoidance manoeuvre; "
+        "0 disables (controller keeps its default speed).";
+      node->declare_parameter(
+        kAvoidSpeedParam, getInput<double>("avoid_speed").value_or(0.0), desc);
+    }
   }
 
   // Wipe the avoidance overlay once on the avoiding->clear transition (idle ticks
@@ -658,8 +677,10 @@ BT::NodeStatus AdjustPathForObstacles::tick()
   }
 
   // Optional slow-down through the manoeuvre (off by default): stamp the
-  // deviating run so the controller commands `avoid_speed` there.
-  const double avoid_speed = getInput<double>("avoid_speed").value_or(0.0);
+  // deviating run so the controller commands the avoidance speed there. Read
+  // from the live ROS parameter (seeded from the avoid_speed port on first tick).
+  double avoid_speed = 0.0;
+  node->get_parameter(kAvoidSpeedParam, avoid_speed);
   applyAvoidanceSlowdown(out, *solved, avoid_speed, kDeviationEpsilon);
   setOutput("path", out);
 

--- a/marine_nav_behavior_tree/test/test_adjust_path_for_obstacles.cpp
+++ b/marine_nav_behavior_tree/test/test_adjust_path_for_obstacles.cpp
@@ -1,0 +1,154 @@
+// Unit tests for the pure corridor-solver core of AdjustPathForObstacles:
+// makeLateralOffsets, resampleStations, and solveCorridorOffsets. No ROS — the
+// DP is a free function over a hand-built cost matrix, exercising the three
+// canonical cases the plan calls out: clear -> nominal, blob -> bounded detour
+// that re-anchors, wall -> infeasible (caller passes nominal through).
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <vector>
+
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "marine_nav_behavior_tree/plugins/action/adjust_path_for_obstacles.h"
+
+using marine_nav_behavior_tree::CorridorParams;
+using marine_nav_behavior_tree::makeLateralOffsets;
+using marine_nav_behavior_tree::resampleStations;
+using marine_nav_behavior_tree::solveCorridorOffsets;
+
+namespace
+{
+
+geometry_msgs::msg::PoseStamped makePose(double x, double y, const std::string & frame = "map")
+{
+  geometry_msgs::msg::PoseStamped p;
+  p.header.frame_id = frame;
+  p.pose.position.x = x;
+  p.pose.position.y = y;
+  return p;
+}
+
+double peakAbs(const std::vector<double> & v)
+{
+  double m = 0.0;
+  for (double d : v) {
+    m = std::max(m, std::abs(d));
+  }
+  return m;
+}
+
+}  // namespace
+
+// --- makeLateralOffsets ----------------------------------------------------
+
+TEST(MakeLateralOffsets, SymmetricWithExactZeroCentre)
+{
+  const auto o = makeLateralOffsets(2.0, 0.5);
+  ASSERT_EQ(o.size(), 9u);            // -2 .. 2 step 0.5
+  EXPECT_DOUBLE_EQ(o.front(), -2.0);
+  EXPECT_DOUBLE_EQ(o.back(), 2.0);
+  EXPECT_DOUBLE_EQ(o[4], 0.0);        // exact centre
+}
+
+TEST(MakeLateralOffsets, DegenerateStepYieldsSingleZero)
+{
+  const auto o = makeLateralOffsets(2.0, 0.0);
+  ASSERT_EQ(o.size(), 1u);
+  EXPECT_DOUBLE_EQ(o[0], 0.0);
+}
+
+// --- resampleStations ------------------------------------------------------
+
+TEST(ResampleStations, StraightLineSpacingNormalAndYaw)
+{
+  std::vector<geometry_msgs::msg::PoseStamped> poses = {makePose(0.0, 0.0), makePose(10.0, 0.0)};
+  const auto st = resampleStations(poses, 2.0);
+  ASSERT_GE(st.size(), 2u);
+  EXPECT_NEAR(st.front().x, 0.0, 1e-9);
+  EXPECT_NEAR(st.back().x, 10.0, 1e-9);   // endpoint always anchored
+  // Tangent +x -> left normal (0, 1), yaw 0.
+  EXPECT_NEAR(st.front().nx, 0.0, 1e-9);
+  EXPECT_NEAR(st.front().ny, 1.0, 1e-9);
+  EXPECT_NEAR(st.front().yaw, 0.0, 1e-9);
+}
+
+TEST(ResampleStations, FewerThanTwoPosesYieldsEmpty)
+{
+  std::vector<geometry_msgs::msg::PoseStamped> poses = {makePose(0.0, 0.0)};
+  EXPECT_TRUE(resampleStations(poses, 2.0).empty());
+}
+
+// --- solveCorridorOffsets --------------------------------------------------
+
+namespace
+{
+// 7 stations, 9 offsets; whole line active (ends auto-anchored to 0).
+constexpr std::size_t kN = 7;
+const std::vector<double> kOffsets = makeLateralOffsets(2.0, 0.5);
+
+CorridorParams defaultParams()
+{
+  CorridorParams p;
+  p.max_xte = 2.0;
+  p.lateral_step = 0.5;
+  p.w_xte = 1.0;
+  p.w_obs = 0.02;
+  p.w_smooth = 0.1;
+  p.w_temporal = 0.0;
+  p.max_lateral_rate = 1.0;
+  p.lethal_cost = 253.0;
+  return p;
+}
+}  // namespace
+
+TEST(SolveCorridorOffsets, ClearWaterStaysOnLine)
+{
+  std::vector<std::vector<double>> costs(kN, std::vector<double>(kOffsets.size(), 0.0));
+  const auto r = solveCorridorOffsets(costs, kOffsets, defaultParams(), {}, 0, kN);
+  ASSERT_TRUE(r.has_value());
+  EXPECT_NEAR(peakAbs(*r), 0.0, 1e-9);   // no obstacle, no deviation
+}
+
+TEST(SolveCorridorOffsets, BlobProducesBoundedDetourThatReanchors)
+{
+  std::vector<std::vector<double>> costs(kN, std::vector<double>(kOffsets.size(), 0.0));
+  // Block the centre columns (|d| < 1.0 -> indices 3,4,5) at interior stations
+  // 2,3,4, forcing the path off-centre there.
+  for (std::size_t i = 2; i <= 4; ++i) {
+    for (std::size_t j = 3; j <= 5; ++j) {
+      costs[i][j] = 254.0;  // lethal
+    }
+  }
+  const auto r = solveCorridorOffsets(costs, kOffsets, defaultParams(), {}, 0, kN);
+  ASSERT_TRUE(r.has_value());
+  EXPECT_NEAR(r->front(), 0.0, 1e-9);            // anchored start
+  EXPECT_NEAR(r->back(), 0.0, 1e-9);             // anchored end
+  EXPECT_GE(peakAbs(*r), 1.0 - 1e-9);            // deviated clear of the blob
+  EXPECT_LE(peakAbs(*r), 2.0 + 1e-9);            // within the corridor
+}
+
+TEST(SolveCorridorOffsets, FullWallIsInfeasible)
+{
+  std::vector<std::vector<double>> costs(kN, std::vector<double>(kOffsets.size(), 0.0));
+  for (std::size_t j = 0; j < kOffsets.size(); ++j) {
+    costs[3][j] = 254.0;   // an entire station blocked across the corridor
+  }
+  const auto r = solveCorridorOffsets(costs, kOffsets, defaultParams(), {}, 0, kN);
+  EXPECT_FALSE(r.has_value());
+}
+
+TEST(SolveCorridorOffsets, RespectsLateralRateLimit)
+{
+  std::vector<std::vector<double>> costs(kN, std::vector<double>(kOffsets.size(), 0.0));
+  for (std::size_t i = 2; i <= 4; ++i) {
+    for (std::size_t j = 3; j <= 5; ++j) {
+      costs[i][j] = 254.0;
+    }
+  }
+  const auto r = solveCorridorOffsets(costs, kOffsets, defaultParams(), {}, 0, kN);
+  ASSERT_TRUE(r.has_value());
+  for (std::size_t i = 1; i < r->size(); ++i) {
+    EXPECT_LE(std::abs((*r)[i] - (*r)[i - 1]), 1.0 + 1e-9);  // max_lateral_rate
+  }
+}

--- a/marine_nav_behavior_tree/test/test_adjust_path_for_obstacles.cpp
+++ b/marine_nav_behavior_tree/test/test_adjust_path_for_obstacles.cpp
@@ -6,7 +6,9 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <cmath>
+#include <string>
 #include <vector>
 
 #include "geometry_msgs/msg/pose_stamped.hpp"

--- a/marine_nav_behavior_tree/test/test_adjust_path_for_obstacles.cpp
+++ b/marine_nav_behavior_tree/test/test_adjust_path_for_obstacles.cpp
@@ -12,8 +12,10 @@
 #include <vector>
 
 #include "geometry_msgs/msg/pose_stamped.hpp"
+#include "nav_msgs/msg/path.hpp"
 #include "marine_nav_behavior_tree/plugins/action/adjust_path_for_obstacles.h"
 
+using marine_nav_behavior_tree::applyAvoidanceSlowdown;
 using marine_nav_behavior_tree::CorridorParams;
 using marine_nav_behavior_tree::makeLateralOffsets;
 using marine_nav_behavior_tree::resampleStations;
@@ -170,5 +172,74 @@ TEST(SolveCorridorOffsets, RespectsLateralRateLimit)
   ASSERT_TRUE(r.has_value());
   for (std::size_t i = 1; i < r->size(); ++i) {
     EXPECT_LE(std::abs((*r)[i] - (*r)[i - 1]), 1.0 + 1e-9);  // max_lateral_rate
+  }
+}
+
+// --- applyAvoidanceSlowdown ------------------------------------------------
+
+namespace
+{
+nav_msgs::msg::Path straightPath(int n)
+{
+  // n poses 1 m apart along +x; stamps left zero.
+  nav_msgs::msg::Path path;
+  for (int i = 0; i < n; ++i) {
+    geometry_msgs::msg::PoseStamped p;
+    p.pose.position.x = i * 1.0;
+    path.poses.push_back(p);
+  }
+  return path;
+}
+
+double stampSeconds(const geometry_msgs::msg::PoseStamped & p)
+{
+  return p.header.stamp.sec + p.header.stamp.nanosec * 1e-9;
+}
+}  // namespace
+
+TEST(ApplyAvoidanceSlowdown, StampsDeviatingRunAtTargetSpeed)
+{
+  auto path = straightPath(7);
+  std::vector<double> d(7, 0.0);
+  d[2] = 1.0;
+  d[3] = 1.5;
+  d[4] = 1.0;  // deviating run [2,4]
+
+  applyAvoidanceSlowdown(path, d, 0.5, 0.05);  // 0.5 m/s through the run
+
+  // Outside the run: untouched (zero) stamps.
+  for (int i : {0, 1, 5, 6}) {
+    EXPECT_EQ(path.poses[i].header.stamp.sec, 0);
+    EXPECT_EQ(path.poses[i].header.stamp.nanosec, 0u);
+  }
+  // In the run: non-zero, strictly increasing, implied speed == 0.5 m/s.
+  EXPECT_GT(stampSeconds(path.poses[2]), 0.0);
+  for (int i = 3; i <= 4; ++i) {
+    const double dt = stampSeconds(path.poses[i]) - stampSeconds(path.poses[i - 1]);
+    const double dist = path.poses[i].pose.position.x - path.poses[i - 1].pose.position.x;
+    EXPECT_GT(dt, 0.0);
+    EXPECT_NEAR(dist / dt, 0.5, 1e-6);
+  }
+}
+
+TEST(ApplyAvoidanceSlowdown, DisabledOrNoRunLeavesStampsZero)
+{
+  auto path = straightPath(5);
+  std::vector<double> d(5, 0.0);
+  d[2] = 1.0;  // a deviating pose, but...
+  applyAvoidanceSlowdown(path, d, 0.0, 0.05);  // ...avoid_speed = 0 disables
+  for (const auto & p : path.poses) {
+    EXPECT_EQ(p.header.stamp.sec, 0);
+    EXPECT_EQ(p.header.stamp.nanosec, 0u);
+  }
+
+  // Single deviating pose => no 2-pose segment => no-op even when enabled.
+  auto path2 = straightPath(5);
+  std::vector<double> single(5, 0.0);
+  single[2] = 1.0;
+  applyAvoidanceSlowdown(path2, single, 0.5, 0.05);
+  for (const auto & p : path2.poses) {
+    EXPECT_EQ(p.header.stamp.sec, 0);
+    EXPECT_EQ(p.header.stamp.nanosec, 0u);
   }
 }

--- a/marine_nav_behavior_tree/test/test_adjust_path_for_obstacles.cpp
+++ b/marine_nav_behavior_tree/test/test_adjust_path_for_obstacles.cpp
@@ -138,6 +138,24 @@ TEST(SolveCorridorOffsets, FullWallIsInfeasible)
   EXPECT_FALSE(r.has_value());
 }
 
+TEST(SolveCorridorOffsets, LethalAnchorIsInfeasible)
+{
+  // A lethal cell on the centreline at an anchor endpoint (here the start
+  // anchor, station 0, centre column 4) must make the corridor infeasible —
+  // a pinned station is forced to d=0, so it cannot route around the obstacle,
+  // and the solver must not report a clear path through it.
+  std::vector<std::vector<double>> costs(kN, std::vector<double>(kOffsets.size(), 0.0));
+  costs[0][4] = 254.0;  // lethal at the start-anchor's d=0 cell
+  const auto r = solveCorridorOffsets(costs, kOffsets, defaultParams(), {}, 0, kN);
+  EXPECT_FALSE(r.has_value());
+
+  // Same at the end anchor (station kN-1).
+  std::vector<std::vector<double>> costs_end(kN, std::vector<double>(kOffsets.size(), 0.0));
+  costs_end[kN - 1][4] = 254.0;
+  const auto r_end = solveCorridorOffsets(costs_end, kOffsets, defaultParams(), {}, 0, kN);
+  EXPECT_FALSE(r_end.has_value());
+}
+
 TEST(SolveCorridorOffsets, RespectsLateralRateLimit)
 {
   std::vector<std::vector<double>> costs(kN, std::vector<double>(kOffsets.size(), 0.0));

--- a/marine_nav_behavior_tree/test/test_adjust_path_for_obstacles.cpp
+++ b/marine_nav_behavior_tree/test/test_adjust_path_for_obstacles.cpp
@@ -62,6 +62,23 @@ TEST(MakeLateralOffsets, DegenerateStepYieldsSingleZero)
   EXPECT_DOUBLE_EQ(o[0], 0.0);
 }
 
+TEST(MakeLateralOffsets, NeverExceedsMaxXteForNonMultiple)
+{
+  // max_xte not an exact multiple of the step: floor, so no offset overshoots
+  // the corridor half-width (1.0 / 0.6 -> {-0.6, 0, 0.6}, NOT ±1.2).
+  const auto o = makeLateralOffsets(1.0, 0.6);
+  ASSERT_EQ(o.size(), 3u);
+  for (double d : o) {
+    EXPECT_LE(std::abs(d), 1.0 + 1e-9);
+  }
+  EXPECT_DOUBLE_EQ(o[1], 0.0);
+
+  // Corridor narrower than one step -> only the centre (no deviation possible).
+  const auto narrow = makeLateralOffsets(0.3, 0.5);
+  ASSERT_EQ(narrow.size(), 1u);
+  EXPECT_DOUBLE_EQ(narrow[0], 0.0);
+}
+
 // --- resampleStations ------------------------------------------------------
 
 TEST(ResampleStations, StraightLineSpacingNormalAndYaw)

--- a/marine_nav_bt_task_navigator/behavior_trees/nav2.btproj
+++ b/marine_nav_bt_task_navigator/behavior_trees/nav2.btproj
@@ -21,6 +21,7 @@
             <input_port name="w_smooth" default="2.0" type="double">Smoothness weight on (d_i - d_{i-1})^2</input_port>
             <input_port name="w_temporal" default="0.0" type="double">Chatter-damping weight vs last tick</input_port>
             <input_port name="max_lateral_rate" default="1.0" type="double">Max |d| change between stations (m)</input_port>
+            <input_port name="avoid_speed" default="0.0" type="double">Optional speed (m/s) through the avoidance manoeuvre via per-pose timestamps; 0 disables</input_port>
         </Action>
         <Condition ID="AllTasksDoneCondition">
             <input_port name="task_list" default="{task_list}" type="std::shared_ptr&lt;marine_nav_tasks::TaskList&gt;">List of tasks to check</input_port>

--- a/marine_nav_bt_task_navigator/behavior_trees/nav2.btproj
+++ b/marine_nav_bt_task_navigator/behavior_trees/nav2.btproj
@@ -13,15 +13,15 @@
             <input_port name="nominal_path" default="{nominal_survey_path}" type="nav_msgs::msg::Path_&lt;std::allocator&lt;void&gt; &gt;">Nominal trackline to reshape around obstacles</input_port>
             <output_port name="path" default="{survey_path}" type="nav_msgs::msg::Path_&lt;std::allocator&lt;void&gt; &gt;">Reshaped path for FollowPath (nominal pass-through when clear/blocked)</output_port>
             <input_port name="costmap_topic" default="local_costmap/costmap_raw" type="std::string">nav2_msgs/Costmap topic supplying the obstacle field</input_port>
-            <input_port name="max_xte" default="6.0" type="double">Corridor half-width (m): max deviation and give-up bound</input_port>
-            <input_port name="station_step" default="2.0" type="double">Along-track resample spacing (m)</input_port>
-            <input_port name="lateral_step" default="0.5" type="double">Cross-track offset resolution (m)</input_port>
-            <input_port name="w_xte" default="1.0" type="double">Restoring-spring weight on d^2</input_port>
-            <input_port name="w_obs" default="0.02" type="double">Weight on graded obstacle cost</input_port>
-            <input_port name="w_smooth" default="2.0" type="double">Smoothness weight on (d_i - d_{i-1})^2</input_port>
-            <input_port name="w_temporal" default="0.0" type="double">Chatter-damping weight vs last tick</input_port>
-            <input_port name="max_lateral_rate" default="1.0" type="double">Max |d| change between stations (m)</input_port>
-            <input_port name="avoid_speed" default="0.0" type="double">Initial speed (m/s) through the avoidance manoeuvre; 0 disables. Seeds live ROS param 'survey_avoidance_speed' (authoritative thereafter)</input_port>
+            <input_port name="max_deviation" default="6.0" type="double">Max metres the line may bend off-course; also the give-up bound</input_port>
+            <input_port name="along_track_spacing" default="2.0" type="double">Waypoint spacing along the line (m)</input_port>
+            <input_port name="lateral_resolution" default="0.5" type="double">Cross-track search resolution (m)</input_port>
+            <input_port name="line_following_weight" default="1.0" type="double">Higher = hug the survey line more strongly</input_port>
+            <input_port name="obstacle_avoidance_weight" default="0.02" type="double">Higher = deviate more strongly around obstacles</input_port>
+            <input_port name="smoothness_weight" default="2.0" type="double">Higher = smoother detours (penalise sharp lateral changes)</input_port>
+            <input_port name="chatter_damping_weight" default="0.0" type="double">Higher = steadier path tick-to-tick (anti-chatter)</input_port>
+            <input_port name="max_lateral_change" default="1.0" type="double">Max cross-track change between adjacent waypoints (m)</input_port>
+            <input_port name="avoid_speed" default="0.0" type="double">Speed (m/s) through the manoeuvre via per-pose timestamps; 0 disables</input_port>
         </Action>
         <Condition ID="AllTasksDoneCondition">
             <input_port name="task_list" default="{task_list}" type="std::shared_ptr&lt;marine_nav_tasks::TaskList&gt;">List of tasks to check</input_port>

--- a/marine_nav_bt_task_navigator/behavior_trees/nav2.btproj
+++ b/marine_nav_bt_task_navigator/behavior_trees/nav2.btproj
@@ -9,6 +9,19 @@
             <input_port name="sub_task_id" default="{sub_task_id}" type="std::string">ID of new sub-task to add to parent task</input_port>
             <input_port name="parent_task" default="{parent_task}" type="std::shared_ptr&lt;marine_nav_tasks::Task&gt;">Parent task to add sub-task to</input_port>
         </Action>
+        <Action ID="AdjustPathForObstacles">
+            <input_port name="nominal_path" default="{nominal_survey_path}" type="nav_msgs::msg::Path_&lt;std::allocator&lt;void&gt; &gt;">Nominal trackline to reshape around obstacles</input_port>
+            <output_port name="path" default="{survey_path}" type="nav_msgs::msg::Path_&lt;std::allocator&lt;void&gt; &gt;">Reshaped path for FollowPath (nominal pass-through when clear/blocked)</output_port>
+            <input_port name="costmap_topic" default="local_costmap/costmap_raw" type="std::string">nav2_msgs/Costmap topic supplying the obstacle field</input_port>
+            <input_port name="max_xte" default="6.0" type="double">Corridor half-width (m): max deviation and give-up bound</input_port>
+            <input_port name="station_step" default="2.0" type="double">Along-track resample spacing (m)</input_port>
+            <input_port name="lateral_step" default="0.5" type="double">Cross-track offset resolution (m)</input_port>
+            <input_port name="w_xte" default="1.0" type="double">Restoring-spring weight on d^2</input_port>
+            <input_port name="w_obs" default="0.02" type="double">Weight on graded obstacle cost</input_port>
+            <input_port name="w_smooth" default="2.0" type="double">Smoothness weight on (d_i - d_{i-1})^2</input_port>
+            <input_port name="w_temporal" default="0.0" type="double">Chatter-damping weight vs last tick</input_port>
+            <input_port name="max_lateral_rate" default="1.0" type="double">Max |d| change between stations (m)</input_port>
+        </Action>
         <Condition ID="AllTasksDoneCondition">
             <input_port name="task_list" default="{task_list}" type="std::shared_ptr&lt;marine_nav_tasks::TaskList&gt;">List of tasks to check</input_port>
         </Condition>

--- a/marine_nav_bt_task_navigator/behavior_trees/nav2.btproj
+++ b/marine_nav_bt_task_navigator/behavior_trees/nav2.btproj
@@ -21,7 +21,7 @@
             <input_port name="w_smooth" default="2.0" type="double">Smoothness weight on (d_i - d_{i-1})^2</input_port>
             <input_port name="w_temporal" default="0.0" type="double">Chatter-damping weight vs last tick</input_port>
             <input_port name="max_lateral_rate" default="1.0" type="double">Max |d| change between stations (m)</input_port>
-            <input_port name="avoid_speed" default="0.0" type="double">Optional speed (m/s) through the avoidance manoeuvre via per-pose timestamps; 0 disables</input_port>
+            <input_port name="avoid_speed" default="0.0" type="double">Initial speed (m/s) through the avoidance manoeuvre; 0 disables. Seeds live ROS param 'survey_avoidance_speed' (authoritative thereafter)</input_port>
         </Action>
         <Condition ID="AllTasksDoneCondition">
             <input_port name="task_list" default="{task_list}" type="std::shared_ptr&lt;marine_nav_tasks::TaskList&gt;">List of tasks to check</input_port>

--- a/marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml
+++ b/marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml
@@ -788,7 +788,7 @@
                   type="double">Max |d| change between stations (m)</input_port>
       <input_port name="avoid_speed"
                   default="0.0"
-                  type="double">Optional speed (m/s) through the avoidance manoeuvre via per-pose timestamps; 0 disables</input_port>
+                  type="double">Initial speed (m/s) through the avoidance manoeuvre; 0 disables. Seeds live ROS param 'survey_avoidance_speed' (authoritative thereafter)</input_port>
     </Action>
     <Action ID="SetPathFromTask">
       <input_port name="end_index"

--- a/marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml
+++ b/marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml
@@ -786,6 +786,9 @@
       <input_port name="max_lateral_rate"
                   default="1.0"
                   type="double">Max |d| change between stations (m)</input_port>
+      <input_port name="avoid_speed"
+                  default="0.0"
+                  type="double">Optional speed (m/s) through the avoidance manoeuvre via per-pose timestamps; 0 disables</input_port>
     </Action>
     <Action ID="SetPathFromTask">
       <input_port name="end_index"

--- a/marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml
+++ b/marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml
@@ -762,33 +762,33 @@
       <input_port name="costmap_topic"
                   default="local_costmap/costmap_raw"
                   type="std::string">nav2_msgs/Costmap topic supplying the obstacle field</input_port>
-      <input_port name="max_xte"
+      <input_port name="max_deviation"
                   default="6.0"
-                  type="double">Corridor half-width (m): max deviation and give-up bound</input_port>
-      <input_port name="station_step"
+                  type="double">Max metres the line may bend off-course; also the give-up bound</input_port>
+      <input_port name="along_track_spacing"
                   default="2.0"
-                  type="double">Along-track resample spacing (m)</input_port>
-      <input_port name="lateral_step"
+                  type="double">Waypoint spacing along the line (m)</input_port>
+      <input_port name="lateral_resolution"
                   default="0.5"
-                  type="double">Cross-track offset resolution (m)</input_port>
-      <input_port name="w_xte"
+                  type="double">Cross-track search resolution (m)</input_port>
+      <input_port name="line_following_weight"
                   default="1.0"
-                  type="double">Restoring-spring weight on d^2</input_port>
-      <input_port name="w_obs"
+                  type="double">Higher = hug the survey line more strongly</input_port>
+      <input_port name="obstacle_avoidance_weight"
                   default="0.02"
-                  type="double">Weight on graded obstacle cost</input_port>
-      <input_port name="w_smooth"
+                  type="double">Higher = deviate more strongly around obstacles</input_port>
+      <input_port name="smoothness_weight"
                   default="2.0"
-                  type="double">Smoothness weight on (d_i - d_{i-1})^2</input_port>
-      <input_port name="w_temporal"
+                  type="double">Higher = smoother detours (penalise sharp lateral changes)</input_port>
+      <input_port name="chatter_damping_weight"
                   default="0.0"
-                  type="double">Chatter-damping weight vs last tick</input_port>
-      <input_port name="max_lateral_rate"
+                  type="double">Higher = steadier path tick-to-tick (anti-chatter)</input_port>
+      <input_port name="max_lateral_change"
                   default="1.0"
-                  type="double">Max |d| change between stations (m)</input_port>
+                  type="double">Max cross-track change between adjacent waypoints (m)</input_port>
       <input_port name="avoid_speed"
                   default="0.0"
-                  type="double">Initial speed (m/s) through the avoidance manoeuvre; 0 disables. Seeds live ROS param 'survey_avoidance_speed' (authoritative thereafter)</input_port>
+                  type="double">Speed (m/s) through the manoeuvre via per-pose timestamps; 0 disables</input_port>
     </Action>
     <Action ID="SetPathFromTask">
       <input_port name="end_index"

--- a/marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml
+++ b/marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml
@@ -401,16 +401,24 @@
                             selected_controller="{selected_controller}"/>
         <SetControllerSpeed speed="{target_speed}"
                             controller_name="{selected_controller}"/>
-        <!-- Refresh {survey_path} every tick so an operator mid-line mission
+        <!-- Refresh {nominal_survey_path} every tick so an operator mid-line mission
              re-send (which updates {current_task} → {survey_line_task} via
              UpdateCurrentTaskData upstream) propagates to FollowPath. Nav2
              FollowPathAction::on_wait_for_result re-reads the path port each
              RUNNING tick, compares against goal_.path, and sets goal_updated_
              on a change → BtActionNode preempts with the new goal. For #35. -->
         <SetPathFromTask end_index="-1"
-                         path="{survey_path}"
+                         path="{nominal_survey_path}"
                          start_index="0"
                          task="{survey_line_task}"/>
+        <!-- Reshape the trackline around obstacles before it reaches FollowPath:
+             corridor solver over the local costmap, anchored to the nominal line.
+             Passes nominal through unchanged when clear or fully blocked. Re-ticked
+             here every loop (the ReactiveSequence IS the monitor); a changed
+             {survey_path} preempts the running FollowPath via the #35 mechanism
+             above. For #30. -->
+        <AdjustPathForObstacles nominal_path="{nominal_survey_path}"
+                                path="{survey_path}"/>
         <!-- Recover transient FollowPath ABORTs (e.g. a momentary progress-checker trip)
              with a short Wait, then retry — up to 3 times. On persistent failure the
              RecoveryNode FAILs up to the dispatch, which records the line failed
@@ -743,6 +751,41 @@
       <input_port name="parameter_suffix"
                   default="default_speed"
                   type="std::string">Parameter suffix appended to controller_name to form the full parameter path (controller_name + "." + parameter_suffix).</input_port>
+    </Action>
+    <Action ID="AdjustPathForObstacles">
+      <input_port name="nominal_path"
+                  default="{nominal_survey_path}"
+                  type="nav_msgs::msg::Path_&lt;std::allocator&lt;void&gt; &gt;">Nominal trackline to reshape around obstacles</input_port>
+      <output_port name="path"
+                   default="{survey_path}"
+                   type="nav_msgs::msg::Path_&lt;std::allocator&lt;void&gt; &gt;">Reshaped path for FollowPath (nominal pass-through when clear/blocked)</output_port>
+      <input_port name="costmap_topic"
+                  default="local_costmap/costmap_raw"
+                  type="std::string">nav2_msgs/Costmap topic supplying the obstacle field</input_port>
+      <input_port name="max_xte"
+                  default="6.0"
+                  type="double">Corridor half-width (m): max deviation and give-up bound</input_port>
+      <input_port name="station_step"
+                  default="2.0"
+                  type="double">Along-track resample spacing (m)</input_port>
+      <input_port name="lateral_step"
+                  default="0.5"
+                  type="double">Cross-track offset resolution (m)</input_port>
+      <input_port name="w_xte"
+                  default="1.0"
+                  type="double">Restoring-spring weight on d^2</input_port>
+      <input_port name="w_obs"
+                  default="0.02"
+                  type="double">Weight on graded obstacle cost</input_port>
+      <input_port name="w_smooth"
+                  default="2.0"
+                  type="double">Smoothness weight on (d_i - d_{i-1})^2</input_port>
+      <input_port name="w_temporal"
+                  default="0.0"
+                  type="double">Chatter-damping weight vs last tick</input_port>
+      <input_port name="max_lateral_rate"
+                  default="1.0"
+                  type="double">Max |d| change between stations (m)</input_port>
     </Action>
     <Action ID="SetPathFromTask">
       <input_port name="end_index"


### PR DESCRIPTION
Closes #30

## Summary

Reactive **corridor path-adjuster** so a survey line keeps covering *around* an
obstacle instead of being lost or mis-marked done — plus a **CAMP overlay** that
makes the boat's reaction visible to the operator. A new BT node,
`AdjustPathForObstacles`, sits between `SetPathFromTask` and `FollowPath` in the
SurveyLine inner ReactiveSequence: it reshapes the followed path around obstacles
sampled from the existing local costmap, anchored to the nominal trackline, and
publishes a marker overlay whenever it deviates.

> **Supersedes the issue's original framing.** #30 proposed pre-decomposing
> tracklines into skippable segments + a deferred-set + return-pass scheduler.
> Design discussion converged on this simpler approach with the same goal and far
> less machinery (no coverage-state node, no scheduler). The issue body has been
> reconciled to match.

## Approach

The cross-track offset `d` **is** the cross-track error by construction, so the
XTE term is analytic (`w_xte·d²`) and shares no costmap budget; obstacle cost is
*sampled* from the existing `local_costmap/costmap_raw` (no new grid). A small
per-station lateral-offset DP finds the minimum-cost `d(s)`:

- **Anchored** at both ends of the active range → a true detour that returns to
  the line. A lethal cell at an anchor makes the corridor infeasible (→ nominal +
  reflex backstop), never a "clear" report.
- **Active range** = stations ahead of the boat and inside the rolling costmap
  window; the rest pass through nominal.
- **Clear → nominal unchanged** (byte-identical, no spurious preemption);
  **fully blocked → nominal unchanged**, degrading to today's reflex-stop →
  `FollowPath` ABORT → `RecoveryNode` → `SetTaskFailed` → pilot.
- The `w_xte·d²` spring means only the obstacle-cost *gradient* moves the path, so
  the 150 m inflation tails can't bow the line; an `INF` floor on inscribed/lethal
  guarantees it never plans into an obstacle body.

The ReactiveSequence re-tick **is** the monitor — a changed `{survey_path}`
preempts the running `FollowPath` via the same `on_wait_for_result` mechanism as
the #35 mid-line re-send. No separate watcher node; the controller
(`CrabbingPathFollower`) stays a pure tracker.

## Operator visualization (CAMP)

Operator-awareness sibling of rolker/unh_echoboats_project11#183 (which covers the
*reflex* Collision Monitor overlay/annunciator); this is the distinct
*deliberative* survey-line adjuster overlay. While deviating, the node publishes a
`visualization_msgs/MarkerArray` on `survey_obstacle_avoidance` — **faint nominal
line + bright adjusted path + red "avoiding" band + an "AVOIDING" text flag**.
CAMP's `MarkersManager` auto-discovers any MarkerArray, so it appears with **no
CAMP-side change**. A `DELETEALL` clears the overlay when the boat rejoins the
line. The obstacle itself is already visible via CAMP's auto-discovered
`local_costmap/costmap` (OccupancyGrid) grid layer.

> **Adjacent bug found, not fixed here**: `CrabbingPathFollower` publishes the
> followed path on `received_global_plan`, but CAMP subscribes to
> `received_global_**path**` (`platform.cpp:103`) and nothing publishes that name.
> CAMP's dedicated path renderer is therefore dead; the marker layers compensate.
> Fixed in rolker/camp#56; the followed path + this overlay are forwarded
> over the udp_bridge in rolker/unh_echoboats_project11#200.

## Optional slow-down through the manoeuvre

`avoid_speed` port (default `0.0` = off). When set and the path deviates,
`applyAvoidanceSlowdown()` writes per-pose timestamps on the deviating run so the
controller commands `avoid_speed` (m/s) there — `CrabbingPathFollower` derives
per-segment speed from `segment_distance / Δstamp` when both endpoint stamps are
non-zero (`crabbing_path_follower.cpp:347-353`). Poses outside the run keep zero
stamps (controller default speed); stamps are geometry-derived from a fixed base,
so a held detour doesn't re-trigger `FollowPath` preemption. Opt-in via `avoid_speed`. **All tunables (this and the corridor weights /
dimensions) are live ROS parameters** under the grouped `survey_avoidance.*`
namespace — each XML port seeds the param on first tick, and the param is the
live knob thereafter, so the whole avoider tunes in sim/field without
redeploying the BT (`ros2 param set <bt_navigator> survey_avoidance.<name> <value>`
/ rqt_reconfigure). Names favour intent: the key ratio is
`line_following_weight` : `obstacle_avoidance_weight` (stay-on-line vs avoid).

## Scope (v1)

No gap tracking / coverage-state / return scheduler — the pilot handles any holes;
the CAMP overlay above is what makes the deviation legible. Coverage-as-state
remains the #29 follow-on.

## Files

| File | Change |
|---|---|
| `marine_nav_behavior_tree/.../adjust_path_for_obstacles.{h,cpp}` | New node + pure DP core + CAMP marker overlay + costmap/pose robustness guards |
| `marine_nav_behavior_tree/test/test_adjust_path_for_obstacles.cpp` | 9 unit tests (no ROS) |
| `marine_nav_behavior_tree/{CMakeLists.txt,package.xml}` | Source/test targets; `nav2_msgs` + `nav_msgs` + `visualization_msgs` deps |
| `marine_nav_behavior_tree/src/bt_register_nodes.cpp` | Register the node |
| `marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml` | Insert node + port rename in SurveyLine; inline `TreeNodesModel` |
| `marine_nav_bt_task_navigator/behavior_trees/nav2.btproj` | Groot palette |

## Review fixes & hardening (from `/review-code` + `/triage-reviews`)

- **Callback-lifetime UAF** (`c6ba027`): the costmap subscription captured `this`
  and runs on the executor thread; moved the cache into a `shared_ptr` captured by
  value so a teardown-time callback can't touch freed state.
- **Lethal-anchor reject** (`e0ae769`): pinned anchors no longer skip the
  lethal-cost check; added `LethalAnchorIsInfeasible` test.
- **Robustness guards** (`fcd02af`): costmap-metadata validation (resolution,
  size, buffer length, identity origin) + pose-lookup-failure passthrough, both
  degrading to nominal rather than misregistering / guessing.

## Test plan

- [x] `marine_nav_behavior_tree` + `marine_nav_bt_task_navigator` build clean
- [x] Node appears in the generated nodes manifest; `run_tasks.xml` + `nav2.btproj` well-formed (`xmllint`)
- [x] 11 gtests pass — clear→on-line, blob→bounded re-anchored detour, wall→infeasible, **lethal-anchor→infeasible**, lateral-rate limit, offset/resample helpers
- [ ] Sim/field tuning of `w_xte:w_obs`, `max_xte`, `max_lateral_rate` (defaults pending)
- [ ] Confirm survey-line pose frame vs costmap `map_tide` in the deployed config (node defaults to TF-transform either way)
- [ ] Eyeball the CAMP overlay in sim (nominal/adjusted/avoiding band + "AVOIDING" flag) on a deviating run

## Notes

- **Costmap source**: `nav2_msgs/Costmap` (`costmap_raw`, 0–254) so the
  inscribed/lethal `INF` floor and `NO_INFORMATION`→free mapping are exact; raw
  index math, no `nav2_costmap_2d` dependency.
- **Build gotcha**: adding a *new* BT node in a worktree trips the POST_BUILD
  nodes-xml generator (overridden-package SONAME shadow loads the stale main
  `.so`). Workaround: prepend the package build dir to `LD_LIBRARY_PATH`. See the
  plan's Implementation Notes; candidate for a durable worktree-build-script fix.

Plan + review timeline: `.agent/work-plans/issue-30/`.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`




