### PR TITLE
Updatable goto override + mid-line resume after override (#52)

### DIFF
--- a/marine_nav_behavior_tree/CMakeLists.txt
+++ b/marine_nav_behavior_tree/CMakeLists.txt
@@ -91,6 +91,7 @@ add_library(${PROJECT_NAME}_bt_plugins SHARED
   src/plugins/condition/all_tasks_done.cpp
   src/plugins/condition/has_sub_tasks.cpp
   src/plugins/condition/path_empty.cpp
+  src/plugins/condition/robot_on_path.cpp
   src/plugins/decorator/restart_on_task_change.cpp
 )
 
@@ -292,6 +293,39 @@ if(BUILD_TESTING)
     ament_target_dependencies(test_hover_reentry
       behaviortree_cpp
       rclcpp
+    )
+  endif()
+
+  ament_add_gtest(test_goto_reentry
+    test/test_goto_reentry.cpp
+  )
+  if(TARGET test_goto_reentry)
+    target_include_directories(test_goto_reentry PRIVATE
+      "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    )
+    target_link_libraries(test_goto_reentry
+      ${PROJECT_NAME}_bt_plugins
+    )
+    ament_target_dependencies(test_goto_reentry
+      behaviortree_cpp
+      rclcpp
+    )
+  endif()
+
+  ament_add_gtest(test_robot_on_path
+    test/test_robot_on_path.cpp
+  )
+  if(TARGET test_robot_on_path)
+    target_include_directories(test_robot_on_path PRIVATE
+      "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    )
+    target_link_libraries(test_robot_on_path
+      ${PROJECT_NAME}_bt_plugins
+    )
+    ament_target_dependencies(test_robot_on_path
+      behaviortree_cpp
+      geometry_msgs
+      nav_msgs
     )
   endif()
 endif()

--- a/marine_nav_behavior_tree/include/marine_nav_behavior_tree/plugins/condition/robot_on_path.h
+++ b/marine_nav_behavior_tree/include/marine_nav_behavior_tree/plugins/condition/robot_on_path.h
@@ -1,0 +1,54 @@
+#ifndef MARINE_NAV_BEHAVIOR_TREE_CONDITIONS_ROBOT_ON_PATH_H
+#define MARINE_NAV_BEHAVIOR_TREE_CONDITIONS_ROBOT_ON_PATH_H
+
+#include <behaviortree_cpp/bt_factory.h>
+#include "geometry_msgs/msg/point.hpp"
+#include "nav_msgs/msg/path.hpp"
+#include "tf2_ros/buffer.hpp"
+
+namespace marine_nav_behavior_tree
+{
+
+/**
+ * @brief Condition that succeeds when the robot is within `threshold` metres of
+ * `path` (perpendicular distance to the nearest segment of the polyline).
+ *
+ * Motivation (#52): `TransitAndSurveyLine` unconditionally leads in to the survey
+ * line's first waypoint on every entry. After an override (hover park / goto
+ * nudge) halts and the survey-line case re-enters, that lead-in drives the boat
+ * back to the line start and re-runs the whole line. Gating the lead-in on this
+ * condition lets a resume skip the transit when the boat is already on the line —
+ * the path-following controller (`CrabbingPathFollower`) then resumes from the
+ * boat's current position. On a genuine fresh entry the boat is not yet on the
+ * line, so the lead-in runs as before.
+ *
+ * Degrades safely: a missing TF (cannot determine the robot pose) or an empty
+ * path returns FAILURE, preserving the existing transit-to-start behaviour.
+ */
+class RobotOnPath : public BT::ConditionNode
+{
+public:
+  RobotOnPath(const std::string & name, const BT::NodeConfig & config);
+
+  static BT::PortsList providedPorts()
+  {
+    return {
+      BT::InputPort<nav_msgs::msg::Path>("path", "{survey_path}", "Path to test proximity to"),
+      BT::InputPort<double>("threshold", "Maximum distance (m) from the path to count as 'on' it"),
+      BT::InputPort<std::shared_ptr<tf2_ros::Buffer>>("tf_buffer", "{tf_buffer}", "TF2 buffer"),
+      BT::InputPort<std::string>("robot_frame", "{robot_frame}", "Robot base frame"),
+    };
+  }
+
+  BT::NodeStatus tick() override;
+
+  /// Minimum distance from `point` to the polyline through `path.poses`, in the
+  /// XY plane. Returns -1.0 for an empty path (no meaningful distance). Static so
+  /// the geometry can be unit-tested without a TF fixture.
+  static double minDistanceToPath(
+    const geometry_msgs::msg::Point & point, const nav_msgs::msg::Path & path);
+};
+
+}  // namespace marine_nav_behavior_tree
+
+#endif

--- a/marine_nav_behavior_tree/include/marine_nav_behavior_tree/plugins/condition/robot_on_path.h
+++ b/marine_nav_behavior_tree/include/marine_nav_behavior_tree/plugins/condition/robot_on_path.h
@@ -1,5 +1,8 @@
-#ifndef MARINE_NAV_BEHAVIOR_TREE_CONDITIONS_ROBOT_ON_PATH_H
-#define MARINE_NAV_BEHAVIOR_TREE_CONDITIONS_ROBOT_ON_PATH_H
+#ifndef MARINE_NAV_BEHAVIOR_TREE__PLUGINS__CONDITION__ROBOT_ON_PATH_H_
+#define MARINE_NAV_BEHAVIOR_TREE__PLUGINS__CONDITION__ROBOT_ON_PATH_H_
+
+#include <memory>
+#include <string>
 
 #include <behaviortree_cpp/bt_factory.h>
 #include "geometry_msgs/msg/point.hpp"
@@ -51,4 +54,4 @@ public:
 
 }  // namespace marine_nav_behavior_tree
 
-#endif
+#endif  // MARINE_NAV_BEHAVIOR_TREE__PLUGINS__CONDITION__ROBOT_ON_PATH_H_

--- a/marine_nav_behavior_tree/src/bt_register_nodes.cpp
+++ b/marine_nav_behavior_tree/src/bt_register_nodes.cpp
@@ -24,6 +24,7 @@
 #include "marine_nav_behavior_tree/plugins/condition/all_tasks_done.h"
 #include "marine_nav_behavior_tree/plugins/condition/has_sub_tasks.h"
 #include "marine_nav_behavior_tree/plugins/condition/path_empty.h"
+#include "marine_nav_behavior_tree/plugins/condition/robot_on_path.h"
 
 #include "marine_nav_behavior_tree/plugins/decorator/restart_on_task_change.h"
 
@@ -90,6 +91,7 @@ BT_REGISTER_NODES(factory)
   factory.registerNodeType<marine_nav_behavior_tree::AllTasksDone>("AllTasksDoneCondition");
   factory.registerNodeType<marine_nav_behavior_tree::HasSubTasks>("HasSubTasksCondition");
   factory.registerNodeType<marine_nav_behavior_tree::PathEmpty>("PathEmptyCondition");
+  factory.registerNodeType<marine_nav_behavior_tree::RobotOnPath>("RobotOnPath");
 
   factory.registerNodeType<marine_nav_behavior_tree::RestartOnTaskChange>("RestartOnTaskChange");
 

--- a/marine_nav_behavior_tree/src/plugins/condition/robot_on_path.cpp
+++ b/marine_nav_behavior_tree/src/plugins/condition/robot_on_path.cpp
@@ -1,0 +1,102 @@
+#include "marine_nav_behavior_tree/plugins/condition/robot_on_path.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+#include "nav2_util/robot_utils.hpp"
+
+namespace marine_nav_behavior_tree
+{
+
+RobotOnPath::RobotOnPath(const std::string & name, const BT::NodeConfig & config)
+: BT::ConditionNode(name, config)
+{
+}
+
+namespace
+{
+// Distance from point (px, py) to the segment [(ax, ay), (bx, by)] in the XY plane.
+double distancePointToSegment(
+  double px, double py, double ax, double ay, double bx, double by)
+{
+  const double dx = bx - ax;
+  const double dy = by - ay;
+  const double seg_len_sq = dx * dx + dy * dy;
+  double t = 0.0;
+  if (seg_len_sq > 0.0) {
+    // Projection parameter of the point onto the segment, clamped to [0, 1] so a
+    // point beyond either end measures to the nearer endpoint.
+    t = ((px - ax) * dx + (py - ay) * dy) / seg_len_sq;
+    t = std::max(0.0, std::min(1.0, t));
+  }
+  const double cx = ax + t * dx;
+  const double cy = ay + t * dy;
+  return std::hypot(px - cx, py - cy);
+}
+}  // namespace
+
+double RobotOnPath::minDistanceToPath(
+  const geometry_msgs::msg::Point & point, const nav_msgs::msg::Path & path)
+{
+  const auto & poses = path.poses;
+  if (poses.empty()) {
+    return -1.0;
+  }
+  if (poses.size() == 1) {
+    return std::hypot(
+      point.x - poses.front().pose.position.x,
+      point.y - poses.front().pose.position.y);
+  }
+  double min_dist = std::numeric_limits<double>::max();
+  for (std::size_t i = 0; i + 1 < poses.size(); ++i) {
+    const double d = distancePointToSegment(
+      point.x, point.y,
+      poses[i].pose.position.x, poses[i].pose.position.y,
+      poses[i + 1].pose.position.x, poses[i + 1].pose.position.y);
+    min_dist = std::min(min_dist, d);
+  }
+  return min_dist;
+}
+
+BT::NodeStatus RobotOnPath::tick()
+{
+  auto path_bb = getInput<nav_msgs::msg::Path>("path");
+  if (!path_bb) {
+    throw BT::RuntimeError(name(), " missing required input [path]: ", path_bb.error());
+  }
+  auto threshold_bb = getInput<double>("threshold");
+  if (!threshold_bb) {
+    throw BT::RuntimeError(name(), " missing required input [threshold]: ", threshold_bb.error());
+  }
+  auto tf_buffer_bb = getInput<std::shared_ptr<tf2_ros::Buffer>>("tf_buffer");
+  if (!tf_buffer_bb) {
+    throw BT::RuntimeError(name(), " missing required input [tf_buffer]: ", tf_buffer_bb.error());
+  }
+  auto robot_frame_bb = getInput<std::string>("robot_frame");
+  if (!robot_frame_bb) {
+    throw BT::RuntimeError(name(), " missing required input [robot_frame]: ", robot_frame_bb.error());
+  }
+
+  const auto & path = path_bb.value();
+  if (path.poses.empty()) {
+    // No line to be "on" → fall back to the lead-in (which will also be a no-op).
+    return BT::NodeStatus::FAILURE;
+  }
+
+  geometry_msgs::msg::PoseStamped current_pose;
+  if (!nav2_util::getCurrentPose(
+      current_pose, *tf_buffer_bb.value(), path.header.frame_id, robot_frame_bb.value()))
+  {
+    // Cannot determine the robot pose → fall back to the lead-in (transit to start).
+    return BT::NodeStatus::FAILURE;
+  }
+
+  const double dist = minDistanceToPath(current_pose.pose.position, path);
+  if (dist >= 0.0 && dist <= threshold_bb.value()) {
+    return BT::NodeStatus::SUCCESS;
+  }
+  return BT::NodeStatus::FAILURE;
+}
+
+}  // namespace marine_nav_behavior_tree

--- a/marine_nav_behavior_tree/src/plugins/condition/robot_on_path.cpp
+++ b/marine_nav_behavior_tree/src/plugins/condition/robot_on_path.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <memory>
 
 #include "nav2_util/robot_utils.hpp"
 

--- a/marine_nav_behavior_tree/test/test_goto_reentry.cpp
+++ b/marine_nav_behavior_tree/test/test_goto_reentry.cpp
@@ -1,0 +1,140 @@
+// Regression tests for the #52 goto re-command fix.
+//
+// GotoTask wraps its inner Sequence in RestartOnTaskChange (mirroring the hover
+// fix #46). The dispatch Switch keys on task *type*, so re-issuing a goto override
+// (still type 'goto') never halts the branch on its own; without the decorator the
+// Sequence stays parked at the RUNNING GotoPose child, SetPathFromTask is never
+// re-ticked, and the boat keeps driving to the original target.
+//
+// Goto differs from hover in one way that matters here: its final child
+// (GotoPose / NavigateThroughWaypoints) DOES return SUCCESS when the target is
+// reached, whereas Hover holds forever. These tests pin both the re-command
+// behaviour and that the decorator does not interfere with normal completion.
+//
+// Pure BT-mechanics — no ROS fixture. A counting leaf stands in for
+// SetPathFromTask (the per-entry target read); a RUNNING-then-SUCCESS leaf stands
+// in for GotoPose driving to and reaching the target.
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "behaviortree_cpp/bt_factory.h"
+#include "marine_nav_behavior_tree/plugins/decorator/restart_on_task_change.h"
+#include "rclcpp/time.hpp"
+
+namespace
+{
+
+// Counts ticks. Stands in for SetPathFromTask — the work that must re-run on each
+// goto (re-)entry so the new target is read.
+class CountingAction : public BT::SyncActionNode
+{
+public:
+  CountingAction(const std::string & name, const BT::NodeConfig & config)
+  : BT::SyncActionNode(name, config) {}
+  static BT::PortsList providedPorts() { return {}; }
+  static int count;
+  BT::NodeStatus tick() override
+  {
+    ++count;
+    return BT::NodeStatus::SUCCESS;
+  }
+};
+int CountingAction::count = 0;
+
+// RUNNING for a fixed number of ticks, then SUCCESS. Stands in for GotoPose
+// driving to the target and arriving (unlike Hover, which never succeeds).
+class ArrivingLeaf : public BT::StatefulActionNode
+{
+public:
+  ArrivingLeaf(const std::string & name, const BT::NodeConfig & config)
+  : BT::StatefulActionNode(name, config) {}
+  static BT::PortsList providedPorts() { return {}; }
+  static int ticks_until_arrival;
+  BT::NodeStatus onStart() override
+  {
+    remaining_ = ticks_until_arrival;
+    return BT::NodeStatus::RUNNING;
+  }
+  BT::NodeStatus onRunning() override
+  {
+    if (remaining_-- <= 0) {
+      return BT::NodeStatus::SUCCESS;
+    }
+    return BT::NodeStatus::RUNNING;
+  }
+  void onHalted() override {}
+
+private:
+  int remaining_{0};
+};
+int ArrivingLeaf::ticks_until_arrival = 3;
+
+BT::BehaviorTreeFactory makeFactory()
+{
+  BT::BehaviorTreeFactory factory;
+  factory.registerNodeType<CountingAction>("Counter");
+  factory.registerNodeType<ArrivingLeaf>("ArrivingLeaf");
+  factory.registerNodeType<marine_nav_behavior_tree::RestartOnTaskChange>("RestartOnTaskChange");
+  return factory;
+}
+
+// Mirrors GotoTask's inner shape: RestartOnTaskChange[ Sequence[ SetPathFromTask,
+// GotoPose, SetTaskDone ] ]. SetTaskDone is a no-op Counter-free SUCCESS leaf here.
+const char * kGotoShape =
+  R"(<root BTCPP_format="4"><BehaviorTree ID="MainTree">
+       <RestartOnTaskChange task_update_time="{t}">
+         <Sequence><Counter/><ArrivingLeaf/></Sequence>
+       </RestartOnTaskChange>
+     </BehaviorTree></root>)";
+
+const rclcpp::Time T1(10, 0, RCL_ROS_TIME);
+const rclcpp::Time T2(20, 0, RCL_ROS_TIME);
+
+}  // namespace
+
+// A re-issued goto (timestamp bump) while GotoPose is RUNNING re-ticks
+// SetPathFromTask, so the new target is read.
+TEST(GotoReentry, ReissuedGotoRereadsTarget)
+{
+  CountingAction::count = 0;
+  ArrivingLeaf::ticks_until_arrival = 5;
+  auto factory = makeFactory();
+  auto tree = factory.createTreeFromText(kGotoShape);
+
+  tree.rootBlackboard()->set("t", T1);
+  tree.tickOnce();                      // baseline T1; Counter (1); ArrivingLeaf RUNNING
+  EXPECT_EQ(CountingAction::count, 1);
+
+  tree.tickOnce();                      // still driving, t stable → no re-read
+  EXPECT_EQ(CountingAction::count, 1);
+
+  tree.rootBlackboard()->set("t", T2);
+  tree.tickOnce();                      // re-issued goto → restart; Counter (2)
+  EXPECT_EQ(CountingAction::count, 2);
+}
+
+// While the timestamp is stable, the drive to the target is not disturbed: the
+// target is read once and the goto runs to completion.
+TEST(GotoReentry, StableGotoRunsToCompletionWithoutReread)
+{
+  CountingAction::count = 0;
+  ArrivingLeaf::ticks_until_arrival = 3;
+  auto factory = makeFactory();
+  auto tree = factory.createTreeFromText(kGotoShape);
+
+  tree.rootBlackboard()->set("t", T1);
+  BT::NodeStatus status = BT::NodeStatus::RUNNING;
+  for (int i = 0; i < 10 && status == BT::NodeStatus::RUNNING; ++i) {
+    status = tree.tickOnce();
+  }
+  EXPECT_EQ(status, BT::NodeStatus::SUCCESS);   // goto completes normally
+  EXPECT_EQ(CountingAction::count, 1);          // target read exactly once
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/marine_nav_behavior_tree/test/test_robot_on_path.cpp
+++ b/marine_nav_behavior_tree/test/test_robot_on_path.cpp
@@ -1,0 +1,87 @@
+// Unit tests for RobotOnPath's geometry (#52).
+//
+// The tick() wraps a TF pose lookup around minDistanceToPath(); the geometry is
+// factored out as a static method so it can be pinned here without a TF fixture.
+// The point being made for the mid-line-resume fix: distance is to the *nearest
+// segment* of the line, so a boat parked 60 m along a 100 m line reads as "on it"
+// for a few-metre threshold even though it is far from the line's start.
+
+#include <gtest/gtest.h>
+
+#include <utility>
+#include <vector>
+
+#include "marine_nav_behavior_tree/plugins/condition/robot_on_path.h"
+
+using marine_nav_behavior_tree::RobotOnPath;
+
+namespace
+{
+geometry_msgs::msg::Point pt(double x, double y)
+{
+  geometry_msgs::msg::Point p;
+  p.x = x;
+  p.y = y;
+  p.z = 0.0;
+  return p;
+}
+
+nav_msgs::msg::Path makePath(const std::vector<std::pair<double, double>> & pts)
+{
+  nav_msgs::msg::Path path;
+  for (const auto & xy : pts) {
+    geometry_msgs::msg::PoseStamped ps;
+    ps.pose.position.x = xy.first;
+    ps.pose.position.y = xy.second;
+    path.poses.push_back(ps);
+  }
+  return path;
+}
+}  // namespace
+
+TEST(RobotOnPath, EmptyPathReturnsNegative)
+{
+  EXPECT_LT(RobotOnPath::minDistanceToPath(pt(0, 0), makePath({})), 0.0);
+}
+
+TEST(RobotOnPath, SinglePoseIsPointDistance)
+{
+  EXPECT_DOUBLE_EQ(RobotOnPath::minDistanceToPath(pt(0, 0), makePath({{3.0, 4.0}})), 5.0);
+}
+
+TEST(RobotOnPath, OnTheLineIsZero)
+{
+  EXPECT_NEAR(RobotOnPath::minDistanceToPath(pt(5, 0), makePath({{0, 0}, {10, 0}})), 0.0, 1e-9);
+}
+
+TEST(RobotOnPath, PerpendicularDistanceToSegment)
+{
+  EXPECT_NEAR(RobotOnPath::minDistanceToPath(pt(5, 3), makePath({{0, 0}, {10, 0}})), 3.0, 1e-9);
+}
+
+TEST(RobotOnPath, BeyondSegmentEndClampsToVertex)
+{
+  // Point past the far end of the only segment → distance to the (10, 0) vertex.
+  EXPECT_NEAR(RobotOnPath::minDistanceToPath(pt(13, 4), makePath({{0, 0}, {10, 0}})), 5.0, 1e-9);
+}
+
+TEST(RobotOnPath, NearestSegmentOfMultiSegmentLine)
+{
+  // L-shaped line; point is closest to the second segment.
+  auto path = makePath({{0, 0}, {10, 0}, {10, 10}});
+  EXPECT_NEAR(RobotOnPath::minDistanceToPath(pt(8, 5), path), 2.0, 1e-9);
+}
+
+TEST(RobotOnPath, MidLineResumeIsOnTheLine)
+{
+  // The fix's core case: boat ~60 m along a 100 m line, 2 m off it. "On the line"
+  // for a few-metre threshold despite being 60 m from the start.
+  auto path = makePath({{0, 0}, {100, 0}});
+  EXPECT_NEAR(RobotOnPath::minDistanceToPath(pt(60, 2), path), 2.0, 1e-9);
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml
+++ b/marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml
@@ -45,16 +45,27 @@
   <BehaviorTree ID="GotoTask">
     <ReactiveSequence name="GotoTaskReactiveSequence">
       <ScriptCondition code="current_task_type == &apos;goto&apos;"/>
-      <Sequence name="GotoPoseAndSetDoneSequence">
-        <SetPathFromTask end_index="-1"
-                         path="{goal_poses}"
-                         start_index="0"
-                         task="{current_task}"/>
-        <SubTree ID="GotoPose"
-                 _autoremap="true"/>
-        <SetTaskDone name="SetGotoTaskDone"
-                     task="{current_task}"/>
-      </Sequence>
+      <!-- RestartOnTaskChange forces a clean re-entry whenever
+           {current_task_update_time} changes — i.e. the operator re-issues a goto
+           override. The dispatch Switch keys on task *type*, so a same-type
+           re-command does NOT halt this branch on its own; without this decorator
+           the Sequence stays parked at the RUNNING GotoPose child, SetPathFromTask
+           is never re-ticked, and the boat keeps driving to the ORIGINAL target.
+           Mirrors the hover fix (#46); for #52. Must stay the LAST child of the
+           outer ReactiveSequence (a sibling after it would halt this subtree every
+           tick). -->
+      <RestartOnTaskChange task_update_time="{current_task_update_time}">
+        <Sequence name="GotoPoseAndSetDoneSequence">
+          <SetPathFromTask end_index="-1"
+                           path="{goal_poses}"
+                           start_index="0"
+                           task="{current_task}"/>
+          <SubTree ID="GotoPose"
+                   _autoremap="true"/>
+          <SetTaskDone name="SetGotoTaskDone"
+                       task="{current_task}"/>
+        </Sequence>
+      </RestartOnTaskChange>
     </ReactiveSequence>
   </BehaviorTree>
 
@@ -217,6 +228,7 @@
         <Fallback name="GotoOrFailed">
           <SubTree ID="GotoTask"
                    current_task="{current_task}"
+                   current_task_update_time="{current_task_update_time}"
                    lead_in_distance="0.0"
                    server_timeout="{server_timeout}"
                    bt_loop_duration="{bt_loop_duration}"
@@ -501,14 +513,34 @@
 
   <BehaviorTree ID="TransitAndSurveyLine">
     <Sequence>
-      <GetSubPath output_path="{transit_path}"
-                  end_index="0"
-                  start_index="0"
-                  input_path="{survey_path}"/>
-      <Script code="navigation_state := &apos;transit&apos;"/>
-      <SubTree ID="NavigateThroughWaypoints"
-               goals="{transit_path}"
-               _autoremap="true"/>
+      <!-- Lead in to the line's first waypoint UNLESS the boat is already on the
+           line. After an override (hover park / goto nudge) halts and the
+           survey-line case re-enters, the boat is still on the line; skipping the
+           transit lets the path-following controller resume from the boat's
+           current position instead of driving back to the line start and re-running
+           the whole line (inefficient on long lines — e.g. a goto nudge to recover
+           a sonar hiccup). On a genuine fresh entry the boat is not yet on the line,
+           so RobotOnPath fails and the lead-in runs exactly as before. RobotOnPath
+           also degrades to the lead-in on missing TF or an empty path. For #52.
+           threshold is metres of cross-track tolerance — comfortably above survey
+           cross-track error / goto-park positioning error and below the line
+           spacing; tune here if a survey runs lines closer than this. -->
+      <Fallback name="LeadInUnlessOnLine">
+        <RobotOnPath path="{survey_path}"
+                     threshold="5.0"
+                     tf_buffer="{tf_buffer}"
+                     robot_frame="{robot_frame}"/>
+        <Sequence name="LeadInToLineStart">
+          <GetSubPath output_path="{transit_path}"
+                      end_index="0"
+                      start_index="0"
+                      input_path="{survey_path}"/>
+          <Script code="navigation_state := &apos;transit&apos;"/>
+          <SubTree ID="NavigateThroughWaypoints"
+                   goals="{transit_path}"
+                   _autoremap="true"/>
+        </Sequence>
+      </Fallback>
       <SubTree ID="SurveyLine"
                server_timeout="{server_timeout}"
                bt_loop_duration="{bt_loop_duration}"
@@ -696,6 +728,19 @@
       <input_port name="path"
                   default="{path}"
                   type="nav_msgs::msg::Path_&lt;std::allocator&lt;void&gt; &gt;">Path to check</input_port>
+    </Condition>
+    <Condition ID="RobotOnPath">
+      <input_port name="path"
+                  default="{survey_path}"
+                  type="nav_msgs::msg::Path_&lt;std::allocator&lt;void&gt; &gt;">Path to test proximity to</input_port>
+      <input_port name="threshold"
+                  type="double">Maximum distance (m) from the path to count as 'on' it</input_port>
+      <input_port name="tf_buffer"
+                  default="{tf_buffer}"
+                  type="std::shared_ptr&lt;tf2_ros::Buffer&gt;">TF2 buffer</input_port>
+      <input_port name="robot_frame"
+                  default="{robot_frame}"
+                  type="std::string">Robot base frame</input_port>
     </Condition>
     <Action ID="PredictStoppingPose">
       <input_port name="deceleration"


### PR DESCRIPTION
Implements the two operator override capabilities from #52, for mid-survey
repositioning — in particular recovering a sonar hiccup on a long line without
re-running the whole line.

## Changes

**1. Updatable goto override** — `GotoTask`'s inner `Sequence` is wrapped in
`RestartOnTaskChange` (keyed on `{current_task_update_time}`), mirroring the hover
fix (#46). Re-issuing a `goto` override now re-targets the boat instead of
latching on the original target. The `GotoTask` call site forwards the timestamp
port.

**2. Mid-line resume after an override** — new `RobotOnPath` condition node (robot
pose via TF vs. `{survey_path}`, SUCCESS within a threshold). `TransitAndSurveyLine`'s
lead-in is gated by `Fallback[RobotOnPath, lead-in]`. After an override (hover park
/ goto nudge) halts and the survey-line case re-enters, the boat is already on the
line, so the lead-in is skipped and `CrabbingPathFollower` resumes from the boat's
current position rather than transiting back to the line start. Fresh entry is
unchanged (boat not yet on the line → lead-in runs). Degrades to the lead-in on
missing TF or empty path.

Why this works: the controller already resumes mid-line natively
(`computeVelocityCommands` re-derives `current_segment_` from the boat's position
each tick); the restart was caused solely by the BT's unconditional lead-in.

## Tests

- `test_robot_on_path` — geometry (nearest-segment distance), 7 cases.
- `test_goto_reentry` — re-command re-reads target + normal completion, 2 cases.
- All `marine_nav_behavior_tree` GTests pass (0 failures). The package's
  pre-existing `uncrustify` lint failures are unchanged and unrelated (they hit
  merged files too); new files match the neighboring code style.

## Validation status

⏳ **Sim + on-water validation pending** (this is why the PR is a draft). To check:
multi-line mission, mid-line-2 — (a) re-issue a goto → re-targets; (b) goto to
mid-line → survey resumes mid-line, not from the start; (c) hover park + cancel →
resumes mid-line. The `RobotOnPath` `{tf_buffer}`/`{robot_frame}` scope at
`TransitAndSurveyLine` is the one thing to confirm live (reached via `_autoremap`,
as `FixPathOrientations` does a level deeper).

Closes #52. Part of #50.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
