### PR TITLE
Field import: unh_marine_navigation (2026-06-01)

### DIFF
--- a/marine_nav_behavior_tree/include/marine_nav_behavior_tree/plugins/action/adjust_path_for_obstacles.h
+++ b/marine_nav_behavior_tree/include/marine_nav_behavior_tree/plugins/action/adjust_path_for_obstacles.h
@@ -107,6 +107,12 @@ class AdjustPathForObstacles : public BT::SyncActionNode
 public:
   AdjustPathForObstacles(const std::string & name, const BT::NodeConfig & config);
 
+  // Clears the avoidance overlay on teardown (tree reload / new goal / shutdown)
+  // so a deviation in progress when the node is destroyed doesn't leave a stale
+  // overlay in consumers that don't honour marker lifetime (e.g. CAMP).
+  // SyncActionNode::halt() is final, so the destructor is the available hook.
+  ~AdjustPathForObstacles() override;
+
   static BT::PortsList providedPorts();
 
   BT::NodeStatus tick() override;
@@ -126,6 +132,15 @@ private:
   // was_avoiding_ tracks so an idle tree doesn't republish every tick.
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr viz_pub_;
   bool was_avoiding_ = false;
+
+  // Node + robot frame cached on first tick so clearOverlay() can publish the
+  // DELETEALL from the destructor, where the blackboard may already be gone.
+  rclcpp::Node::SharedPtr node_;
+  std::string robot_frame_;
+
+  // Publish a DELETEALL for the overlay; no-op unless we were avoiding. Shared by
+  // the in-tick avoiding->clear transition and the destructor.
+  void clearOverlay();
 
   // Previous tick's per-station offsets, for the temporal (chatter) term.
   std::vector<double> prev_offsets_;

--- a/marine_nav_behavior_tree/src/plugins/action/adjust_path_for_obstacles.cpp
+++ b/marine_nav_behavior_tree/src/plugins/action/adjust_path_for_obstacles.cpp
@@ -417,6 +417,35 @@ AdjustPathForObstacles::AdjustPathForObstacles(
 {
 }
 
+AdjustPathForObstacles::~AdjustPathForObstacles()
+{
+  // Tree reload / new goal / shutdown while a deviation was being drawn would
+  // otherwise leave the AVOIDING overlay latched in CAMP (which doesn't honour
+  // the 2 s marker lifetime). clearOverlay() is a no-op unless was_avoiding_.
+  clearOverlay();
+}
+
+void AdjustPathForObstacles::clearOverlay()
+{
+  if (!viz_pub_ || !was_avoiding_) {
+    return;
+  }
+  visualization_msgs::msg::MarkerArray arr;
+  visualization_msgs::msg::Marker del;
+  // A valid header even for a DELETEALL: some consumers (RViz/CAMP) warn on or
+  // drop markers with an empty frame_id. Cached on first tick so this is safe
+  // from the destructor.
+  del.header.frame_id = robot_frame_;
+  if (node_) {
+    del.header.stamp = node_->now();
+  }
+  del.ns = kVizNamespace;
+  del.action = visualization_msgs::msg::Marker::DELETEALL;
+  arr.markers.push_back(del);
+  viz_pub_->publish(arr);
+  was_avoiding_ = false;
+}
+
 BT::PortsList AdjustPathForObstacles::providedPorts()
 {
   return {
@@ -472,6 +501,10 @@ BT::NodeStatus AdjustPathForObstacles::tick()
   // cache (not `this`), so a callback still in flight on the executor thread when
   // this node is destroyed (tree reload / shutdown) touches live state, not freed.
   if (!costmap_sub_) {
+    // Cache for clearOverlay() (used from the destructor, where the blackboard
+    // may already be torn down).
+    node_ = node;
+    robot_frame_ = config().blackboard->get<std::string>("robot_frame");
     costmap_topic_ = getInput<std::string>("costmap_topic").value_or(
       "local_costmap/costmap_raw");
     auto cache = costmap_cache_;
@@ -501,22 +534,10 @@ BT::NodeStatus AdjustPathForObstacles::tick()
   }
 
   // Wipe the avoidance overlay once on the avoiding->clear transition (idle ticks
-  // then publish nothing, rather than spamming a DELETEALL every loop).
-  auto clear_viz = [&]() {
-    if (was_avoiding_ && viz_pub_) {
-      visualization_msgs::msg::MarkerArray arr;
-      visualization_msgs::msg::Marker del;
-      // Give the DELETEALL a valid header — some marker consumers (RViz/CAMP)
-      // warn on or drop markers with an empty frame_id even for a delete.
-      del.header.frame_id = config().blackboard->get<std::string>("robot_frame");
-      del.header.stamp = node->now();
-      del.ns = kVizNamespace;
-      del.action = visualization_msgs::msg::Marker::DELETEALL;
-      arr.markers.push_back(del);
-      viz_pub_->publish(arr);
-    }
-    was_avoiding_ = false;
-  };
+  // then publish nothing, rather than spamming a DELETEALL every loop). The
+  // destructor shares clearOverlay() for the teardown case (tree reload / new
+  // goal) that no tick reaches.
+  auto clear_viz = [this]() {clearOverlay();};
 
   auto passthrough = [&]() {
     clear_viz();

--- a/marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml
+++ b/marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml
@@ -430,7 +430,8 @@
              {survey_path} preempts the running FollowPath via the #35 mechanism
              above. For #30. -->
         <AdjustPathForObstacles nominal_path="{nominal_survey_path}"
-                                path="{survey_path}"/>
+                                path="{survey_path}"
+                                obstacle_avoidance_weight="1.0"/>
         <!-- Recover transient FollowPath ABORTs (e.g. a momentary progress-checker trip)
              with a short Wait, then retry — up to 3 times. On persistent failure the
              RecoveryNode FAILs up to the dispatch, which records the line failed


### PR DESCRIPTION
Imports 2 field commits from the 2026-06-01 BizzyBoat deployment
(`gitcloud/jazzy`), preserving the original field SHAs (branched from the
field ref — not cherry-picked).

- `ea7277d` clear avoidance overlay on teardown (`SyncActionNode::halt()` is
  `final` in BT.CPP 4.9 → stale `AVOIDING` overlay lingered in CAMP)
- `9ce5bb6` raise survey `obstacle_avoidance_weight` to `1.0` (field tune,
  not sim-validated)

See the issue for the pre-review findings (weight not sim-validated; DELETEALL
from destructor is best-effort on shutdown; no regression test for the teardown
clear). Draft pending review + the test gap.

Closes #54. Relates to #30.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
