### PR TITLE
Fix windowed-costmap delivery: match Nav2 costmap QoS (#56)

### DIFF
--- a/marine_nav_utilities/include/marine_nav_utilities/costmap_window_node.h
+++ b/marine_nav_utilities/include/marine_nav_utilities/costmap_window_node.h
@@ -48,12 +48,27 @@ public:
     post_param_callback_handle_ = add_post_set_parameters_callback(
       std::bind(&CostmapWindowNode::onPostSetParameters, this, std::placeholders::_1));
 
-    // Nav2 publishes the costmap reliable + transient-local (latched). Use
-    // best-available for both policies so we attach and receive the streamed
-    // updates regardless of how the source is configured.
+    // Match Nav2's costmap publisher QoS EXPLICITLY: reliable + transient-local,
+    // depth 1 (nav2_costmap_2d Costmap2DPublisher uses
+    // `KeepLast(1).transient_local().reliable()`). This matters because that
+    // publisher is *subscription-count-gated* — `publishCostmap()` only emits the
+    // OccupancyGrid when `costmap_pub_->get_subscription_count() > 0`. With the
+    // earlier `best_available` policies our subscription's match against the lazy,
+    // transient-local publisher was nondeterministic at startup, so the publisher
+    // often saw 0 subscribers and stayed silent until a *second* subscriber
+    // (e.g. rqt_udp_bridge) was attached by hand — the long-standing costmap hack
+    // (#56). An explicit transient-local subscriber deterministically counts
+    // toward the gate AND re-requests the latched grid on every (re)match, so the
+    // window is delivered without the manual second subscriber.
+    //
+    // Trade-off: an explicit transient-local subscription only matches a
+    // transient-local publisher. Nav2's costmap is always transient-local (above),
+    // so this is correct for the intended source; a hypothetical volatile costmap
+    // source would no longer match (the old best_available did). That's an
+    // acceptable narrowing — this node exists to window the Nav2 local costmap.
     rclcpp::QoS sub_qos(1);
-    sub_qos.reliability_best_available();
-    sub_qos.durability_best_available();
+    sub_qos.reliable();
+    sub_qos.transient_local();
     subscription_ = create_subscription<nav_msgs::msg::OccupancyGrid>(
       "costmap", sub_qos,
       std::bind(&CostmapWindowNode::costmapCallback, this, std::placeholders::_1));

--- a/marine_nav_utilities/test/test_costmap_window_node.cpp
+++ b/marine_nav_utilities/test/test_costmap_window_node.cpp
@@ -1,7 +1,10 @@
+#include <chrono>
 #include <cmath>
 #include <limits>
 #include <memory>
 #include <string>
+#include <thread>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -65,4 +68,40 @@ TEST_F(CostmapWindowNodeTest, NonNumericWindowSizeRejected)
   const auto result = node_->set_parameter(rclcpp::Parameter("window_size", std::string("wide")));
   EXPECT_FALSE(result.successful);
   EXPECT_DOUBLE_EQ(node_->get_parameter("window_size").as_double(), 200.0);
+}
+
+// #56: the "costmap" subscription must explicitly advertise reliable +
+// transient-local QoS so it deterministically matches (and counts toward the
+// subscription-count gate of) Nav2's reliable+transient-local costmap publisher
+// — `Costmap2DPublisher::publishCostmap()` only emits when
+// `get_subscription_count() > 0`. The previous `best_available` policies made the
+// match nondeterministic at startup, which is why a manual second subscriber was
+// needed. Guard against a regression back to best_available / volatile.
+TEST_F(CostmapWindowNodeTest, CostmapSubscriptionIsReliableTransientLocal)
+{
+  rclcpp::executors::SingleThreadedExecutor exec;
+  exec.add_node(node_);
+
+  std::vector<rclcpp::TopicEndpointInfo> infos;
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  while (std::chrono::steady_clock::now() < deadline) {
+    infos = node_->get_subscriptions_info_by_topic("/costmap");
+    if (!infos.empty()) {
+      break;
+    }
+    exec.spin_some();
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  }
+
+  ASSERT_FALSE(infos.empty()) << "no subscription discovered on /costmap";
+  bool found_reliable_transient_local = false;
+  for (const auto & info : infos) {
+    if (info.qos_profile().reliability() == rclcpp::ReliabilityPolicy::Reliable &&
+      info.qos_profile().durability() == rclcpp::DurabilityPolicy::TransientLocal)
+    {
+      found_reliable_transient_local = true;
+    }
+  }
+  EXPECT_TRUE(found_reliable_transient_local)
+    << "costmap subscription must be reliable + transient_local (matches Nav2; #56)";
 }


### PR DESCRIPTION
## Fix

`costmap_window_node` subscribed to `costmap` with **`best_available`** reliability
+ durability. Nav2's OccupancyGrid costmap publisher is **reliable + transient_local**
and **subscription-count-gated** — `Costmap2DPublisher::publishCostmap()` only emits
when `get_subscription_count() > 0` (nav2_costmap_2d 1.3.11 `costmap_2d_publisher.cpp`
L70 = `KeepLast(1).transient_local().reliable()`, L248 = the gate). `best_available`
matched nondeterministically at startup, so the publisher often saw 0 subscribers and
stayed silent until a **manual second subscriber** (`rqt_udp_bridge`) was attached —
the long-standing "costmap hack" (#56).

This switches the subscription to an **explicit `reliable` + `transient_local`,
depth-1** QoS that deterministically matches Nav2's publisher (counts toward the
gate) and re-requests the latched grid on every (re)match — removing the manual
hack. Trade-off documented in-code: an explicit transient_local subscription only
matches a transient_local source; Nav2's costmap always is.

## Test

Adds `CostmapWindowNodeTest.CostmapSubscriptionIsReliableTransientLocal` — guards
against a regression back to `best_available`/volatile. Full package gtests pass
(`test_costmap_window_node` 6/6, `test_costmap_window` 11/11).

## Notes for the reviewer

- **Validation caveat:** the *gate* and *QoS* are code-confirmed; the precise
  startup match race wasn't reproduced live. Recommend a **controlled bench/sim
  reproduction** (windower vs a gated transient_local publisher, no second
  subscriber) to confirm the hack is truly gone before relying on it in the field.
  Until then the documented `rqt_udp_bridge` workaround remains the stopgap
  (tracked for the next deployment, echoboats #205).
- **Local lint noise:** this environment's `uncrustify 0.78.1` mass-fails the whole
  package (647/694 files, incl. the *unmodified* base file) — a version drift vs the
  repo's CI pin, **not** introduced here. My added lines follow the file's existing
  (CI-passing) style; I did not reformat to 0.78.1 or change lint config.

Closes #56.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
