### PR TITLE
[PLAN] CA safety node: speed-scaled yaw-preserving slowdown + reverse-assisted stop

### DIFF
--- a/.agent/work-plans/issue-64/plan.md
+++ b/.agent/work-plans/issue-64/plan.md
@@ -12,7 +12,10 @@ boat gets stuck pointed at an obstacle. This node **replaces** the nav2 Collisio
 earlier and proportionally to speed while *preserving the avoider's yaw authority*, then
 brakes to a stop with reverse thrust over a short distance. It also **takes over the
 Collision Monitor's zone visualization** so CAMP's existing yellow (slowdown) / red (stop)
-boxes keep rendering — with the yellow box now sized live by the speed-scaled zone.
+boxes keep rendering — with the yellow box now sized live by the speed-scaled zone. CAMP draws each box as an
+**outline when idle and a translucent fill when active**, where "active" comes from a
+separate `nav2_msgs/CollisionMonitorState` message — so the node publishes that too, not
+just the polygons.
 cmd_vel chain wiring lives in config, not this repo — so this PR delivers the **node +
 tests only**; per-240 wiring is config (rolker/seafloor_echoboat_project11#43).
 
@@ -33,11 +36,16 @@ tests only**; per-240 wiring is config (rolker/seafloor_echoboat_project11#43).
    ~0** (no sustained reverse), capped by `reverse_distance`/`reverse_duration`. The
    `cancel_yaw_during_reverse` **dynamic** param toggles whether `angular.z` is zeroed
    (straight brake — sidesteps yaw-sign-in-reverse) or passed through.
-4. **Zone visualization** — publish `geometry_msgs/PolygonStamped` on
-   `collision_monitor/slowdown_polygon` (sized live by the speed-scaled `L`) and
-   `collision_monitor/stop_polygon` (fixed), in `base_frame`, matching the Collision
-   Monitor's current topics/types so CAMP's yellow/red boxes render unchanged. Gated by
-   `publish_visualization` (default true).
+4. **Zone visualization (two parts — CAMP needs both):**
+   (a) `geometry_msgs/PolygonStamped` on `collision_monitor/slowdown_polygon` (sized live
+   by the speed-scaled `L`) and `collision_monitor/stop_polygon` (fixed), in `base_frame`
+   — CAMP keys box **color** off the topic name (amber=slowdown, red=stop) and the shape
+   off these.
+   (b) `nav2_msgs/CollisionMonitorState` on `collision_monitor_state` with `action_type`
+   = highest-priority current action (`DO_NOTHING`/`SLOWDOWN`/`STOP`) — CAMP keys the
+   **frame-vs-fill** off `action_type` (outline when idle, translucent fill when a zone of
+   that kind is active), with a 2 s staleness watchdog → **publish every cycle**.
+   Both gated by `publish_visualization` (default true).
 5. **Source-loss handling** — use the last cloud until `source_timeout`; after that,
    `source_loss_behavior` (`hold` | `passthrough` | `stop`, default `passthrough` + warn)
    decides. (Configurable per discussion — `stop` reintroduces the deadlock, so not default.)
@@ -47,9 +55,10 @@ tests only**; per-240 wiring is config (rolker/seafloor_echoboat_project11#43).
 7. **`main()`** wrapper in `src/ca_safety_node.cpp`.
 8. **Tests**: `test_ca_safety.cpp` (pure: zone sizing at speed extremes; slowdown floor
    keeps `linear.x` > 0; reverse-brake terminates at ~0; cancel-yaw toggle both ways;
-   polygon geometry tracks `L`; param validation incl. NaN/inf/out-of-domain).
+   polygon geometry tracks `L`; `action_type` maps clear→`DO_NOTHING`,
+   slowdown→`SLOWDOWN`, stop→`STOP`; param validation incl. NaN/inf/out-of-domain).
    `test_ca_safety_node.cpp` (param defaults, dynamic update accept/reject, message flow,
-   viz polygons published). GTest, in-process.
+   viz polygons + `CollisionMonitorState` published). GTest, in-process.
 9. **Package README** documenting params, topics, chain placement ("replaces Collision
    Monitor"), **and the safety-behavior rationale** (reverse-near-obstacles, yaw-preserving
    slowdown) — Q4: documented with the node rather than a project `docs/decisions/`.
@@ -58,10 +67,10 @@ tests only**; per-240 wiring is config (rolker/seafloor_echoboat_project11#43).
 
 | File (new, under `marine_nav_ca_safety_node/`) | Change |
 |---|---|
-| `package.xml` | format 2, BSD; deps: rclcpp, geometry_msgs, sensor_msgs, nav_msgs, tf2, tf2_ros, tf2_geometry_msgs, rcl_interfaces |
+| `package.xml` | format 2, BSD; deps: rclcpp, geometry_msgs, sensor_msgs, nav_msgs, nav2_msgs, tf2, tf2_ros, tf2_geometry_msgs, rcl_interfaces |
 | `CMakeLists.txt` | library + `ca_safety_node` executable → `lib/${PROJECT_NAME}`; gtest registration |
 | `include/marine_nav_ca_safety_node/ca_safety.h` | pure logic: zone sizing, range, twist modulation, polygon geometry, validation |
-| `include/marine_nav_ca_safety_node/ca_safety_node.h` | node: subs/pub (incl. viz polygon pubs), TF, param declare+validate, modulation loop |
+| `include/marine_nav_ca_safety_node/ca_safety_node.h` | node: subs/pub (incl. viz polygon + `CollisionMonitorState` pubs), TF, param declare+validate, modulation loop |
 | `src/ca_safety_node.cpp` | `main()` |
 | `test/test_ca_safety.cpp` | pure-logic unit tests |
 | `test/test_ca_safety_node.cpp` | node param/flow/viz tests |
@@ -83,7 +92,8 @@ tests only**; per-240 wiring is config (rolker/seafloor_echoboat_project11#43).
 | `source_timeout` | double / 1.0 s | finite, > 0 |
 | `source_loss_behavior` | string / `passthrough` | one of `hold`,`passthrough`,`stop` |
 | `publish_visualization` | bool / true | — |
-| `slowdown_polygon_topic` / `stop_polygon_topic` | string / `collision_monitor/slowdown_polygon`, `collision_monitor/stop_polygon` | non-empty |
+| `slowdown_polygon_topic` / `stop_polygon_topic` | string / `collision_monitor/slowdown_polygon`, `collision_monitor/stop_polygon` | non-empty (name carries color) |
+| `state_topic` | string / `collision_monitor_state` | non-empty (`nav2_msgs/CollisionMonitorState`; CAMP discovers by type) |
 
 ## Principles Self-Check
 
@@ -110,14 +120,15 @@ tests only**; per-240 wiring is config (rolker/seafloor_echoboat_project11#43).
 | If we change... | Also update... | In plan? |
 |---|---|---|
 | Add a new node (params/topics) | Package README; per-240 config | README yes; config → seafloor#43 |
-| Replace the Collision Monitor (incl. viz) | nav2 chain wiring; **viz topics consumed by CAMP** (keep same topic names/types) | Config → seafloor#43; reconcile #25/#27/#36 |
+| Replace the Collision Monitor (incl. viz) | nav2 chain wiring; **CAMP viz**: polygon topics (color by name) + `CollisionMonitorState` (fill) | Config → seafloor#43; reconcile #25/#27/#36 |
 | New `/odom` + pointcloud deps | Topic supply (coverage decision) | External → seafloor#43 |
 
 ## Open Questions
 
-- [ ] Verify CAMP keys its yellow/red polygon styling off the **topic names**
-      (`collision_monitor/slowdown_polygon` / `stop_polygon`) so republishing them is
-      sufficient — confirm during integration (seafloor#43).
+- [ ] None open — CAMP viz mechanism confirmed against `camp` source: box **color** keyed
+      off topic name (amber=slowdown, red=stop); **frame-vs-fill** driven by
+      `nav2_msgs/CollisionMonitorState.action_type` (2 s staleness watchdog). Plan is
+      review-plan-ready.
 
 ## Estimated Scope
 

--- a/.agent/work-plans/issue-64/plan.md
+++ b/.agent/work-plans/issue-64/plan.md
@@ -111,6 +111,7 @@ namespacing and frame-prefixing (the deployment's namespace + its roll/pitch-sta
 | `slowdown_width` / `stop_length` / `stop_width` | double / 6.0, 5.0, 4.0 m | finite, > 0 |
 | `reverse_speed` | double / 0.5 m/s | finite, > 0 |
 | `reverse_distance` / `reverse_duration` | double / 3.0 m, 4.0 s | finite, > 0 (hard backstop, odom-independent) |
+| `stop_speed_eps` | double / 0.05 m/s | startup; speed below which the boat is "stopped" (ends reverse brake) |
 | `cancel_yaw_during_reverse` | bool / true | passthrough path (`false`) disabled until sim sign test |
 | `source_timeout` | double / 1.0 s | finite, > 0 |
 | `source_loss_behavior` | string / `passthrough` | one of `hold`,`passthrough`,`stop` |

--- a/.agent/work-plans/issue-64/plan.md
+++ b/.agent/work-plans/issue-64/plan.md
@@ -111,7 +111,8 @@ namespacing and frame-prefixing (the deployment's namespace + its roll/pitch-sta
 | `slowdown_width` / `stop_length` / `stop_width` | double / 6.0, 5.0, 4.0 m | finite, > 0 |
 | `reverse_speed` | double / 0.5 m/s | finite, > 0 |
 | `reverse_distance` / `reverse_duration` | double / 3.0 m, 4.0 s | finite, > 0 (hard backstop, odom-independent) |
-| `stop_speed_eps` | double / 0.05 m/s | startup; speed below which the boat is "stopped" (ends reverse brake) |
+| `stop_speed_eps` | double / 0.05 m/s | finite, > 0; speed below which the boat is "stopped" (ends reverse brake) |
+| `reverse_clear_debounce` | double / 1.0 s | finite, > 0; sustained-clear time before a reverse episode resets its backstop (flicker guard) |
 | `cancel_yaw_during_reverse` | bool / true | passthrough path (`false`) disabled until sim sign test |
 | `source_timeout` | double / 1.0 s | finite, > 0 |
 | `source_loss_behavior` | string / `passthrough` | one of `hold`,`passthrough`,`stop` |

--- a/.agent/work-plans/issue-64/plan.md
+++ b/.agent/work-plans/issue-64/plan.md
@@ -16,8 +16,8 @@ visualization (CAMP's yellow/red boxes; the fill is driven by a separate
 
 **The node is platform-agnostic.** It lives in the generic `unh_marine_navigation` core,
 so it uses **generic relative topic names and unprefixed frame-param defaults**; all
-namespacing and frame-prefixing (`bizzy/`, the roll/pitch-stabilized `…/base_link_level`
-frame) is applied externally by the launch/config (seafloor#43). This PR delivers the
+namespacing and frame-prefixing (the deployment's namespace + its roll/pitch-stabilized
+`…/base_link_level` frame) is applied externally by the launch/config (seafloor#43). This PR delivers the
 **node + tests only**.
 
 ## Approach

--- a/.agent/work-plans/issue-64/plan.md
+++ b/.agent/work-plans/issue-64/plan.md
@@ -8,130 +8,153 @@ https://github.com/rolker/unh_marine_navigation/issues/64
 
 On EchoBoat 240 (vectored thrust) a hard emergency stop zeroes yaw authority, so the
 boat gets stuck pointed at an obstacle. This node **replaces** the nav2 Collision Monitor
-(confirmed) with a graduated **safety brake** (not a maneuvering/escape node): it slows
-earlier and proportionally to speed while *preserving the avoider's yaw authority*, then
-brakes to a stop with reverse thrust over a short distance. It also **takes over the
-Collision Monitor's zone visualization** so CAMP's existing yellow (slowdown) / red (stop)
-boxes keep rendering — with the yellow box now sized live by the speed-scaled zone. CAMP draws each box as an
-**outline when idle and a translucent fill when active**, where "active" comes from a
-separate `nav2_msgs/CollisionMonitorState` message — so the node publishes that too, not
-just the polygons.
-cmd_vel chain wiring lives in config, not this repo — so this PR delivers the **node +
-tests only**; per-240 wiring is config (rolker/seafloor_echoboat_project11#43).
+with a graduated **safety brake** (not a maneuvering/escape node): it slows earlier and
+proportionally to speed while *preserving the avoider's yaw authority*, then brakes to a
+stop with reverse thrust over a short distance. It also takes over the CM's zone
+visualization (CAMP's yellow/red boxes; the fill is driven by a separate
+`nav2_msgs/CollisionMonitorState`, so the node publishes both).
+
+**The node is platform-agnostic.** It lives in the generic `unh_marine_navigation` core,
+so it uses **generic relative topic names and unprefixed frame-param defaults**; all
+namespacing and frame-prefixing (`bizzy/`, the roll/pitch-stabilized `…/base_link_level`
+frame) is applied externally by the launch/config (seafloor#43). This PR delivers the
+**node + tests only**.
 
 ## Approach
 
-1. **New package `marine_nav_ca_safety_node`**, mirroring the `marine_nav_utilities`
-   standalone-node pattern (ament_cmake, `package.xml` format 2, BSD, C++17).
+1. **New package `marine_nav_ca_safety`** (executable `ca_safety_node`), mirroring the
+   `marine_nav_utilities` standalone-node pattern (ament_cmake, `package.xml` format 2,
+   BSD, C++17). REP-144 naming: package by domain, executable by role.
 2. **ROS-free core header `ca_safety.h`** — pure, gtest-able functions: slowdown length
    `L = clamp(v·T + L_min, L_min, L_max)` (≡ time-to-collision); nearest forward-sector
-   obstacle range from points already in base frame; twist modulation
-   {slowdown scale that keeps `linear.x` at/above a positive floor; pass `angular.z`
-   through; stop-zone → reverse-brake setpoint}; zone-polygon geometry (for viz);
-   validation predicates (finite + domain). Mirrors the `costmap_window.h` predicate style.
-3. **Node class `ca_safety_node.h`** (`rclcpp::Node`): subs `cmd_vel_in` (TwistStamped),
-   pointcloud (PointCloud2, tf2 → `base_frame`), odom (Odometry, forward-speed feedback);
-   pub `cmd_vel_out` (TwistStamped). On each cmd_vel: derive zone from latest cloud range
-   + measured speed, modulate, publish. Reverse braking is **closed-loop on odom speed to
-   ~0** (no sustained reverse), capped by `reverse_distance`/`reverse_duration`. The
-   `cancel_yaw_during_reverse` **dynamic** param toggles whether `angular.z` is zeroed
-   (straight brake — sidesteps yaw-sign-in-reverse) or passed through.
-4. **Zone visualization (two parts — CAMP needs both):**
-   (a) `geometry_msgs/PolygonStamped` on `collision_monitor/slowdown_polygon` (sized live
-   by the speed-scaled `L`) and `collision_monitor/stop_polygon` (fixed), in `base_frame`
-   — CAMP keys box **color** off the topic name (amber=slowdown, red=stop) and the shape
-   off these.
-   (b) `nav2_msgs/CollisionMonitorState` on `collision_monitor_state` with `action_type`
-   = highest-priority current action (`DO_NOTHING`/`SLOWDOWN`/`STOP`) — CAMP keys the
-   **frame-vs-fill** off `action_type` (outline when idle, translucent fill when a zone of
-   that kind is active), with a 2 s staleness watchdog → **publish every cycle**.
-   Both gated by `publish_visualization` (default true).
-5. **Source-loss handling** — use the last cloud until `source_timeout`; after that,
-   `source_loss_behavior` (`hold` | `passthrough` | `stop`, default `passthrough` + warn)
-   decides. (Configurable per discussion — `stop` reintroduces the deadlock, so not default.)
-6. **Dynamic parameter validation** per the #62 `CostmapWindowNode` precedent: pre-set
-   `onSetParameters` validates (finite/domain, int→double coercion), post-set applies to
-   `std::atomic` members.
-7. **`main()`** wrapper in `src/ca_safety_node.cpp`.
-8. **Tests**: `test_ca_safety.cpp` (pure: zone sizing at speed extremes; slowdown floor
-   keeps `linear.x` > 0; reverse-brake terminates at ~0; cancel-yaw toggle both ways;
-   polygon geometry tracks `L`; `action_type` maps clear→`DO_NOTHING`,
-   slowdown→`SLOWDOWN`, stop→`STOP`; param validation incl. NaN/inf/out-of-domain).
-   `test_ca_safety_node.cpp` (param defaults, dynamic update accept/reject, message flow,
-   viz polygons + `CollisionMonitorState` published). GTest, in-process.
-9. **Package README** documenting params, topics, chain placement ("replaces Collision
-   Monitor"), **and the safety-behavior rationale** (reverse-near-obstacles, yaw-preserving
-   slowdown) — Q4: documented with the node rather than a project `docs/decisions/`.
+   obstacle range from points already in the computation frame; twist modulation
+   {slowdown scale keeping `linear.x` ≥ a positive floor; pass `angular.z`; stop-zone →
+   reverse-brake setpoint}; zone-polygon geometry; validation predicates (finite + domain).
+   Mirrors `costmap_window.h`.
+3. **Node `ca_safety_node.h`** (`rclcpp::Node`): subs `cmd_vel_in` (TwistStamped),
+   pointcloud (PointCloud2), odom (Odometry); pub `cmd_vel_out` (TwistStamped).
+   **Transform:** `tf2_ros::Buffer`/`Listener` + `tf2_sensor_msgs::doTransform` to bring the
+   PointCloud2 into `base_frame` before range computation — the live cloud is in a
+   roll/pitch-stabilized frame, and `base_frame` is a **generic param** (default
+   `base_link`; deployment supplies e.g. `…/base_link_level`). On each cmd_vel: derive zone
+   from latest cloud range + measured speed, modulate, publish `cmd_vel_out`. If input
+   cmd_vel pauses, the node stops emitting `cmd_vel_out` (the FCU's own GUIDED watchdog
+   handles a stale command, cf. #28).
+4. **Reverse-assisted stop** — closed-loop on odom forward speed to ~0, with a **hard
+   backstop independent of odom**: reverse ends at `reverse_distance` (integrated from
+   reverse-start) or `reverse_duration`, whichever first — a mid-reverse odom dropout
+   cannot cause aft runaway. `cancel_yaw_during_reverse` dynamic param, **default `true`**
+   (straight brake — the safe path). **The yaw-passthrough path (`false`) ships disabled
+   and is enabled only after the sim yaw-sign-in-reverse test passes** (the issue's blocker;
+   wrong sign would swing the bow *into* the obstacle).
+5. **Visualization — timer-driven, both parts.** An independent timer (`viz_rate`, default
+   2 Hz, well inside CAMP's 2 s watchdog) publishes: (a) `geometry_msgs/PolygonStamped` on
+   the slowdown/stop polygon topics (slowdown sized live by `L`), in `base_frame` — CAMP
+   colors by topic name; (b) `nav2_msgs/CollisionMonitorState.action_type`
+   (`DO_NOTHING`/`SLOWDOWN`/`STOP`) — CAMP's frame-vs-fill. Driving these from a timer (not
+   cmd_vel) keeps fills from blanking when cmd_vel pauses. Gated by `publish_visualization`.
+6. **Source-loss handling** — cloud: use the last cloud until `source_timeout`, then
+   `source_loss_behavior` (`hold`|`passthrough`|`stop`, default `passthrough`+warn; `stop`
+   reintroduces the deadlock). odom: covered by the reverse hard backstop (4).
+7. **Explicit QoS per endpoint** (mirroring `costmap_window_node`'s QoS rationale, which
+   exists precisely because implicit QoS caused a silent no-data bug, #56): pointcloud =
+   **sensor-data/best-effort** (nav2 sensor sources are best-effort; a reliable sub gets
+   nothing); cmd_vel in/out = reliable, depth 1, volatile (match `velocity_smoother` out /
+   `echo_helm` in — a mismatch means **no helm commands**); odom = reliable, depth 5;
+   polygons + state = reliable, depth 1, volatile (match CAMP's `QoS(1)`).
+8. **Sole-helm-publisher invariant** — exactly one publisher on `cmd_vel_out` at any time.
+   The CM must be removed from the chain/lifecycle at cutover (wiring = seafloor#43); the
+   node logs a warning if it detects another publisher on `cmd_vel_out`. (CM currently runs
+   as a pass-through on non-reflex boats — cutover handled per-boat in #43.)
+9. **Dynamic parameter validation** per the #62 `CostmapWindowNode` precedent (pre-set
+   `onSetParameters` validates finite/domain + int→double; post-set applies to `std::atomic`).
+10. **`main()`** in `src/ca_safety_node.cpp`.
+11. **Tests.** `test_ca_safety.cpp` (pure: zone sizing at speed extremes; slowdown floor
+    keeps `linear.x` > 0; reverse-brake terminates at ~0; reverse hard backstop on odom
+    loss; cancel-yaw both ways; polygon tracks `L`; `action_type` mapping; param validation
+    incl. NaN/inf/domain). `test_ca_safety_node.cpp` (param defaults, dynamic accept/reject,
+    viz+state published on timer). **`test_ca_safety_launch.py` (launch_testing):** QoS
+    interop (best-effort cloud + cmd_vel actually flow), TF transform of a real cloud into
+    `base_frame`, single-publisher on `cmd_vel_out`. **Sim gates (before water):**
+    yaw-preserving slowdown at speed extremes; reverse termination / no aft runaway; escape
+    when the avoider has given up; source-loss passthrough; **yaw-sign-in-reverse sign test
+    (gates enabling the passthrough path)** — recorded via sim bag (ensure CA/reverse state
+    is in the recording, cf. marine_simulation #62/#63).
+12. **Package README**: params, topics, QoS, chain placement, the platform-agnostic naming
+    note, and the safety-behavior rationale (Q4 — documented with the node).
 
 ## Files to Change
 
-| File (new, under `marine_nav_ca_safety_node/`) | Change |
+| File (new, under `marine_nav_ca_safety/`) | Change |
 |---|---|
-| `package.xml` | format 2, BSD; deps: rclcpp, geometry_msgs, sensor_msgs, nav_msgs, nav2_msgs, tf2, tf2_ros, tf2_geometry_msgs, rcl_interfaces |
-| `CMakeLists.txt` | library + `ca_safety_node` executable → `lib/${PROJECT_NAME}`; gtest registration |
-| `include/marine_nav_ca_safety_node/ca_safety.h` | pure logic: zone sizing, range, twist modulation, polygon geometry, validation |
-| `include/marine_nav_ca_safety_node/ca_safety_node.h` | node: subs/pub (incl. viz polygon + `CollisionMonitorState` pubs), TF, param declare+validate, modulation loop |
+| `package.xml` | format 2, BSD; deps: rclcpp, geometry_msgs, sensor_msgs, nav_msgs, nav2_msgs (for `CollisionMonitorState` — CAMP keys off this exact type), tf2, tf2_ros, tf2_geometry_msgs, **tf2_sensor_msgs** (PointCloud2 `doTransform`), rcl_interfaces |
+| `CMakeLists.txt` | library + `ca_safety_node` exec → `lib/${PROJECT_NAME}`; gtest + launch_testing registration |
+| `include/marine_nav_ca_safety/ca_safety.h` | pure logic: zone sizing, range, twist modulation, polygon geometry, validation |
+| `include/marine_nav_ca_safety/ca_safety_node.h` | node: subs/pub, tf transform, timer-driven viz+state, param declare+validate, modulation loop |
 | `src/ca_safety_node.cpp` | `main()` |
 | `test/test_ca_safety.cpp` | pure-logic unit tests |
 | `test/test_ca_safety_node.cpp` | node param/flow/viz tests |
-| `README.md` | params, topics, chain placement, safety-behavior rationale |
+| `test/test_ca_safety_launch.py` | launch_testing: QoS / TF / single-publisher interop |
+| `README.md` | params, topics, QoS, chain, platform-agnostic note, safety rationale |
 
-## Parameters (all validated; geometry/reverse/viz toggles are dynamic)
+## Parameters (generic/unprefixed defaults; geometry/reverse/viz toggles dynamic)
 
-| Param | Type / default | Validation |
+| Param | Type / default | QoS / validation |
 |---|---|---|
-| `cmd_vel_in_topic` / `cmd_vel_out_topic` | string / `cmd_vel_smoothed`, `piloting_mode/autonomous/cmd_vel` | non-empty (TwistStamped, confirmed used everywhere) |
-| `pointcloud_topic` / `odom_topic` / `base_frame` | string / `collision_monitor/pointcloud`, `odom`, `base_link` | non-empty |
+| `cmd_vel_in_topic` / `cmd_vel_out_topic` | string / `cmd_vel_smoothed`, `piloting_mode/autonomous/cmd_vel` | reliable d1 volatile; non-empty (TwistStamped) |
+| `pointcloud_topic` | string / `collision_monitor/pointcloud` | **sensor-data/best-effort** |
+| `odom_topic` | string / `odom` | reliable d5 |
+| `base_frame` | string / `base_link` | non-empty (generic; deployment supplies prefixed/level frame) |
 | `ttc_time_constant` `T` | double / 4.0 s | finite, > 0 |
 | `slowdown_min_length` / `slowdown_max_length` | double / 5.0, 25.0 m | finite, > 0, min ≤ max |
 | `slowdown_speed_floor` | double / small +ε (m/s) | finite, > 0 (keeps yaw authority) |
 | `slowdown_width` / `stop_length` / `stop_width` | double / 6.0, 5.0, 4.0 m | finite, > 0 |
 | `reverse_speed` | double / 0.5 m/s | finite, > 0 |
-| `reverse_distance` / `reverse_duration` | double / 3.0 m, 4.0 s | finite, > 0 |
-| `cancel_yaw_during_reverse` | bool / true | — (live toggle for on-water A/B) |
+| `reverse_distance` / `reverse_duration` | double / 3.0 m, 4.0 s | finite, > 0 (hard backstop, odom-independent) |
+| `cancel_yaw_during_reverse` | bool / true | passthrough path (`false`) disabled until sim sign test |
 | `source_timeout` | double / 1.0 s | finite, > 0 |
 | `source_loss_behavior` | string / `passthrough` | one of `hold`,`passthrough`,`stop` |
 | `publish_visualization` | bool / true | — |
-| `slowdown_polygon_topic` / `stop_polygon_topic` | string / `collision_monitor/slowdown_polygon`, `collision_monitor/stop_polygon` | non-empty (name carries color) |
-| `state_topic` | string / `collision_monitor_state` | non-empty (`nav2_msgs/CollisionMonitorState`; CAMP discovers by type) |
+| `viz_rate` | double / 2.0 Hz | finite, > 0 (inside CAMP's 2 s watchdog) |
+| `slowdown_polygon_topic` / `stop_polygon_topic` | string / `collision_monitor/slowdown_polygon`, `…/stop_polygon` | reliable d1; name carries color |
+| `state_topic` | string / `collision_monitor_state` | reliable d1 (`nav2_msgs/CollisionMonitorState`; CAMP discovers by type) |
 
 ## Principles Self-Check
 
 | Principle | Consideration |
 |---|---|
-| Human control & transparency | All behavior configurable; reverse-yaw toggle is a live param; **zone viz preserved** (operator keeps the yellow/red boxes, yellow now reflects speed); output cmd_vel observable |
-| A change includes its consequences | Node ships with unit tests + README rationale; config wiring at seafloor#43, recovery at #67; CM-replacement (incl. viz) reconciled |
-| Only what's needed | One small node package; reuses the existing param-validation pattern; viz reuses existing CAMP display (no CAMP change); pointcloud injected (no all-around perception) |
+| Human control & transparency | All behavior configurable; reverse-yaw toggle live (passthrough gated until tested); zone viz preserved (yellow reflects speed); cmd_vel observable |
+| A change includes its consequences | Unit + launch_testing + README; config at seafloor#43; recovery at #67; CM-replacement + sole-publisher cutover reconciled |
+| Only what's needed | One small node package; reuses param-validation pattern; reuses CAMP display; pointcloud injected |
 | Improve incrementally | Node here; per-240 wiring separate (#43); recovery separate (#67) |
-| Test what breaks | Unit tests target the failure modes that matter (slowdown floor, reverse termination, yaw toggle, viz tracking, bad params); sim validation required before water |
-| Workspace vs project separation | Project nav code in the project repo; no workspace coupling |
+| Test what breaks | Pure tests + launch_testing for the risky interop (QoS, TF, single-publisher) + enumerated sim gates; reverse-yaw passthrough gated on the sign test |
+| Workspace vs project separation | Project nav code; **platform-agnostic** — generic relative topics + unprefixed frame defaults, prefix/namespace applied externally |
 
 ## ADR Compliance
 
 | ADR | Triggered | How addressed |
 |---|---|---|
-| 0008 — ROS 2 conventions | Yes | New package mirrors existing `marine_nav_utilities` (format 2, BSD, ament_cmake, C++17); launch/wiring stays in config repo |
-| 0002 — Worktree isolation | Yes | Work on `feature/issue-64` worktree |
-| 0001 — Capture decisions | Yes | Safety-behavior rationale documented in the package README (Q4) |
-| 0013 — progress.md vocabulary | Yes | `## Plan Authored` entry appended |
+| 0008 — ROS 2 conventions | Yes | Mirrors `marine_nav_utilities`; **REP-144 naming** (`marine_nav_ca_safety` pkg / `ca_safety_node` exec); explicit QoS; generic frame/topic names (platform-agnostic) |
+| 0002 — Worktree isolation | Yes | `feature/issue-64` worktree |
+| 0001 — Capture decisions | Yes | Safety-behavior rationale in the package README |
+| 0013 — progress.md vocabulary | Yes | `## Plan Authored` / `## Plan Review` entries |
 
 ## Consequences
 
 | If we change... | Also update... | In plan? |
 |---|---|---|
 | Add a new node (params/topics) | Package README; per-240 config | README yes; config → seafloor#43 |
-| Replace the Collision Monitor (incl. viz) | nav2 chain wiring; **CAMP viz**: polygon topics (color by name) + `CollisionMonitorState` (fill) | Config → seafloor#43; reconcile #25/#27/#36 |
-| New `/odom` + pointcloud deps | Topic supply (coverage decision) | External → seafloor#43 |
+| Replace the Collision Monitor (incl. viz) | nav2 chain wiring + **sole-helm-publisher cutover** (one publisher on `cmd_vel_out`); CAMP viz (polygon topics + `CollisionMonitorState`) | Config → seafloor#43; reconcile #25/#27/#36; CM pass-through on non-reflex boats |
+| New `odom` + pointcloud deps + tf transform | Topic supply + `base_frame` value (prefixed/level) | External → seafloor#43 |
 
 ## Open Questions
 
-- [ ] None open — CAMP viz mechanism confirmed against `camp` source: box **color** keyed
-      off topic name (amber=slowdown, red=stop); **frame-vs-fill** driven by
-      `nav2_msgs/CollisionMonitorState.action_type` (2 s staleness watchdog). Plan is
-      review-plan-ready.
+- [ ] (integration, seafloor#43) Confirm the cutover removes the CM cleanly (single helm
+      publisher), and that CAMP's polygon coloring keys off the topic names — verify on the
+      bench during wiring.
 
 ## Estimated Scope
 
-**Single PR** (node + unit tests + viz) in `unh_marine_navigation`. Config wiring is a
-separate PR in `seafloor_echoboat_project11` (#43); recovery BT back-off is #67. Sim
-validation before any on-water trust.
+**Single PR** (node + unit + launch_testing) in `unh_marine_navigation`. Config wiring is a
+separate PR in `seafloor_echoboat_project11` (#43); recovery BT back-off is #67. Sim gates
+must pass before any on-water trust (and gate the reverse-yaw-passthrough path).

--- a/.agent/work-plans/issue-64/plan.md
+++ b/.agent/work-plans/issue-64/plan.md
@@ -7,12 +7,14 @@ https://github.com/rolker/unh_marine_navigation/issues/64
 ## Context
 
 On EchoBoat 240 (vectored thrust) a hard emergency stop zeroes yaw authority, so the
-boat gets stuck pointed at an obstacle. This node replaces the nav2 Collision Monitor
-with a graduated **safety brake** (not a maneuvering/escape node): it slows earlier and
-proportionally to speed while *preserving the avoider's yaw authority*, then brakes to a
-stop with reverse thrust over a short distance. cmd_vel chain wiring lives in config, not
-this repo — so this PR delivers the **node + tests only**; per-240 wiring is config
-(rolker/seafloor_echoboat_project11#43).
+boat gets stuck pointed at an obstacle. This node **replaces** the nav2 Collision Monitor
+(confirmed) with a graduated **safety brake** (not a maneuvering/escape node): it slows
+earlier and proportionally to speed while *preserving the avoider's yaw authority*, then
+brakes to a stop with reverse thrust over a short distance. It also **takes over the
+Collision Monitor's zone visualization** so CAMP's existing yellow (slowdown) / red (stop)
+boxes keep rendering — with the yellow box now sized live by the speed-scaled zone.
+cmd_vel chain wiring lives in config, not this repo — so this PR delivers the **node +
+tests only**; per-240 wiring is config (rolker/seafloor_echoboat_project11#43).
 
 ## Approach
 
@@ -22,8 +24,8 @@ this repo — so this PR delivers the **node + tests only**; per-240 wiring is c
    `L = clamp(v·T + L_min, L_min, L_max)` (≡ time-to-collision); nearest forward-sector
    obstacle range from points already in base frame; twist modulation
    {slowdown scale that keeps `linear.x` at/above a positive floor; pass `angular.z`
-   through; stop-zone → reverse-brake setpoint}; validation predicates (finite + domain).
-   Mirrors the `costmap_window.h` predicate style.
+   through; stop-zone → reverse-brake setpoint}; zone-polygon geometry (for viz);
+   validation predicates (finite + domain). Mirrors the `costmap_window.h` predicate style.
 3. **Node class `ca_safety_node.h`** (`rclcpp::Node`): subs `cmd_vel_in` (TwistStamped),
    pointcloud (PointCloud2, tf2 → `base_frame`), odom (Odometry, forward-speed feedback);
    pub `cmd_vel_out` (TwistStamped). On each cmd_vel: derive zone from latest cloud range
@@ -31,15 +33,26 @@ this repo — so this PR delivers the **node + tests only**; per-240 wiring is c
    ~0** (no sustained reverse), capped by `reverse_distance`/`reverse_duration`. The
    `cancel_yaw_during_reverse` **dynamic** param toggles whether `angular.z` is zeroed
    (straight brake — sidesteps yaw-sign-in-reverse) or passed through.
-4. **Dynamic parameter validation** per the #62 `CostmapWindowNode` precedent: pre-set
+4. **Zone visualization** — publish `geometry_msgs/PolygonStamped` on
+   `collision_monitor/slowdown_polygon` (sized live by the speed-scaled `L`) and
+   `collision_monitor/stop_polygon` (fixed), in `base_frame`, matching the Collision
+   Monitor's current topics/types so CAMP's yellow/red boxes render unchanged. Gated by
+   `publish_visualization` (default true).
+5. **Source-loss handling** — use the last cloud until `source_timeout`; after that,
+   `source_loss_behavior` (`hold` | `passthrough` | `stop`, default `passthrough` + warn)
+   decides. (Configurable per discussion — `stop` reintroduces the deadlock, so not default.)
+6. **Dynamic parameter validation** per the #62 `CostmapWindowNode` precedent: pre-set
    `onSetParameters` validates (finite/domain, int→double coercion), post-set applies to
    `std::atomic` members.
-5. **`main()`** wrapper in `src/ca_safety_node.cpp`.
-6. **Tests**: `test_ca_safety.cpp` (pure: zone sizing at speed extremes; slowdown floor
+7. **`main()`** wrapper in `src/ca_safety_node.cpp`.
+8. **Tests**: `test_ca_safety.cpp` (pure: zone sizing at speed extremes; slowdown floor
    keeps `linear.x` > 0; reverse-brake terminates at ~0; cancel-yaw toggle both ways;
-   param validation incl. NaN/inf/out-of-domain). `test_ca_safety_node.cpp` (param
-   defaults, dynamic update accept/reject, basic message flow). GTest, in-process.
-7. **Package README** (params, topics, chain placement, "replaces Collision Monitor").
+   polygon geometry tracks `L`; param validation incl. NaN/inf/out-of-domain).
+   `test_ca_safety_node.cpp` (param defaults, dynamic update accept/reject, message flow,
+   viz polygons published). GTest, in-process.
+9. **Package README** documenting params, topics, chain placement ("replaces Collision
+   Monitor"), **and the safety-behavior rationale** (reverse-near-obstacles, yaw-preserving
+   slowdown) — Q4: documented with the node rather than a project `docs/decisions/`.
 
 ## Files to Change
 
@@ -47,18 +60,18 @@ this repo — so this PR delivers the **node + tests only**; per-240 wiring is c
 |---|---|
 | `package.xml` | format 2, BSD; deps: rclcpp, geometry_msgs, sensor_msgs, nav_msgs, tf2, tf2_ros, tf2_geometry_msgs, rcl_interfaces |
 | `CMakeLists.txt` | library + `ca_safety_node` executable → `lib/${PROJECT_NAME}`; gtest registration |
-| `include/marine_nav_ca_safety_node/ca_safety.h` | pure logic: zone sizing, range, twist modulation, validation predicates |
-| `include/marine_nav_ca_safety_node/ca_safety_node.h` | node class: subs/pub, TF, param declare+validate, modulation loop |
+| `include/marine_nav_ca_safety_node/ca_safety.h` | pure logic: zone sizing, range, twist modulation, polygon geometry, validation |
+| `include/marine_nav_ca_safety_node/ca_safety_node.h` | node: subs/pub (incl. viz polygon pubs), TF, param declare+validate, modulation loop |
 | `src/ca_safety_node.cpp` | `main()` |
 | `test/test_ca_safety.cpp` | pure-logic unit tests |
-| `test/test_ca_safety_node.cpp` | node param/flow tests |
-| `README.md` | params, topics, chain placement |
+| `test/test_ca_safety_node.cpp` | node param/flow/viz tests |
+| `README.md` | params, topics, chain placement, safety-behavior rationale |
 
-## Parameters (all validated; geometry/reverse are dynamic)
+## Parameters (all validated; geometry/reverse/viz toggles are dynamic)
 
 | Param | Type / default | Validation |
 |---|---|---|
-| `cmd_vel_in_topic` / `cmd_vel_out_topic` | string / `cmd_vel_smoothed`, `piloting_mode/autonomous/cmd_vel` | non-empty |
+| `cmd_vel_in_topic` / `cmd_vel_out_topic` | string / `cmd_vel_smoothed`, `piloting_mode/autonomous/cmd_vel` | non-empty (TwistStamped, confirmed used everywhere) |
 | `pointcloud_topic` / `odom_topic` / `base_frame` | string / `collision_monitor/pointcloud`, `odom`, `base_link` | non-empty |
 | `ttc_time_constant` `T` | double / 4.0 s | finite, > 0 |
 | `slowdown_min_length` / `slowdown_max_length` | double / 5.0, 25.0 m | finite, > 0, min ≤ max |
@@ -68,16 +81,19 @@ this repo — so this PR delivers the **node + tests only**; per-240 wiring is c
 | `reverse_distance` / `reverse_duration` | double / 3.0 m, 4.0 s | finite, > 0 |
 | `cancel_yaw_during_reverse` | bool / true | — (live toggle for on-water A/B) |
 | `source_timeout` | double / 1.0 s | finite, > 0 |
+| `source_loss_behavior` | string / `passthrough` | one of `hold`,`passthrough`,`stop` |
+| `publish_visualization` | bool / true | — |
+| `slowdown_polygon_topic` / `stop_polygon_topic` | string / `collision_monitor/slowdown_polygon`, `collision_monitor/stop_polygon` | non-empty |
 
 ## Principles Self-Check
 
 | Principle | Consideration |
 |---|---|
-| Human control & transparency | All behavior is configurable; reverse-yaw toggle is a live param; output cmd_vel is observable (a diagnostics topic is a possible follow-up) |
-| A change includes its consequences | Node ships with unit tests; config wiring tracked at seafloor#43, recovery at #67; CM-replacement reconciliation called out |
-| Only what's needed | One small node package; reuses the existing param-validation pattern; no all-around perception (pointcloud injected) |
+| Human control & transparency | All behavior configurable; reverse-yaw toggle is a live param; **zone viz preserved** (operator keeps the yellow/red boxes, yellow now reflects speed); output cmd_vel observable |
+| A change includes its consequences | Node ships with unit tests + README rationale; config wiring at seafloor#43, recovery at #67; CM-replacement (incl. viz) reconciled |
+| Only what's needed | One small node package; reuses the existing param-validation pattern; viz reuses existing CAMP display (no CAMP change); pointcloud injected (no all-around perception) |
 | Improve incrementally | Node here; per-240 wiring separate (#43); recovery separate (#67) |
-| Test what breaks | Unit tests target the failure modes that matter (slowdown floor, reverse termination, yaw toggle, bad params); sim validation required before water |
+| Test what breaks | Unit tests target the failure modes that matter (slowdown floor, reverse termination, yaw toggle, viz tracking, bad params); sim validation required before water |
 | Workspace vs project separation | Project nav code in the project repo; no workspace coupling |
 
 ## ADR Compliance
@@ -86,7 +102,7 @@ this repo — so this PR delivers the **node + tests only**; per-240 wiring is c
 |---|---|---|
 | 0008 — ROS 2 conventions | Yes | New package mirrors existing `marine_nav_utilities` (format 2, BSD, ament_cmake, C++17); launch/wiring stays in config repo |
 | 0002 — Worktree isolation | Yes | Work on `feature/issue-64` worktree |
-| 0001 — Capture decisions | Watch | Safety-behavior rationale lives in #64/PR; project repo has no `docs/decisions/` — see Open Questions |
+| 0001 — Capture decisions | Yes | Safety-behavior rationale documented in the package README (Q4) |
 | 0013 — progress.md vocabulary | Yes | `## Plan Authored` entry appended |
 
 ## Consequences
@@ -94,18 +110,17 @@ this repo — so this PR delivers the **node + tests only**; per-240 wiring is c
 | If we change... | Also update... | In plan? |
 |---|---|---|
 | Add a new node (params/topics) | Package README; per-240 config | README yes; config → seafloor#43 |
-| Replace the Collision Monitor | nav2 chain wiring (CM in/out, velocity_smoother placement) | Config → seafloor#43; reconcile #25/#27/#36 |
+| Replace the Collision Monitor (incl. viz) | nav2 chain wiring; **viz topics consumed by CAMP** (keep same topic names/types) | Config → seafloor#43; reconcile #25/#27/#36 |
 | New `/odom` + pointcloud deps | Topic supply (coverage decision) | External → seafloor#43 |
 
 ## Open Questions
 
-- [ ] **Replace vs augment** the Collision Monitor — plan assumes *replace*; confirm.
-- [ ] **Stale/absent pointcloud** behavior — passthrough, hold-last, or fail-safe stop? (safety decision; note stop kills yaw).
-- [ ] **cmd_vel message type** — assumed TwistStamped (CM ran stamped); confirm against the live chain.
-- [ ] **Capture the safety decision** — record reverse-near-obstacles rationale in PR, or adopt a project `docs/decisions/`?
+- [ ] Verify CAMP keys its yellow/red polygon styling off the **topic names**
+      (`collision_monitor/slowdown_polygon` / `stop_polygon`) so republishing them is
+      sufficient — confirm during integration (seafloor#43).
 
 ## Estimated Scope
 
-**Single PR** (node + unit tests) in `unh_marine_navigation`. Config wiring is a separate
-PR in `seafloor_echoboat_project11` (#43); recovery BT back-off is #67. Sim validation
-before any on-water trust.
+**Single PR** (node + unit tests + viz) in `unh_marine_navigation`. Config wiring is a
+separate PR in `seafloor_echoboat_project11` (#43); recovery BT back-off is #67. Sim
+validation before any on-water trust.

--- a/.agent/work-plans/issue-64/plan.md
+++ b/.agent/work-plans/issue-64/plan.md
@@ -1,0 +1,111 @@
+# Plan: CA safety node — speed-scaled yaw-preserving slowdown + reverse-assisted stop
+
+## Issue
+
+https://github.com/rolker/unh_marine_navigation/issues/64
+
+## Context
+
+On EchoBoat 240 (vectored thrust) a hard emergency stop zeroes yaw authority, so the
+boat gets stuck pointed at an obstacle. This node replaces the nav2 Collision Monitor
+with a graduated **safety brake** (not a maneuvering/escape node): it slows earlier and
+proportionally to speed while *preserving the avoider's yaw authority*, then brakes to a
+stop with reverse thrust over a short distance. cmd_vel chain wiring lives in config, not
+this repo — so this PR delivers the **node + tests only**; per-240 wiring is config
+(rolker/seafloor_echoboat_project11#43).
+
+## Approach
+
+1. **New package `marine_nav_ca_safety_node`**, mirroring the `marine_nav_utilities`
+   standalone-node pattern (ament_cmake, `package.xml` format 2, BSD, C++17).
+2. **ROS-free core header `ca_safety.h`** — pure, gtest-able functions: slowdown length
+   `L = clamp(v·T + L_min, L_min, L_max)` (≡ time-to-collision); nearest forward-sector
+   obstacle range from points already in base frame; twist modulation
+   {slowdown scale that keeps `linear.x` at/above a positive floor; pass `angular.z`
+   through; stop-zone → reverse-brake setpoint}; validation predicates (finite + domain).
+   Mirrors the `costmap_window.h` predicate style.
+3. **Node class `ca_safety_node.h`** (`rclcpp::Node`): subs `cmd_vel_in` (TwistStamped),
+   pointcloud (PointCloud2, tf2 → `base_frame`), odom (Odometry, forward-speed feedback);
+   pub `cmd_vel_out` (TwistStamped). On each cmd_vel: derive zone from latest cloud range
+   + measured speed, modulate, publish. Reverse braking is **closed-loop on odom speed to
+   ~0** (no sustained reverse), capped by `reverse_distance`/`reverse_duration`. The
+   `cancel_yaw_during_reverse` **dynamic** param toggles whether `angular.z` is zeroed
+   (straight brake — sidesteps yaw-sign-in-reverse) or passed through.
+4. **Dynamic parameter validation** per the #62 `CostmapWindowNode` precedent: pre-set
+   `onSetParameters` validates (finite/domain, int→double coercion), post-set applies to
+   `std::atomic` members.
+5. **`main()`** wrapper in `src/ca_safety_node.cpp`.
+6. **Tests**: `test_ca_safety.cpp` (pure: zone sizing at speed extremes; slowdown floor
+   keeps `linear.x` > 0; reverse-brake terminates at ~0; cancel-yaw toggle both ways;
+   param validation incl. NaN/inf/out-of-domain). `test_ca_safety_node.cpp` (param
+   defaults, dynamic update accept/reject, basic message flow). GTest, in-process.
+7. **Package README** (params, topics, chain placement, "replaces Collision Monitor").
+
+## Files to Change
+
+| File (new, under `marine_nav_ca_safety_node/`) | Change |
+|---|---|
+| `package.xml` | format 2, BSD; deps: rclcpp, geometry_msgs, sensor_msgs, nav_msgs, tf2, tf2_ros, tf2_geometry_msgs, rcl_interfaces |
+| `CMakeLists.txt` | library + `ca_safety_node` executable → `lib/${PROJECT_NAME}`; gtest registration |
+| `include/marine_nav_ca_safety_node/ca_safety.h` | pure logic: zone sizing, range, twist modulation, validation predicates |
+| `include/marine_nav_ca_safety_node/ca_safety_node.h` | node class: subs/pub, TF, param declare+validate, modulation loop |
+| `src/ca_safety_node.cpp` | `main()` |
+| `test/test_ca_safety.cpp` | pure-logic unit tests |
+| `test/test_ca_safety_node.cpp` | node param/flow tests |
+| `README.md` | params, topics, chain placement |
+
+## Parameters (all validated; geometry/reverse are dynamic)
+
+| Param | Type / default | Validation |
+|---|---|---|
+| `cmd_vel_in_topic` / `cmd_vel_out_topic` | string / `cmd_vel_smoothed`, `piloting_mode/autonomous/cmd_vel` | non-empty |
+| `pointcloud_topic` / `odom_topic` / `base_frame` | string / `collision_monitor/pointcloud`, `odom`, `base_link` | non-empty |
+| `ttc_time_constant` `T` | double / 4.0 s | finite, > 0 |
+| `slowdown_min_length` / `slowdown_max_length` | double / 5.0, 25.0 m | finite, > 0, min ≤ max |
+| `slowdown_speed_floor` | double / small +ε (m/s) | finite, > 0 (keeps yaw authority) |
+| `slowdown_width` / `stop_length` / `stop_width` | double / 6.0, 5.0, 4.0 m | finite, > 0 |
+| `reverse_speed` | double / 0.5 m/s | finite, > 0 |
+| `reverse_distance` / `reverse_duration` | double / 3.0 m, 4.0 s | finite, > 0 |
+| `cancel_yaw_during_reverse` | bool / true | — (live toggle for on-water A/B) |
+| `source_timeout` | double / 1.0 s | finite, > 0 |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Human control & transparency | All behavior is configurable; reverse-yaw toggle is a live param; output cmd_vel is observable (a diagnostics topic is a possible follow-up) |
+| A change includes its consequences | Node ships with unit tests; config wiring tracked at seafloor#43, recovery at #67; CM-replacement reconciliation called out |
+| Only what's needed | One small node package; reuses the existing param-validation pattern; no all-around perception (pointcloud injected) |
+| Improve incrementally | Node here; per-240 wiring separate (#43); recovery separate (#67) |
+| Test what breaks | Unit tests target the failure modes that matter (slowdown floor, reverse termination, yaw toggle, bad params); sim validation required before water |
+| Workspace vs project separation | Project nav code in the project repo; no workspace coupling |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0008 — ROS 2 conventions | Yes | New package mirrors existing `marine_nav_utilities` (format 2, BSD, ament_cmake, C++17); launch/wiring stays in config repo |
+| 0002 — Worktree isolation | Yes | Work on `feature/issue-64` worktree |
+| 0001 — Capture decisions | Watch | Safety-behavior rationale lives in #64/PR; project repo has no `docs/decisions/` — see Open Questions |
+| 0013 — progress.md vocabulary | Yes | `## Plan Authored` entry appended |
+
+## Consequences
+
+| If we change... | Also update... | In plan? |
+|---|---|---|
+| Add a new node (params/topics) | Package README; per-240 config | README yes; config → seafloor#43 |
+| Replace the Collision Monitor | nav2 chain wiring (CM in/out, velocity_smoother placement) | Config → seafloor#43; reconcile #25/#27/#36 |
+| New `/odom` + pointcloud deps | Topic supply (coverage decision) | External → seafloor#43 |
+
+## Open Questions
+
+- [ ] **Replace vs augment** the Collision Monitor — plan assumes *replace*; confirm.
+- [ ] **Stale/absent pointcloud** behavior — passthrough, hold-last, or fail-safe stop? (safety decision; note stop kills yaw).
+- [ ] **cmd_vel message type** — assumed TwistStamped (CM ran stamped); confirm against the live chain.
+- [ ] **Capture the safety decision** — record reverse-near-obstacles rationale in PR, or adopt a project `docs/decisions/`?
+
+## Estimated Scope
+
+**Single PR** (node + unit tests) in `unh_marine_navigation`. Config wiring is a separate
+PR in `seafloor_echoboat_project11` (#43); recovery BT back-off is #67. Sim validation
+before any on-water trust.

--- a/.agent/work-plans/issue-64/progress.md
+++ b/.agent/work-plans/issue-64/progress.md
@@ -1,0 +1,24 @@
+---
+issue: 64
+---
+
+# Issue #64 — Collision avoidance at survey speed: turn-before-slowdown is speed-limited (near-miss)
+
+## Issue Review
+**Status**: complete
+**When**: 2026-06-04 19:23 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Issue**: #64
+**Comment**: https://github.com/rolker/unh_marine_navigation/issues/64#issuecomment-4626804034
+**Scope verdict**: needs-splitting
+
+### Actions
+- [ ] Split #64 into sub-issues (keep #64 as umbrella): (a) speed-scaled slowdown zones [config in seafloor/echoboats]; (b) custom e-stop node (yaw-preserving + reverse-arc) [this repo]; (c) yaw-sign-in-reverse sim verification spike [blocks (b)]; (d) recovery-BT back-off branch; (e) aft reflex cloud [if scope expands]
+- [ ] Settle replace-vs-augment with the existing nav2 Collision Monitor (reconcile chain placement vs seafloor #25/#27/#36 + velocity_smoother) before planning the node
+- [ ] Default reflex scope to forward-only + aft-gated reverse for June; defer all-around
+- [ ] Treat as safety-critical: sim validation + regression tests in-scope, not follow-ups (yaw-sign-in-reverse, reverse closed-loop termination, speed-scaled zone extremes, escape-when-avoider-gave-up)
+- [ ] ADR-0008: declare + validate node parameters (finiteness/domain), per #62 precedent
+- [ ] Capture the safety-behavior decision (replace CM + autonomous reverse near obstacles) durably; operator-visible/configurable/abortable (CAMP annunciation)
+- [ ] Coordinate speed-scaled polygon config with seafloor #3 (model split, in flight); principled fix tracked at seafloor #42
+- [ ] Add /odom (mavros local_position/velocity_body) subscription; wire back-off into run_tasks.xml RecoveryNode

--- a/.agent/work-plans/issue-64/progress.md
+++ b/.agent/work-plans/issue-64/progress.md
@@ -78,3 +78,5 @@ issue: 64
 - [ ] (suggestion) source_loss hold uses stale cloud indefinitely — warn (Copilot)
 - [ ] (suggestion) Default rclcpp::Time members clock-type fragile — init from clock (Claude)
 - [ ] (suggestion) Integration test missing closed-loop stop + flicker coverage (Claude+Copilot)
+
+**Resolved**: all 4 must-fix + 4 suggestions addressed in `7d0a7b9` (rebuilt + retested: 17 pure gtests, 12 node gtests, 4 launch tests, cppcheck + python lint green). Remaining colcon-test lint = repo-convention copyright/cpplint + uncrustify 0.78.1 drift only.

--- a/.agent/work-plans/issue-64/progress.md
+++ b/.agent/work-plans/issue-64/progress.md
@@ -80,3 +80,18 @@ issue: 64
 - [ ] (suggestion) Integration test missing closed-loop stop + flicker coverage (Claude+Copilot)
 
 **Resolved**: all 4 must-fix + 4 suggestions addressed in `7d0a7b9` (rebuilt + retested: 17 pure gtests, 12 node gtests, 4 launch tests, cppcheck + python lint green). Remaining colcon-test lint = repo-convention copyright/cpplint + uncrustify 0.78.1 drift only.
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-06-05 01:58 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**PR**: #68
+**Sources**: Copilot PR review (5 inline comments)
+**Verdict**: all valid; addressed in `45e51ae`
+
+### Findings
+- [x] (valid, safety) odom NaN not sanitized → applyStop could hold zero instead of braking in the stop zone — drop non-finite odom → stale → duration backstop; +launch test (obstacle + NaN odom must brake)
+- [x] (valid) source_loss_behavior silently defaulted on unknown string → warn
+- [x] (valid) sole-helm-publisher invariant not enforced in code → warn if >1 publisher on cmd_vel_out
+- [x] (doc) reverse_distance "independent of odom" misleading → clarified (duration is the odom-independent bound)
+- [x] (doc) isFinitePositive "UB" comment → reworded (NaN propagation, not UB)

--- a/.agent/work-plans/issue-64/progress.md
+++ b/.agent/work-plans/issue-64/progress.md
@@ -37,3 +37,23 @@ issue: 64
 - [ ] Stale/absent pointcloud behavior (passthrough / hold-last / fail-safe stop)
 - [ ] Confirm cmd_vel message type is TwistStamped against the live chain
 - [ ] Capture the safety-behavior decision (PR rationale vs project docs/decisions)
+
+## Plan Review
+**Status**: complete
+**When**: 2026-06-04 20:51 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context)) (in-context — author self-review; incorporated an independent fresh-context sub-review)
+
+**Plan**: `.agent/work-plans/issue-64/plan.md` at `675dee1`
+**PR**: https://github.com/rolker/unh_marine_navigation/pull/68
+**Verdict**: changes-requested
+
+### Findings
+- [ ] (must-fix) Reflex cloud is in `bizzy/base_link_level` (stabilized, tf_prefixed), not `base_link`; add `tf2_sensor_msgs` dep + name the transform mechanism + handle tf_prefix + level-vs-base distinction — plan.md:31,33,70,84
+- [ ] (must-fix) Specify QoS per endpoint (pointcloud best-effort/sensor-data; state+polygons reliable depth1; cmd_vel matched to smoother/echo_helm) — stack has silent QoS-mismatch history (#56) — plan.md:32-48,70-77
+- [ ] (must-fix) Drive viz + CollisionMonitorState from an independent ~1-2 Hz timer, not piggybacked on cmd_vel (CAMP 2 s watchdog blanks fills if cmd_vel pauses); state cmd_vel_out behavior when input stops — plan.md:34,46-47
+- [ ] (must-fix) Sole-helm-publisher invariant + CM→node cutover ordering as explicit risk (wiring in seafloor#43); note CM-as-passthrough on non-reflex boats — plan.md:19-20,83
+- [ ] (must-fix) Make sim/integration validation concrete (scenarios+acceptance or launch_testing); GATE the reverse-yaw-passthrough path off until the yaw-sign-in-reverse sim test passes (issue's stated blocker, currently demoted to a live toggle) — plan.md:38,60-61,106,137
+- [ ] (suggestion) Rename package `marine_nav_ca_safety` (executable `ca_safety_node`) per REP-144 — plan.md:24,68,71
+- [ ] (suggestion) Justify the `nav2_msgs` coupling (one line) — plan.md:70
+- [ ] (suggestion) Specify odom-loss handling in reverse: duration/distance hard backstop independent of odom — plan.md:36-38,49-51
+- [ ] (suggestion) Add launch_testing artifact to Files table if adopting the integration-test finding — plan.md:66-77

--- a/.agent/work-plans/issue-64/progress.md
+++ b/.agent/work-plans/issue-64/progress.md
@@ -57,3 +57,24 @@ issue: 64
 - [ ] (suggestion) Justify the `nav2_msgs` coupling (one line) — plan.md:70
 - [ ] (suggestion) Specify odom-loss handling in reverse: duration/distance hard backstop independent of odom — plan.md:36-38,49-51
 - [ ] (suggestion) Add launch_testing artifact to Files table if adopting the integration-test finding — plan.md:66-77
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-04 22:33 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: changes-requested
+
+**Branch**: feature/issue-64 at `e2e811f`
+**Mode**: pre-push
+**Depth**: Deep (reason: safety-critical, replaces sole helm publisher)
+**Must-fix**: 4 | **Suggestions**: 4
+
+### Findings
+- [ ] (must-fix) Reverse backstop resets on transient declassification → runaway into unsensed stern (Claude+Copilot cross-confirmed) — `ca_safety_node.h` doStop/resetReverse
+- [ ] (must-fix) Distance backstop permanently disabled if odom stale at reverse start (Claude+Copilot) — `ca_safety_node.h:313`
+- [ ] (must-fix) Unvalidated input twist (NaN/inf) propagates to helm (Copilot) — `ca_safety_node.h` cmdVelCallback
+- [ ] (must-fix) stop_speed_eps unvalidated, not dynamic (Claude) — `ca_safety_node.h:62`
+- [ ] (suggestion) Enforce slowdown min<=max cross-field (Claude+Copilot)
+- [ ] (suggestion) source_loss hold uses stale cloud indefinitely — warn (Copilot)
+- [ ] (suggestion) Default rclcpp::Time members clock-type fragile — init from clock (Claude)
+- [ ] (suggestion) Integration test missing closed-loop stop + flicker coverage (Claude+Copilot)

--- a/.agent/work-plans/issue-64/progress.md
+++ b/.agent/work-plans/issue-64/progress.md
@@ -22,3 +22,18 @@ issue: 64
 - [ ] Capture the safety-behavior decision (replace CM + autonomous reverse near obstacles) durably; operator-visible/configurable/abortable (CAMP annunciation)
 - [ ] Coordinate speed-scaled polygon config with seafloor #3 (model split, in flight); principled fix tracked at seafloor #42
 - [ ] Add /odom (mavros local_position/velocity_body) subscription; wire back-off into run_tasks.xml RecoveryNode
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-06-04 20:08 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Plan**: `.agent/work-plans/issue-64/plan.md` at `5ebde97`
+**PR**: https://github.com/rolker/unh_marine_navigation/pull/68 (`[PLAN]` prefix)
+**Phases**: single
+
+### Open questions
+- [ ] Replace vs augment the nav2 Collision Monitor (plan assumes replace)
+- [ ] Stale/absent pointcloud behavior (passthrough / hold-last / fail-safe stop)
+- [ ] Confirm cmd_vel message type is TwistStamped against the live chain
+- [ ] Capture the safety-behavior decision (PR rationale vs project docs/decisions)

--- a/marine_nav_ca_safety/CMakeLists.txt
+++ b/marine_nav_ca_safety/CMakeLists.txt
@@ -1,0 +1,88 @@
+cmake_minimum_required(VERSION 3.14.4)
+
+project(marine_nav_ca_safety)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(nav_msgs REQUIRED)
+find_package(nav2_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(rcl_interfaces REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(tf2 REQUIRED)
+find_package(tf2_ros REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
+find_package(tf2_sensor_msgs REQUIRED)
+
+# Header-only logic + node class; exported as an INTERFACE library.
+add_library(${PROJECT_NAME} INTERFACE)
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+target_include_directories(
+  ${PROJECT_NAME}
+  INTERFACE
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+
+set(ca_safety_deps
+  geometry_msgs
+  nav_msgs
+  nav2_msgs
+  sensor_msgs
+  rcl_interfaces
+  rclcpp
+  tf2
+  tf2_ros
+  tf2_geometry_msgs
+  tf2_sensor_msgs
+)
+
+add_executable(ca_safety_node src/ca_safety_node.cpp)
+target_include_directories(ca_safety_node PRIVATE include)
+ament_target_dependencies(ca_safety_node ${ca_safety_deps})
+
+install(TARGETS ca_safety_node
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+install(
+  DIRECTORY include/
+  DESTINATION include/${PROJECT_NAME}
+)
+
+install(
+  TARGETS ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
+)
+
+ament_export_targets(export_${PROJECT_NAME})
+ament_export_dependencies(${ca_safety_deps})
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+
+  find_package(ament_cmake_gtest REQUIRED)
+
+  # Pure logic — no ROS link needed.
+  ament_add_gtest(test_ca_safety test/test_ca_safety.cpp)
+  target_include_directories(test_ca_safety PRIVATE include)
+
+  ament_add_gtest(test_ca_safety_node test/test_ca_safety_node.cpp)
+  target_include_directories(test_ca_safety_node PRIVATE include)
+  ament_target_dependencies(test_ca_safety_node ${ca_safety_deps})
+
+  # Cross-process integration: QoS interop (best-effort cloud, reliable cmd_vel),
+  # TF transform of a real cloud, and the braking reaction + single output publisher.
+  find_package(launch_testing_ament_cmake REQUIRED)
+  add_launch_test(test/test_ca_safety_launch.py)
+endif()
+
+ament_package()

--- a/marine_nav_ca_safety/README.md
+++ b/marine_nav_ca_safety/README.md
@@ -85,7 +85,7 @@ Geometry/reverse tunables and the two toggles are **dynamically updatable**
 | `slowdown_width` | 6.0 m | |
 | `stop_length` / `stop_width` | 5.0 / 4.0 m | |
 | `reverse_speed` | 0.5 m/s | reverse-brake setpoint magnitude |
-| `reverse_distance` / `reverse_duration` | 3.0 m / 4.0 s | odom-independent hard backstop |
+| `reverse_distance` / `reverse_duration` | 3.0 m / 4.0 s | reverse backstop; **duration** is the odom-independent bound (always enforced), distance applies only while odom pose is available |
 | `reverse_clear_debounce` | 1.0 s | sustained-clear time before a reverse episode resets its backstop (flicker guard) |
 | `stop_speed_eps` | 0.05 m/s | speed below which the boat counts as stopped (ends reverse brake) |
 | `cancel_yaw_during_reverse` | true | passthrough (false) gated on the sim sign test |

--- a/marine_nav_ca_safety/README.md
+++ b/marine_nav_ca_safety/README.md
@@ -1,0 +1,102 @@
+# marine_nav_ca_safety
+
+A collision-avoidance **safety brake** for marine vehicles that replaces the
+[nav2 Collision Monitor](https://docs.nav2.org/configuration/packages/configuring-collision-monitor.html)
+in the velocity command chain. It sits between the velocity smoother and the helm:
+it modulates the commanded twist to avoid obstacles, and republishes the Collision
+Monitor's CAMP zone visualization.
+
+## What it does
+
+`ca_safety_node` subscribes to the velocity command, an obstacle point cloud, and
+odometry, and republishes a modulated velocity command:
+
+1. **Speed-scaled, yaw-preserving slowdown.** As an obstacle enters a forward
+   corridor whose length grows with speed (`L = speed * ttc_time_constant +
+   slowdown_min_length`, clamped), the forward speed is scaled down — but never
+   below `slowdown_speed_floor`, so a vectored-thrust hull keeps the thrust it
+   needs to *turn*. Yaw is passed through untouched. This is what lets the
+   deliberative avoider steer clear before the boat reaches the stop box.
+2. **Reverse-assisted stop.** In a close stop box the node brakes to a stop with
+   reverse thrust (closed-loop on odometry speed), with a hard
+   `reverse_distance` / `reverse_duration` backstop that is independent of
+   odometry — so an odometry dropout mid-reverse cannot cause an aft runaway.
+
+It is **not** a maneuvering/escape node: it brakes, it does not try to turn the
+boat out of trouble. Recovering from a full stop is left to the avoider (which the
+yaw-preserving slowdown keeps fed) and to future work.
+
+## Why reverse, and why yaw stays alive (safety rationale)
+
+On a vectored-thrust boat, yaw is produced by thrust × steering — a hard stop
+zeroes thrust and therefore the ability to turn, leaving the boat stuck pointed at
+the obstacle. So this node (a) never zeroes forward speed while slowing (keeps yaw
+authority) and (b) uses reverse thrust to brake in a short distance. By default
+`cancel_yaw_during_reverse` is `true` (a straight brake), because passing yaw
+through *during reverse* requires the steering sign to flip for the reversed
+direction; the pass-through path stays disabled until that sign behavior is
+verified in simulation.
+
+## Platform-agnostic
+
+This package is hull-agnostic: all topic names are **relative** and all frame
+names come from parameters with **generic, unprefixed defaults**. The deployment
+applies the namespace (e.g. via `PushRosNamespace`) and the actual frame (e.g. a
+roll/pitch-stabilized `…/base_link_level`) through launch/config. Nothing here is
+specific to a particular boat.
+
+## Topics
+
+| Direction | Default topic | Type | QoS |
+|---|---|---|---|
+| sub | `cmd_vel_smoothed` | `geometry_msgs/TwistStamped` | reliable, depth 1 |
+| sub | `collision_monitor/pointcloud` | `sensor_msgs/PointCloud2` | **best-effort** (sensor data) |
+| sub | `odom` | `nav_msgs/Odometry` | reliable, depth 5 |
+| pub | `piloting_mode/autonomous/cmd_vel` | `geometry_msgs/TwistStamped` | reliable, depth 1 |
+| pub | `collision_monitor/slowdown_polygon` | `geometry_msgs/PolygonStamped` | reliable, depth 1 |
+| pub | `collision_monitor/stop_polygon` | `geometry_msgs/PolygonStamped` | reliable, depth 1 |
+| pub | `collision_monitor_state` | `nav2_msgs/CollisionMonitorState` | reliable, depth 1 |
+
+QoS is set **explicitly** on every endpoint: the point-cloud subscription is
+best-effort to match the reflex cloud, and the cmd_vel/viz endpoints are reliable
+to match the smoother/helm and CAMP. (Implicit QoS has silently lost data in this
+stack before.)
+
+### CAMP visualization
+
+CAMP draws the slowdown (amber) and stop (red) boxes from the two
+`PolygonStamped` topics (colored by topic name) and fills them when active based
+on `collision_monitor_state.action_type`. The state is published on an
+independent timer (`viz_rate`, default 2 Hz) so the fill does not blank under
+CAMP's 2 s staleness watchdog when cmd_vel pauses. The slowdown polygon is resized
+each tick to the current speed-scaled length.
+
+## Parameters
+
+Geometry/reverse tunables and the two toggles are **dynamically updatable**
+(validated: finite and > 0); topics, frames, `source_loss_behavior`, and
+`viz_rate` are read at startup.
+
+| Parameter | Default | Notes |
+|---|---|---|
+| `ttc_time_constant` | 4.0 s | slowdown length = speed·T + min |
+| `slowdown_min_length` / `slowdown_max_length` | 5.0 / 25.0 m | |
+| `slowdown_speed_floor` | 0.1 m/s | forward speed kept during slowdown (yaw authority) |
+| `slowdown_width` | 6.0 m | |
+| `stop_length` / `stop_width` | 5.0 / 4.0 m | |
+| `reverse_speed` | 0.5 m/s | reverse-brake setpoint magnitude |
+| `reverse_distance` / `reverse_duration` | 3.0 m / 4.0 s | odom-independent hard backstop |
+| `cancel_yaw_during_reverse` | true | passthrough (false) gated on the sim sign test |
+| `source_timeout` | 1.0 s | max cloud/odom age before considered lost |
+| `source_loss_behavior` | `passthrough` | `hold` \| `passthrough` \| `stop` |
+| `publish_visualization` | true | |
+| `viz_rate` | 2.0 Hz | inside CAMP's 2 s watchdog |
+| `base_frame` | `base_link` | generic; deployment supplies the prefixed/level frame |
+| `*_topic` | see table above | all relative |
+
+## Chain placement
+
+This node **replaces** the Collision Monitor, so exactly one of the two may
+publish the helm topic at a time. The per-boat wiring (removing the Collision
+Monitor, pointing the smoother output and reflex cloud at this node, supplying the
+namespaced/level frame) lives in the deployment config repo, not here.

--- a/marine_nav_ca_safety/README.md
+++ b/marine_nav_ca_safety/README.md
@@ -86,6 +86,8 @@ Geometry/reverse tunables and the two toggles are **dynamically updatable**
 | `stop_length` / `stop_width` | 5.0 / 4.0 m | |
 | `reverse_speed` | 0.5 m/s | reverse-brake setpoint magnitude |
 | `reverse_distance` / `reverse_duration` | 3.0 m / 4.0 s | odom-independent hard backstop |
+| `reverse_clear_debounce` | 1.0 s | sustained-clear time before a reverse episode resets its backstop (flicker guard) |
+| `stop_speed_eps` | 0.05 m/s | speed below which the boat counts as stopped (ends reverse brake) |
 | `cancel_yaw_during_reverse` | true | passthrough (false) gated on the sim sign test |
 | `source_timeout` | 1.0 s | max cloud/odom age before considered lost |
 | `source_loss_behavior` | `passthrough` | `hold` \| `passthrough` \| `stop` |

--- a/marine_nav_ca_safety/include/marine_nav_ca_safety/ca_safety.h
+++ b/marine_nav_ca_safety/include/marine_nav_ca_safety/ca_safety.h
@@ -11,7 +11,7 @@ namespace marine_nav_ca_safety
 {
 
 /// A tunable is usable only if finite and positive. A NaN would otherwise slip
-/// past a bare `<= 0` test into arithmetic/clamp (undefined behavior). Shared by
+/// past a bare `<= 0` test and propagate through the arithmetic as NaN. Shared by
 /// the pure logic below and the node's parameter validation.
 inline bool isFinitePositive(double v)
 {

--- a/marine_nav_ca_safety/include/marine_nav_ca_safety/ca_safety.h
+++ b/marine_nav_ca_safety/include/marine_nav_ca_safety/ca_safety.h
@@ -1,0 +1,157 @@
+#ifndef MARINE_NAV_CA_SAFETY_CA_SAFETY_H
+#define MARINE_NAV_CA_SAFETY_CA_SAFETY_H
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <limits>
+#include <vector>
+
+namespace marine_nav_ca_safety
+{
+
+/// A tunable is usable only if finite and positive. A NaN would otherwise slip
+/// past a bare `<= 0` test into arithmetic/clamp (undefined behavior). Shared by
+/// the pure logic below and the node's parameter validation.
+inline bool isFinitePositive(double v)
+{
+  return std::isfinite(v) && v > 0.0;
+}
+
+/// A 2D obstacle point expressed in the node's computation (base) frame:
+/// x forward, y left, per REP-103.
+struct Point2
+{
+  double x{0.0};
+  double y{0.0};
+};
+
+/// A planar velocity command (the subset of a Twist this node modulates).
+struct Twist2
+{
+  double linear_x{0.0};
+  double angular_z{0.0};
+};
+
+/// Geometry + behavior tunables. Validated by the node before use; the pure
+/// functions additionally guard against a misordered slowdown length range so a
+/// bad live update can never trigger undefined behavior.
+struct SafetyParams
+{
+  double ttc_time_constant{4.0};     // s   — slowdown leading edge = speed * this + min
+  double slowdown_min_length{5.0};   // m
+  double slowdown_max_length{25.0};  // m
+  double slowdown_speed_floor{0.1};  // m/s — forward speed kept during slowdown (yaw authority)
+  double slowdown_width{6.0};        // m   — full lateral width of the slowdown corridor
+  double stop_length{5.0};           // m
+  double stop_width{4.0};            // m
+  double reverse_speed{0.5};         // m/s — reverse-brake setpoint magnitude
+  bool cancel_yaw_during_reverse{true};
+};
+
+/// Which safety zone the nearest obstacle falls in.
+enum class Zone
+{
+  Clear,
+  Slowdown,
+  Stop
+};
+
+/// Speed-scaled slowdown leading-edge distance (time-to-collision form):
+/// `clamp(speed * T + min, min, max)`. Negative speed is treated as 0 (the boat
+/// is not closing forward). Robust to a misordered [min, max].
+inline double slowdownLength(double speed, const SafetyParams & p)
+{
+  const double lo = p.slowdown_min_length;
+  const double hi = std::max(p.slowdown_max_length, lo);
+  const double len = std::max(0.0, speed) * p.ttc_time_constant + lo;
+  return std::clamp(len, lo, hi);
+}
+
+/// Nearest forward-sector obstacle range: the smallest x over points inside the
+/// centered forward box `[0, max_x] x [-width/2, +width/2]`. Returns +inf when no
+/// point qualifies. Non-finite points are ignored.
+inline double nearestForwardRange(const std::vector<Point2> & pts, double width, double max_x)
+{
+  double nearest = std::numeric_limits<double>::infinity();
+  const double half = 0.5 * width;
+  for (const auto & pt : pts) {
+    if (!std::isfinite(pt.x) || !std::isfinite(pt.y)) {
+      continue;
+    }
+    if (pt.x >= 0.0 && pt.x <= max_x && std::abs(pt.y) <= half) {
+      nearest = std::min(nearest, pt.x);
+    }
+  }
+  return nearest;
+}
+
+/// Classify the active zone. `stop_range` is the nearest range within the stop
+/// box; `slow_range` the nearest within the slowdown corridor (already bounded by
+/// `slowdown_len`). Stop dominates slowdown.
+inline Zone classify(double stop_range, double slow_range, double slowdown_len)
+{
+  if (std::isfinite(stop_range)) {
+    return Zone::Stop;
+  }
+  if (std::isfinite(slow_range) && slow_range <= slowdown_len) {
+    return Zone::Slowdown;
+  }
+  return Zone::Clear;
+}
+
+/// Forward-speed scale in [0, 1]: 1 at/beyond `slowdown_len`, ramping linearly to
+/// 0 at the stop boundary. Degenerate range (`slowdown_len <= stop_len`) yields a
+/// hard step at `stop_len`.
+inline double slowdownScale(double range, double slowdown_len, double stop_len)
+{
+  if (!(slowdown_len > stop_len)) {
+    return (range <= stop_len) ? 0.0 : 1.0;
+  }
+  const double t = (range - stop_len) / (slowdown_len - stop_len);
+  return std::clamp(t, 0.0, 1.0);
+}
+
+/// Yaw-preserving slowdown: reduce a *positive* forward speed toward the floor,
+/// never speeding up, never below the floor (so the boat keeps the thrust it
+/// needs to yaw on a vectored hull). Yaw is passed through untouched. A
+/// non-positive input linear_x is left alone (the node isn't driving forward).
+inline Twist2 applySlowdown(const Twist2 & in, double scale, double speed_floor)
+{
+  Twist2 out = in;  // angular_z preserved
+  if (in.linear_x > 0.0) {
+    const double floor = std::max(0.0, speed_floor);
+    const double scaled = in.linear_x * std::clamp(scale, 0.0, 1.0);
+    out.linear_x = std::min(in.linear_x, std::max(scaled, floor));
+  }
+  return out;
+}
+
+/// Reverse-assisted stop setpoint. While the boat still has forward way on
+/// (`measured_speed > stop_speed_eps`) and reversing is still permitted by the
+/// node's distance/duration backstop (`reverse_allowed`), command reverse thrust
+/// to brake; otherwise hold zero. Yaw is cancelled (straight brake) unless
+/// pass-through is explicitly enabled.
+inline Twist2 applyStop(
+  const Twist2 & in, double measured_speed, bool reverse_allowed,
+  const SafetyParams & p, double stop_speed_eps)
+{
+  Twist2 out;
+  const bool still_moving = measured_speed > stop_speed_eps;
+  out.linear_x = (reverse_allowed && still_moving) ? -std::abs(p.reverse_speed) : 0.0;
+  out.angular_z = p.cancel_yaw_during_reverse ? 0.0 : in.angular_z;
+  return out;
+}
+
+/// Corners of a centered forward box `[0, length] x [-width/2, +width/2]`, ordered
+/// for a closed polygon (far-left, far-right, near-right, near-left). Used for the
+/// CAMP zone-visualization polygons.
+inline std::array<Point2, 4> forwardBoxCorners(double length, double width)
+{
+  const double h = 0.5 * width;
+  return {Point2{length, h}, Point2{length, -h}, Point2{0.0, -h}, Point2{0.0, h}};
+}
+
+}  // namespace marine_nav_ca_safety
+
+#endif  // MARINE_NAV_CA_SAFETY_CA_SAFETY_H

--- a/marine_nav_ca_safety/include/marine_nav_ca_safety/ca_safety.h
+++ b/marine_nav_ca_safety/include/marine_nav_ca_safety/ca_safety.h
@@ -18,6 +18,13 @@ inline bool isFinitePositive(double v)
   return std::isfinite(v) && v > 0.0;
 }
 
+/// Replace a non-finite command component with 0 so NaN/inf from upstream can
+/// never reach the helm. (A zeroed command coasts to a stop — safe.)
+inline double finiteOrZero(double v)
+{
+  return std::isfinite(v) ? v : 0.0;
+}
+
 /// A 2D obstacle point expressed in the node's computation (base) frame:
 /// x forward, y left, per REP-103.
 struct Point2
@@ -141,6 +148,32 @@ inline Twist2 applyStop(
   out.linear_x = (reverse_allowed && still_moving) ? -std::abs(p.reverse_speed) : 0.0;
   out.angular_z = p.cancel_yaw_during_reverse ? 0.0 : in.angular_z;
   return out;
+}
+
+/// Reverse-brake backstop: is reverse still permitted? Bounded by elapsed time
+/// always, and by traveled distance only when a start pose was captured
+/// (`have_distance`). Both limits are evaluated against caller-supplied measured
+/// quantities; the time bound is the odom-independent guarantee.
+inline bool reverseAllowed(
+  double elapsed_s, double duration_limit_s,
+  bool have_distance, double distance_m, double distance_limit_m)
+{
+  if (!(elapsed_s < duration_limit_s)) {
+    return false;
+  }
+  if (have_distance && !(distance_m < distance_limit_m)) {
+    return false;
+  }
+  return true;
+}
+
+/// A reverse-brake episode ends (and its backstop timers may reset) only after
+/// the Stop zone has been gone for longer than the debounce window. This makes
+/// the backstop cumulative across transient declassification (a flickering cloud
+/// must not keep restarting the timer and so permit unbounded reverse).
+inline bool reverseEpisodeEnded(double since_last_stop_s, double clear_debounce_s)
+{
+  return since_last_stop_s > clear_debounce_s;
 }
 
 /// Corners of a centered forward box `[0, length] x [-width/2, +width/2]`, ordered

--- a/marine_nav_ca_safety/include/marine_nav_ca_safety/ca_safety_node.h
+++ b/marine_nav_ca_safety/include/marine_nav_ca_safety/ca_safety_node.h
@@ -59,7 +59,6 @@ public:
     stop_polygon_topic_ =
       declare_parameter<std::string>("stop_polygon_topic", "collision_monitor/stop_polygon");
     base_frame_ = declare_parameter<std::string>("base_frame", "base_link");
-    stop_speed_eps_ = declare_parameter<double>("stop_speed_eps", 0.05);
     const double viz_rate = declare_parameter<double>("viz_rate", 2.0);
     source_loss_behavior_ = parseSourceLoss(
       declare_parameter<std::string>("source_loss_behavior", "passthrough"));
@@ -85,6 +84,11 @@ public:
       "reverse_duration", 4.0, "Hard backstop: max reverse duration (s), independent of odom.");
     source_timeout_ =
       declareDynamicDouble("source_timeout", 1.0, "Max age of cloud/odom before considered lost (s).");
+    stop_speed_eps_ = declareDynamicDouble(
+      "stop_speed_eps", 0.05, "Forward speed below which the boat counts as stopped (ends reverse brake).");
+    reverse_clear_debounce_ = declareDynamicDouble(
+      "reverse_clear_debounce", 1.0,
+      "Sustained clear time before a reverse-brake episode resets its odom-independent backstop.");
     {
       rcl_interfaces::msg::ParameterDescriptor d;
       d.description =
@@ -136,6 +140,14 @@ public:
     viz_timer_ = create_wall_timer(
       std::chrono::duration<double>(1.0 / rate),
       std::bind(&CaSafetyNode::vizTimerCallback, this));
+
+    // Initialize time members from the node clock so the (guarded) age
+    // subtractions below never mix clock types under use_sim_time.
+    const auto t0 = get_clock()->now();
+    last_cloud_time_ = t0;
+    last_odom_time_ = t0;
+    reverse_start_time_ = t0;
+    last_stop_seen_ = t0;
   }
 
 private:
@@ -158,7 +170,7 @@ private:
     static const std::unordered_set<std::string> names{
       "ttc_time_constant", "slowdown_min_length", "slowdown_max_length", "slowdown_speed_floor",
       "slowdown_width", "stop_length", "stop_width", "reverse_speed", "reverse_distance",
-      "reverse_duration", "source_timeout"};
+      "reverse_duration", "source_timeout", "stop_speed_eps", "reverse_clear_debounce"};
     return names;
   }
 
@@ -206,6 +218,21 @@ private:
         break;
       }
     }
+    if (result.successful) {
+      // Cross-field: the slowdown corridor length range must be ordered.
+      // Reconstruct the effective values from this request plus current state.
+      double eff_min = slowdown_min_length_.load();
+      double eff_max = slowdown_max_length_.load();
+      for (const auto & p : parameters) {
+        double v;
+        if (p.get_name() == "slowdown_min_length" && numericFromParameter(p, v)) {eff_min = v;}
+        if (p.get_name() == "slowdown_max_length" && numericFromParameter(p, v)) {eff_max = v;}
+      }
+      if (eff_min > eff_max) {
+        result.successful = false;
+        result.reason = "slowdown_min_length must be <= slowdown_max_length";
+      }
+    }
     return result;
   }
 
@@ -230,7 +257,9 @@ private:
           n == "reverse_duration")
         {
           reverse_duration_ = v;
-        } else if (n == "source_timeout") {source_timeout_ = v;}
+        } else if (n == "source_timeout") {source_timeout_ = v;} else if (n == "stop_speed_eps") {
+          stop_speed_eps_ = v;
+        } else if (n == "reverse_clear_debounce") {reverse_clear_debounce_ = v;}
       } else if (n == "cancel_yaw_during_reverse" &&
         p.get_type() == rclcpp::ParameterType::PARAMETER_BOOL)
       {
@@ -300,31 +329,48 @@ private:
     }
   }
 
-  void resetReverse() {reverse_active_ = false;}
+  // End a reverse episode only after the Stop zone has been gone for the debounce
+  // window, so a flickering (best-effort) cloud cannot keep restarting the
+  // odom-independent backstop and permit unbounded reverse into the unsensed
+  // stern (F1).
+  void maybeEndReverseEpisode(const rclcpp::Time & t)
+  {
+    if (reverse_active_ &&
+      reverseEpisodeEnded((t - last_stop_seen_).seconds(), reverse_clear_debounce_.load()))
+    {
+      reverse_active_ = false;
+    }
+  }
 
   // Reverse-brake with a hard distance/duration backstop that does NOT depend on
   // odom, so an odom dropout mid-reverse cannot cause aft runaway.
   Twist2 doStop(const Twist2 & in, double speed, bool odom_fresh, const SafetyParams & p)
   {
     const rclcpp::Time t = now();
+    last_stop_seen_ = t;
     if (!reverse_active_) {
       reverse_active_ = true;
       reverse_start_time_ = t;
       reverse_start_has_pose_ = odom_fresh;
       reverse_start_x_ = odom_x_;
       reverse_start_y_ = odom_y_;
+    } else if (!reverse_start_has_pose_ && odom_fresh) {
+      // Odom recovered mid-episode: capture the start pose now so the distance
+      // backstop engages from here rather than staying disabled all episode (F2).
+      reverse_start_has_pose_ = true;
+      reverse_start_x_ = odom_x_;
+      reverse_start_y_ = odom_y_;
     }
-    const bool within_duration = (t - reverse_start_time_).seconds() < reverse_duration_.load();
-    bool within_distance = true;
-    if (odom_fresh && reverse_start_has_pose_) {
-      within_distance =
-        std::hypot(odom_x_ - reverse_start_x_, odom_y_ - reverse_start_y_) < reverse_distance_.load();
-    }
-    const bool reverse_allowed = within_duration && within_distance;
+    const double elapsed = (t - reverse_start_time_).seconds();
+    const bool have_distance = odom_fresh && reverse_start_has_pose_;
+    const double distance =
+      have_distance ? std::hypot(odom_x_ - reverse_start_x_, odom_y_ - reverse_start_y_) : 0.0;
+    const bool allowed = reverseAllowed(
+      elapsed, reverse_duration_.load(), have_distance, distance, reverse_distance_.load());
     // With odom stale we cannot tell we've stopped; keep braking until the
     // duration backstop ends it (treat as still moving).
     const double speed_for_stop = odom_fresh ? speed : std::numeric_limits<double>::infinity();
-    return applyStop(in, speed_for_stop, reverse_allowed, p, stop_speed_eps_);
+    return applyStop(in, speed_for_stop, allowed, p, stop_speed_eps_.load());
   }
 
   void cmdVelCallback(const geometry_msgs::msg::TwistStamped & msg)
@@ -341,8 +387,19 @@ private:
 
     std::vector<Point2> pts;
     const bool cloud_usable = use_cloud && transformCloud(pts);
+    if (cloud_usable && !cloud_fresh) {
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *get_clock(), 2000,
+        "CA safety: acting on stale obstacle data (source_loss_behavior=hold).");
+    }
 
-    const Twist2 in{msg.twist.linear.x, msg.twist.angular.z};
+    // Never let a non-finite upstream command reach the helm.
+    if (!std::isfinite(msg.twist.linear.x) || !std::isfinite(msg.twist.angular.z)) {
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *get_clock(), 2000,
+        "CA safety: non-finite cmd_vel input; zeroing affected components.");
+    }
+    const Twist2 in{finiteOrZero(msg.twist.linear.x), finiteOrZero(msg.twist.angular.z)};
     Twist2 out = in;
     Zone zone = Zone::Clear;
 
@@ -354,12 +411,12 @@ private:
       switch (zone) {
         case Zone::Clear:
           out = in;
-          resetReverse();
+          maybeEndReverseEpisode(t);
           break;
         case Zone::Slowdown:
           out = applySlowdown(
             in, slowdownScale(slow_range, slow_len, p.stop_length), p.slowdown_speed_floor);
-          resetReverse();
+          maybeEndReverseEpisode(t);
           break;
         case Zone::Stop:
           out = doStop(in, speed, odom_fresh, p);
@@ -374,7 +431,7 @@ private:
     } else {
       // Passthrough (default) or no cloud ever received.
       out = in;
-      resetReverse();
+      maybeEndReverseEpisode(t);
       if (have_cloud_) {
         RCLCPP_WARN_THROTTLE(
           get_logger(), *get_clock(), 2000,
@@ -437,7 +494,6 @@ private:
   // Construction-time config.
   std::string cmd_vel_in_topic_, cmd_vel_out_topic_, pointcloud_topic_, odom_topic_, state_topic_;
   std::string slowdown_polygon_topic_, stop_polygon_topic_, base_frame_;
-  double stop_speed_eps_{0.05};
   SourceLoss source_loss_behavior_{SourceLoss::Passthrough};
 
   // Live params.
@@ -445,6 +501,7 @@ private:
   std::atomic<double> slowdown_speed_floor_{0.1}, slowdown_width_{6.0}, stop_length_{5.0};
   std::atomic<double> stop_width_{4.0}, reverse_speed_{0.5}, reverse_distance_{3.0};
   std::atomic<double> reverse_duration_{4.0}, source_timeout_{1.0};
+  std::atomic<double> stop_speed_eps_{0.05}, reverse_clear_debounce_{1.0};
   std::atomic<bool> cancel_yaw_during_reverse_{true}, publish_visualization_{true};
 
   // Cached inputs (single-threaded executor; no extra locking).
@@ -459,6 +516,7 @@ private:
   bool reverse_active_{false};
   bool reverse_start_has_pose_{false};
   rclcpp::Time reverse_start_time_;
+  rclcpp::Time last_stop_seen_;
   double reverse_start_x_{0.0}, reverse_start_y_{0.0};
 
   Zone current_zone_{Zone::Clear};

--- a/marine_nav_ca_safety/include/marine_nav_ca_safety/ca_safety_node.h
+++ b/marine_nav_ca_safety/include/marine_nav_ca_safety/ca_safety_node.h
@@ -60,8 +60,15 @@ public:
       declare_parameter<std::string>("stop_polygon_topic", "collision_monitor/stop_polygon");
     base_frame_ = declare_parameter<std::string>("base_frame", "base_link");
     const double viz_rate = declare_parameter<double>("viz_rate", 2.0);
-    source_loss_behavior_ = parseSourceLoss(
-      declare_parameter<std::string>("source_loss_behavior", "passthrough"));
+    const std::string source_loss = declare_parameter<std::string>(
+      "source_loss_behavior", "passthrough");
+    if (source_loss != "hold" && source_loss != "passthrough" && source_loss != "stop") {
+      RCLCPP_WARN(
+        get_logger(),
+        "CA safety: unknown source_loss_behavior '%s'; using 'passthrough' "
+        "(valid: hold|passthrough|stop).", source_loss.c_str());
+    }
+    source_loss_behavior_ = parseSourceLoss(source_loss);
 
     // --- Live (dynamic) parameters: geometry/reverse tunables + toggles ---
     ttc_time_constant_ = declareDynamicDouble(
@@ -79,9 +86,11 @@ public:
     reverse_speed_ =
       declareDynamicDouble("reverse_speed", 0.5, "Reverse-brake setpoint magnitude (m/s).");
     reverse_distance_ = declareDynamicDouble(
-      "reverse_distance", 3.0, "Hard backstop: max reverse distance (m), independent of odom.");
+      "reverse_distance", 3.0,
+      "Max reverse distance (m). Enforced only while odom pose is available.");
     reverse_duration_ = declareDynamicDouble(
-      "reverse_duration", 4.0, "Hard backstop: max reverse duration (s), independent of odom.");
+      "reverse_duration", 4.0,
+      "Max reverse duration (s). The odom-INDEPENDENT hard backstop (always enforced).");
     source_timeout_ =
       declareDynamicDouble("source_timeout", 1.0, "Max age of cloud/odom before considered lost (s).");
     stop_speed_eps_ = declareDynamicDouble(
@@ -296,9 +305,22 @@ private:
 
   void odomCallback(const nav_msgs::msg::Odometry & msg)
   {
-    measured_speed_ = msg.twist.twist.linear.x;
-    odom_x_ = msg.pose.pose.position.x;
-    odom_y_ = msg.pose.pose.position.y;
+    const double v = msg.twist.twist.linear.x;
+    const double x = msg.pose.pose.position.x;
+    const double y = msg.pose.pose.position.y;
+    // Reject non-finite odom: a NaN speed would make applyStop()'s
+    // `measured_speed > stop_speed_eps` read false and hold zero instead of
+    // braking in the Stop zone. Dropping the sample lets odom age out to stale,
+    // so the reverse brake falls back to the duration backstop (safe).
+    if (!std::isfinite(v) || !std::isfinite(x) || !std::isfinite(y)) {
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *get_clock(), 2000,
+        "CA safety: non-finite odom; sample dropped (odom ages to stale).");
+      return;
+    }
+    measured_speed_ = v;
+    odom_x_ = x;
+    odom_y_ = y;
     have_odom_ = true;
     last_odom_time_ = now();
   }
@@ -465,6 +487,17 @@ private:
 
   void vizTimerCallback()
   {
+    // Sole-helm-publisher diagnostic: exactly this node should publish the helm
+    // topic. >1 means the Collision Monitor (or another node) wasn't removed at
+    // cutover — surface it rather than let two publishers fight the helm silently.
+    const auto helm_pubs = count_publishers(cmd_vel_out_topic_);
+    if (helm_pubs > 1) {
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *get_clock(), 5000,
+        "CA safety: %zu publishers on '%s' — expected only this node "
+        "(Collision Monitor not removed at cutover?).",
+        helm_pubs, cmd_vel_out_topic_.c_str());
+    }
     if (!publish_visualization_.load()) {
       return;
     }

--- a/marine_nav_ca_safety/include/marine_nav_ca_safety/ca_safety_node.h
+++ b/marine_nav_ca_safety/include/marine_nav_ca_safety/ca_safety_node.h
@@ -1,0 +1,482 @@
+#ifndef MARINE_NAV_CA_SAFETY_CA_SAFETY_NODE_H
+#define MARINE_NAV_CA_SAFETY_CA_SAFETY_NODE_H
+
+#include <atomic>
+#include <cmath>
+#include <functional>
+#include <memory>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "geometry_msgs/msg/polygon_stamped.hpp"
+#include "geometry_msgs/msg/twist_stamped.hpp"
+#include "marine_nav_ca_safety/ca_safety.h"
+#include "nav2_msgs/msg/collision_monitor_state.hpp"
+#include "nav_msgs/msg/odometry.hpp"
+#include "rcl_interfaces/msg/parameter_descriptor.hpp"
+#include "rcl_interfaces/msg/set_parameters_result.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "sensor_msgs/msg/point_cloud2.hpp"
+#include "sensor_msgs/point_cloud2_iterator.hpp"
+#include "tf2_ros/buffer.h"
+#include "tf2_ros/transform_listener.h"
+#include "tf2_sensor_msgs/tf2_sensor_msgs.hpp"
+
+namespace marine_nav_ca_safety
+{
+
+/// Collision-avoidance **safety brake** that replaces the nav2 Collision Monitor.
+/// It is intentionally *not* a maneuvering/escape node: it modulates the incoming
+/// velocity command to (a) slow down — speed-scaled and yaw-preserving — as an
+/// obstacle enters a forward corridor, and (b) brake to a stop with reverse thrust
+/// in a close stop box, while republishing the CM's CAMP visualization (zone
+/// polygons + CollisionMonitorState for the frame-vs-fill).
+///
+/// The node is **platform-agnostic**: all topic names are relative and frame names
+/// come from parameters with generic, unprefixed defaults. The deployment applies
+/// the namespace and the (roll/pitch-stabilized) frame via launch/config.
+///
+/// Callbacks are serialized by the default single-threaded executor (see main());
+/// shared state is therefore accessed without additional locking, while live
+/// parameters are kept in atomics for lock-free snapshotting.
+class CaSafetyNode : public rclcpp::Node
+{
+public:
+  explicit CaSafetyNode(const rclcpp::NodeOptions & options)
+  : rclcpp::Node("ca_safety", options)
+  {
+    // --- Construction-time parameters (read once; they wire topics/frames) ---
+    cmd_vel_in_topic_ = declare_parameter<std::string>("cmd_vel_in_topic", "cmd_vel_smoothed");
+    cmd_vel_out_topic_ =
+      declare_parameter<std::string>("cmd_vel_out_topic", "piloting_mode/autonomous/cmd_vel");
+    pointcloud_topic_ =
+      declare_parameter<std::string>("pointcloud_topic", "collision_monitor/pointcloud");
+    odom_topic_ = declare_parameter<std::string>("odom_topic", "odom");
+    state_topic_ = declare_parameter<std::string>("state_topic", "collision_monitor_state");
+    slowdown_polygon_topic_ = declare_parameter<std::string>(
+      "slowdown_polygon_topic", "collision_monitor/slowdown_polygon");
+    stop_polygon_topic_ =
+      declare_parameter<std::string>("stop_polygon_topic", "collision_monitor/stop_polygon");
+    base_frame_ = declare_parameter<std::string>("base_frame", "base_link");
+    stop_speed_eps_ = declare_parameter<double>("stop_speed_eps", 0.05);
+    const double viz_rate = declare_parameter<double>("viz_rate", 2.0);
+    source_loss_behavior_ = parseSourceLoss(
+      declare_parameter<std::string>("source_loss_behavior", "passthrough"));
+
+    // --- Live (dynamic) parameters: geometry/reverse tunables + toggles ---
+    ttc_time_constant_ = declareDynamicDouble(
+      "ttc_time_constant", 4.0, "Slowdown leading-edge time constant T (s): length = speed*T + min.");
+    slowdown_min_length_ =
+      declareDynamicDouble("slowdown_min_length", 5.0, "Minimum slowdown corridor length (m).");
+    slowdown_max_length_ =
+      declareDynamicDouble("slowdown_max_length", 25.0, "Maximum slowdown corridor length (m).");
+    slowdown_speed_floor_ = declareDynamicDouble(
+      "slowdown_speed_floor", 0.1, "Forward speed kept during slowdown (m/s) to preserve yaw.");
+    slowdown_width_ =
+      declareDynamicDouble("slowdown_width", 6.0, "Full lateral width of the slowdown corridor (m).");
+    stop_length_ = declareDynamicDouble("stop_length", 5.0, "Stop box forward length (m).");
+    stop_width_ = declareDynamicDouble("stop_width", 4.0, "Stop box lateral width (m).");
+    reverse_speed_ =
+      declareDynamicDouble("reverse_speed", 0.5, "Reverse-brake setpoint magnitude (m/s).");
+    reverse_distance_ = declareDynamicDouble(
+      "reverse_distance", 3.0, "Hard backstop: max reverse distance (m), independent of odom.");
+    reverse_duration_ = declareDynamicDouble(
+      "reverse_duration", 4.0, "Hard backstop: max reverse duration (s), independent of odom.");
+    source_timeout_ =
+      declareDynamicDouble("source_timeout", 1.0, "Max age of cloud/odom before considered lost (s).");
+    {
+      rcl_interfaces::msg::ParameterDescriptor d;
+      d.description =
+        "Cancel commanded yaw while reverse-braking (true = straight brake). The "
+        "pass-through path (false) requires verified reverse-yaw sign handling.";
+      cancel_yaw_during_reverse_ = declare_parameter<bool>("cancel_yaw_during_reverse", true, d);
+    }
+    {
+      rcl_interfaces::msg::ParameterDescriptor d;
+      d.description = "Publish the CAMP zone polygons + CollisionMonitorState.";
+      publish_visualization_ = declare_parameter<bool>("publish_visualization", true, d);
+    }
+
+    param_callback_handle_ = add_on_set_parameters_callback(
+      std::bind(&CaSafetyNode::onSetParameters, this, std::placeholders::_1));
+    post_param_callback_handle_ = add_post_set_parameters_callback(
+      std::bind(&CaSafetyNode::onPostSetParameters, this, std::placeholders::_1));
+
+    // --- TF ---
+    tf_buffer_ = std::make_unique<tf2_ros::Buffer>(get_clock());
+    tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
+
+    // --- I/O with EXPLICIT QoS (this stack has silently lost data to implicit
+    // QoS mismatches, cf. costmap #56). Pointcloud uses best-effort sensor-data
+    // QoS to match nav2 sensor sources; cmd_vel/odom/viz are reliable depth-1
+    // (cmd_vel matches velocity_smoother / echo_helm; viz matches CAMP's QoS(1)). ---
+    cmd_vel_pub_ =
+      create_publisher<geometry_msgs::msg::TwistStamped>(cmd_vel_out_topic_, rclcpp::QoS(1));
+    slowdown_poly_pub_ =
+      create_publisher<geometry_msgs::msg::PolygonStamped>(slowdown_polygon_topic_, rclcpp::QoS(1));
+    stop_poly_pub_ =
+      create_publisher<geometry_msgs::msg::PolygonStamped>(stop_polygon_topic_, rclcpp::QoS(1));
+    state_pub_ =
+      create_publisher<nav2_msgs::msg::CollisionMonitorState>(state_topic_, rclcpp::QoS(1));
+
+    cmd_vel_sub_ = create_subscription<geometry_msgs::msg::TwistStamped>(
+      cmd_vel_in_topic_, rclcpp::QoS(1),
+      std::bind(&CaSafetyNode::cmdVelCallback, this, std::placeholders::_1));
+    cloud_sub_ = create_subscription<sensor_msgs::msg::PointCloud2>(
+      pointcloud_topic_, rclcpp::SensorDataQoS(),
+      std::bind(&CaSafetyNode::cloudCallback, this, std::placeholders::_1));
+    odom_sub_ = create_subscription<nav_msgs::msg::Odometry>(
+      odom_topic_, rclcpp::QoS(5),
+      std::bind(&CaSafetyNode::odomCallback, this, std::placeholders::_1));
+
+    // Viz + state on an independent timer so the CAMP fill (driven by
+    // CollisionMonitorState, 2 s watchdog) does not blank when cmd_vel pauses.
+    const double rate = isFinitePositive(viz_rate) ? viz_rate : 2.0;
+    viz_timer_ = create_wall_timer(
+      std::chrono::duration<double>(1.0 / rate),
+      std::bind(&CaSafetyNode::vizTimerCallback, this));
+  }
+
+private:
+  enum class SourceLoss
+  {
+    Passthrough,
+    Hold,
+    Stop
+  };
+
+  static SourceLoss parseSourceLoss(const std::string & s)
+  {
+    if (s == "hold") {return SourceLoss::Hold;}
+    if (s == "stop") {return SourceLoss::Stop;}
+    return SourceLoss::Passthrough;
+  }
+
+  static const std::unordered_set<std::string> & dynamicDoubles()
+  {
+    static const std::unordered_set<std::string> names{
+      "ttc_time_constant", "slowdown_min_length", "slowdown_max_length", "slowdown_speed_floor",
+      "slowdown_width", "stop_length", "stop_width", "reverse_speed", "reverse_distance",
+      "reverse_duration", "source_timeout"};
+    return names;
+  }
+
+  double declareDynamicDouble(const std::string & name, double def, const std::string & desc)
+  {
+    rcl_interfaces::msg::ParameterDescriptor d;
+    d.dynamic_typing = true;  // accept a bare integer and coerce in the callback
+    d.description = desc + " Finite and > 0.";
+    return declare_parameter(name, def, d);
+  }
+
+  static bool numericFromParameter(const rclcpp::Parameter & p, double & value)
+  {
+    switch (p.get_type()) {
+      case rclcpp::ParameterType::PARAMETER_DOUBLE:
+        value = p.as_double();
+        return true;
+      case rclcpp::ParameterType::PARAMETER_INTEGER:
+        value = static_cast<double>(p.as_int());
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  // Pre-set: validate only, no side effects (a SetParameters request is atomic).
+  rcl_interfaces::msg::SetParametersResult onSetParameters(
+    const std::vector<rclcpp::Parameter> & parameters)
+  {
+    rcl_interfaces::msg::SetParametersResult result;
+    result.successful = true;
+    for (const auto & p : parameters) {
+      if (dynamicDoubles().count(p.get_name()) == 0) {
+        continue;
+      }
+      double v;
+      if (!numericFromParameter(p, v)) {
+        result.successful = false;
+        result.reason = p.get_name() + " must be a number (double or integer)";
+        break;
+      }
+      if (!isFinitePositive(v)) {
+        result.successful = false;
+        result.reason = p.get_name() + " must be finite and > 0";
+        break;
+      }
+    }
+    return result;
+  }
+
+  // Post-set: apply validated values (fires only after the request commits).
+  void onPostSetParameters(const std::vector<rclcpp::Parameter> & parameters)
+  {
+    for (const auto & p : parameters) {
+      const std::string & n = p.get_name();
+      double v;
+      if (dynamicDoubles().count(n) && numericFromParameter(p, v)) {
+        if (n == "ttc_time_constant") {ttc_time_constant_ = v;} else if (n == "slowdown_min_length") {
+          slowdown_min_length_ = v;
+        } else if (n == "slowdown_max_length") {slowdown_max_length_ = v;} else if (
+          n == "slowdown_speed_floor")
+        {
+          slowdown_speed_floor_ = v;
+        } else if (n == "slowdown_width") {slowdown_width_ = v;} else if (n == "stop_length") {
+          stop_length_ = v;
+        } else if (n == "stop_width") {stop_width_ = v;} else if (n == "reverse_speed") {
+          reverse_speed_ = v;
+        } else if (n == "reverse_distance") {reverse_distance_ = v;} else if (
+          n == "reverse_duration")
+        {
+          reverse_duration_ = v;
+        } else if (n == "source_timeout") {source_timeout_ = v;}
+      } else if (n == "cancel_yaw_during_reverse" &&
+        p.get_type() == rclcpp::ParameterType::PARAMETER_BOOL)
+      {
+        cancel_yaw_during_reverse_ = p.as_bool();
+      } else if (n == "publish_visualization" &&
+        p.get_type() == rclcpp::ParameterType::PARAMETER_BOOL)
+      {
+        publish_visualization_ = p.as_bool();
+      }
+    }
+  }
+
+  SafetyParams snapshotParams() const
+  {
+    SafetyParams p;
+    p.ttc_time_constant = ttc_time_constant_.load();
+    p.slowdown_min_length = slowdown_min_length_.load();
+    p.slowdown_max_length = slowdown_max_length_.load();
+    p.slowdown_speed_floor = slowdown_speed_floor_.load();
+    p.slowdown_width = slowdown_width_.load();
+    p.stop_length = stop_length_.load();
+    p.stop_width = stop_width_.load();
+    p.reverse_speed = reverse_speed_.load();
+    p.cancel_yaw_during_reverse = cancel_yaw_during_reverse_.load();
+    return p;
+  }
+
+  void cloudCallback(const sensor_msgs::msg::PointCloud2 & msg)
+  {
+    last_cloud_ = msg;
+    have_cloud_ = true;
+    last_cloud_time_ = now();
+  }
+
+  void odomCallback(const nav_msgs::msg::Odometry & msg)
+  {
+    measured_speed_ = msg.twist.twist.linear.x;
+    odom_x_ = msg.pose.pose.position.x;
+    odom_y_ = msg.pose.pose.position.y;
+    have_odom_ = true;
+    last_odom_time_ = now();
+  }
+
+  // Transform the cached cloud into base_frame and extract (x, y) points.
+  bool transformCloud(std::vector<Point2> & pts)
+  {
+    if (!have_cloud_) {
+      return false;
+    }
+    try {
+      const auto tf = tf_buffer_->lookupTransform(
+        base_frame_, last_cloud_.header.frame_id, tf2::TimePointZero);
+      sensor_msgs::msg::PointCloud2 transformed;
+      tf2::doTransform(last_cloud_, transformed, tf);
+      pts.clear();
+      sensor_msgs::PointCloud2ConstIterator<float> ix(transformed, "x");
+      sensor_msgs::PointCloud2ConstIterator<float> iy(transformed, "y");
+      for (; ix != ix.end(); ++ix, ++iy) {
+        pts.push_back(Point2{static_cast<double>(*ix), static_cast<double>(*iy)});
+      }
+      return true;
+    } catch (const tf2::TransformException & e) {
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *get_clock(), 2000, "CA safety: cloud transform to %s failed: %s",
+        base_frame_.c_str(), e.what());
+      return false;
+    }
+  }
+
+  void resetReverse() {reverse_active_ = false;}
+
+  // Reverse-brake with a hard distance/duration backstop that does NOT depend on
+  // odom, so an odom dropout mid-reverse cannot cause aft runaway.
+  Twist2 doStop(const Twist2 & in, double speed, bool odom_fresh, const SafetyParams & p)
+  {
+    const rclcpp::Time t = now();
+    if (!reverse_active_) {
+      reverse_active_ = true;
+      reverse_start_time_ = t;
+      reverse_start_has_pose_ = odom_fresh;
+      reverse_start_x_ = odom_x_;
+      reverse_start_y_ = odom_y_;
+    }
+    const bool within_duration = (t - reverse_start_time_).seconds() < reverse_duration_.load();
+    bool within_distance = true;
+    if (odom_fresh && reverse_start_has_pose_) {
+      within_distance =
+        std::hypot(odom_x_ - reverse_start_x_, odom_y_ - reverse_start_y_) < reverse_distance_.load();
+    }
+    const bool reverse_allowed = within_duration && within_distance;
+    // With odom stale we cannot tell we've stopped; keep braking until the
+    // duration backstop ends it (treat as still moving).
+    const double speed_for_stop = odom_fresh ? speed : std::numeric_limits<double>::infinity();
+    return applyStop(in, speed_for_stop, reverse_allowed, p, stop_speed_eps_);
+  }
+
+  void cmdVelCallback(const geometry_msgs::msg::TwistStamped & msg)
+  {
+    const SafetyParams p = snapshotParams();
+    const rclcpp::Time t = now();
+    const double timeout = source_timeout_.load();
+
+    const bool odom_fresh = have_odom_ && (t - last_odom_time_).seconds() <= timeout;
+    const double speed = odom_fresh ? measured_speed_ : 0.0;
+
+    const bool cloud_fresh = have_cloud_ && (t - last_cloud_time_).seconds() <= timeout;
+    const bool use_cloud = cloud_fresh || (have_cloud_ && source_loss_behavior_ == SourceLoss::Hold);
+
+    std::vector<Point2> pts;
+    const bool cloud_usable = use_cloud && transformCloud(pts);
+
+    const Twist2 in{msg.twist.linear.x, msg.twist.angular.z};
+    Twist2 out = in;
+    Zone zone = Zone::Clear;
+
+    if (cloud_usable) {
+      const double slow_len = slowdownLength(speed, p);
+      const double slow_range = nearestForwardRange(pts, p.slowdown_width, slow_len);
+      const double stop_range = nearestForwardRange(pts, p.stop_width, p.stop_length);
+      zone = classify(stop_range, slow_range, slow_len);
+      switch (zone) {
+        case Zone::Clear:
+          out = in;
+          resetReverse();
+          break;
+        case Zone::Slowdown:
+          out = applySlowdown(
+            in, slowdownScale(slow_range, slow_len, p.stop_length), p.slowdown_speed_floor);
+          resetReverse();
+          break;
+        case Zone::Stop:
+          out = doStop(in, speed, odom_fresh, p);
+          break;
+      }
+    } else if (source_loss_behavior_ == SourceLoss::Stop && have_cloud_) {
+      // Source lost (and not holding): conservative brake.
+      zone = Zone::Stop;
+      out = doStop(in, speed, odom_fresh, p);
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *get_clock(), 2000, "CA safety: obstacle source lost — braking (stop policy).");
+    } else {
+      // Passthrough (default) or no cloud ever received.
+      out = in;
+      resetReverse();
+      if (have_cloud_) {
+        RCLCPP_WARN_THROTTLE(
+          get_logger(), *get_clock(), 2000,
+          "CA safety: obstacle source lost — passing commands through.");
+      }
+    }
+
+    current_zone_ = zone;
+
+    geometry_msgs::msg::TwistStamped out_msg = msg;  // preserve other twist components + header
+    out_msg.header.stamp = t;
+    out_msg.twist.linear.x = out.linear_x;
+    out_msg.twist.angular.z = out.angular_z;
+    cmd_vel_pub_->publish(out_msg);
+  }
+
+  geometry_msgs::msg::PolygonStamped makePolygon(double length, double width, const rclcpp::Time & t)
+  {
+    geometry_msgs::msg::PolygonStamped poly;
+    poly.header.frame_id = base_frame_;
+    poly.header.stamp = t;
+    for (const auto & c : forwardBoxCorners(length, width)) {
+      geometry_msgs::msg::Point32 pt;
+      pt.x = static_cast<float>(c.x);
+      pt.y = static_cast<float>(c.y);
+      pt.z = 0.0f;
+      poly.polygon.points.push_back(pt);
+    }
+    return poly;
+  }
+
+  void vizTimerCallback()
+  {
+    if (!publish_visualization_.load()) {
+      return;
+    }
+    const rclcpp::Time t = now();
+    const SafetyParams p = snapshotParams();
+    const bool odom_fresh = have_odom_ && (t - last_odom_time_).seconds() <= source_timeout_.load();
+    const double speed = odom_fresh ? measured_speed_ : 0.0;
+
+    slowdown_poly_pub_->publish(makePolygon(slowdownLength(speed, p), p.slowdown_width, t));
+    stop_poly_pub_->publish(makePolygon(p.stop_length, p.stop_width, t));
+
+    nav2_msgs::msg::CollisionMonitorState state;
+    switch (current_zone_) {
+      case Zone::Stop:
+        state.action_type = nav2_msgs::msg::CollisionMonitorState::STOP;
+        break;
+      case Zone::Slowdown:
+        state.action_type = nav2_msgs::msg::CollisionMonitorState::SLOWDOWN;
+        break;
+      case Zone::Clear:
+        state.action_type = nav2_msgs::msg::CollisionMonitorState::DO_NOTHING;
+        break;
+    }
+    state_pub_->publish(state);
+  }
+
+  // Construction-time config.
+  std::string cmd_vel_in_topic_, cmd_vel_out_topic_, pointcloud_topic_, odom_topic_, state_topic_;
+  std::string slowdown_polygon_topic_, stop_polygon_topic_, base_frame_;
+  double stop_speed_eps_{0.05};
+  SourceLoss source_loss_behavior_{SourceLoss::Passthrough};
+
+  // Live params.
+  std::atomic<double> ttc_time_constant_{4.0}, slowdown_min_length_{5.0}, slowdown_max_length_{25.0};
+  std::atomic<double> slowdown_speed_floor_{0.1}, slowdown_width_{6.0}, stop_length_{5.0};
+  std::atomic<double> stop_width_{4.0}, reverse_speed_{0.5}, reverse_distance_{3.0};
+  std::atomic<double> reverse_duration_{4.0}, source_timeout_{1.0};
+  std::atomic<bool> cancel_yaw_during_reverse_{true}, publish_visualization_{true};
+
+  // Cached inputs (single-threaded executor; no extra locking).
+  sensor_msgs::msg::PointCloud2 last_cloud_;
+  bool have_cloud_{false};
+  rclcpp::Time last_cloud_time_;
+  double measured_speed_{0.0}, odom_x_{0.0}, odom_y_{0.0};
+  bool have_odom_{false};
+  rclcpp::Time last_odom_time_;
+
+  // Reverse-brake backstop state.
+  bool reverse_active_{false};
+  bool reverse_start_has_pose_{false};
+  rclcpp::Time reverse_start_time_;
+  double reverse_start_x_{0.0}, reverse_start_y_{0.0};
+
+  Zone current_zone_{Zone::Clear};
+
+  OnSetParametersCallbackHandle::SharedPtr param_callback_handle_;
+  PostSetParametersCallbackHandle::SharedPtr post_param_callback_handle_;
+  std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr cmd_vel_sub_;
+  rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr cloud_sub_;
+  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr odom_sub_;
+  rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr cmd_vel_pub_;
+  rclcpp::Publisher<geometry_msgs::msg::PolygonStamped>::SharedPtr slowdown_poly_pub_;
+  rclcpp::Publisher<geometry_msgs::msg::PolygonStamped>::SharedPtr stop_poly_pub_;
+  rclcpp::Publisher<nav2_msgs::msg::CollisionMonitorState>::SharedPtr state_pub_;
+  rclcpp::TimerBase::SharedPtr viz_timer_;
+};
+
+}  // namespace marine_nav_ca_safety
+
+#endif  // MARINE_NAV_CA_SAFETY_CA_SAFETY_NODE_H

--- a/marine_nav_ca_safety/package.xml
+++ b/marine_nav_ca_safety/package.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>marine_nav_ca_safety</name>
+  <version>0.0.0</version>
+  <description>
+    Collision-avoidance safety brake that replaces the nav2 Collision Monitor:
+    speed-scaled yaw-preserving slowdown plus reverse-assisted stop, with the
+    Collision Monitor's CAMP zone visualization. Platform-agnostic (generic
+    topic/frame names).
+  </description>
+
+  <maintainer email="roland@ccom.unh.edu">Roland Arsenault</maintainer>
+
+  <license>BSD</license>
+
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+
+  <depend>geometry_msgs</depend>
+  <depend>nav_msgs</depend>
+  <depend>nav2_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>rcl_interfaces</depend>
+  <depend>rclcpp</depend>
+  <depend>tf2</depend>
+  <depend>tf2_ros</depend>
+  <depend>tf2_geometry_msgs</depend>
+  <depend>tf2_sensor_msgs</depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>launch_testing_ament_cmake</test_depend>
+  <test_depend>launch_testing_ros</test_depend>
+  <test_depend>launch_ros</test_depend>
+  <test_depend>rclpy</test_depend>
+  <test_depend>sensor_msgs_py</test_depend>
+  <test_depend>tf2_ros</test_depend>
+  <test_depend>std_msgs</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/marine_nav_ca_safety/src/ca_safety_node.cpp
+++ b/marine_nav_ca_safety/src/ca_safety_node.cpp
@@ -1,0 +1,13 @@
+#include <memory>
+
+#include "marine_nav_ca_safety/ca_safety_node.h"
+#include "rclcpp/rclcpp.hpp"
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(
+    std::make_shared<marine_nav_ca_safety::CaSafetyNode>(rclcpp::NodeOptions()));
+  rclcpp::shutdown();
+  return 0;
+}

--- a/marine_nav_ca_safety/test/test_ca_safety.cpp
+++ b/marine_nav_ca_safety/test/test_ca_safety.cpp
@@ -162,3 +162,40 @@ TEST(ForwardBoxCorners, ProducesCenteredForwardRectangle)
   EXPECT_DOUBLE_EQ(c[2].x, 0.0);
   EXPECT_DOUBLE_EQ(c[2].y, -2.0);
 }
+
+TEST(FiniteOrZero, ZeroesNonFinite)
+{
+  EXPECT_DOUBLE_EQ(finiteOrZero(1.5), 1.5);
+  EXPECT_DOUBLE_EQ(finiteOrZero(-2.0), -2.0);
+  EXPECT_DOUBLE_EQ(finiteOrZero(std::nan("")), 0.0);
+  EXPECT_DOUBLE_EQ(finiteOrZero(std::numeric_limits<double>::infinity()), 0.0);
+  EXPECT_DOUBLE_EQ(finiteOrZero(-std::numeric_limits<double>::infinity()), 0.0);
+}
+
+TEST(ReverseAllowed, BoundedByDurationAlways)
+{
+  // Within both bounds.
+  EXPECT_TRUE(reverseAllowed(1.0, 4.0, true, 1.0, 3.0));
+  // Over duration -> not allowed regardless of distance.
+  EXPECT_FALSE(reverseAllowed(4.0, 4.0, true, 0.0, 3.0));
+  EXPECT_FALSE(reverseAllowed(5.0, 4.0, false, 0.0, 3.0));
+}
+
+TEST(ReverseAllowed, DistanceOnlyWhenAvailable)
+{
+  // Distance over limit, and we have it -> blocked.
+  EXPECT_FALSE(reverseAllowed(1.0, 4.0, true, 3.0, 3.0));
+  EXPECT_FALSE(reverseAllowed(1.0, 4.0, true, 5.0, 3.0));
+  // Same distance but no pose captured (odom was stale) -> only duration bounds,
+  // so still allowed (the F2 degraded-but-bounded path).
+  EXPECT_TRUE(reverseAllowed(1.0, 4.0, false, 5.0, 3.0));
+}
+
+TEST(ReverseEpisodeEnded, RequiresSustainedClear)
+{
+  // Brief flicker out of Stop must NOT end the episode (backstop stays cumulative).
+  EXPECT_FALSE(reverseEpisodeEnded(0.2, 1.0));
+  EXPECT_FALSE(reverseEpisodeEnded(1.0, 1.0));
+  // Sustained clear beyond the debounce ends it.
+  EXPECT_TRUE(reverseEpisodeEnded(1.5, 1.0));
+}

--- a/marine_nav_ca_safety/test/test_ca_safety.cpp
+++ b/marine_nav_ca_safety/test/test_ca_safety.cpp
@@ -1,0 +1,164 @@
+#include <cmath>
+#include <limits>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "marine_nav_ca_safety/ca_safety.h"
+
+using namespace marine_nav_ca_safety;  // NOLINT(build/namespaces)
+
+namespace
+{
+SafetyParams defaultParams()
+{
+  return SafetyParams{};  // struct defaults
+}
+}  // namespace
+
+TEST(IsFinitePositive, RejectsNonPositiveAndNonFinite)
+{
+  EXPECT_TRUE(isFinitePositive(0.1));
+  EXPECT_FALSE(isFinitePositive(0.0));
+  EXPECT_FALSE(isFinitePositive(-1.0));
+  EXPECT_FALSE(isFinitePositive(std::nan("")));
+  EXPECT_FALSE(isFinitePositive(std::numeric_limits<double>::infinity()));
+}
+
+TEST(SlowdownLength, ScalesWithSpeedAndClamps)
+{
+  SafetyParams p = defaultParams();
+  p.ttc_time_constant = 4.0;
+  p.slowdown_min_length = 5.0;
+  p.slowdown_max_length = 25.0;
+
+  EXPECT_DOUBLE_EQ(slowdownLength(0.0, p), 5.0);      // floor at min
+  EXPECT_DOUBLE_EQ(slowdownLength(-3.0, p), 5.0);     // negative treated as 0
+  EXPECT_DOUBLE_EQ(slowdownLength(2.0, p), 13.0);     // 2*4 + 5
+  EXPECT_DOUBLE_EQ(slowdownLength(100.0, p), 25.0);   // clamp at max
+}
+
+TEST(SlowdownLength, RobustToMisorderedRange)
+{
+  SafetyParams p = defaultParams();
+  p.slowdown_min_length = 20.0;
+  p.slowdown_max_length = 5.0;  // misordered
+  // Must not invoke UB; result stays >= min.
+  const double len = slowdownLength(0.0, p);
+  EXPECT_GE(len, 20.0);
+  EXPECT_TRUE(std::isfinite(len));
+}
+
+TEST(NearestForwardRange, FindsNearestInsideBoxAndIgnoresOutside)
+{
+  std::vector<Point2> pts{
+    {3.0, 0.0},    // inside, nearest
+    {5.0, 1.0},    // inside, farther
+    {-2.0, 0.0},   // behind -> ignored
+    {4.0, 10.0},   // too wide -> ignored
+    {30.0, 0.0}};  // beyond max_x -> ignored
+  EXPECT_DOUBLE_EQ(nearestForwardRange(pts, /*width=*/6.0, /*max_x=*/20.0), 3.0);
+}
+
+TEST(NearestForwardRange, ReturnsInfWhenEmptyOrAllOutside)
+{
+  EXPECT_TRUE(std::isinf(nearestForwardRange({}, 6.0, 20.0)));
+  std::vector<Point2> pts{{-1.0, 0.0}, {2.0, 9.0}};
+  EXPECT_TRUE(std::isinf(nearestForwardRange(pts, 6.0, 20.0)));
+}
+
+TEST(NearestForwardRange, IgnoresNonFinitePoints)
+{
+  std::vector<Point2> pts{
+    {std::nan(""), 0.0}, {std::numeric_limits<double>::infinity(), 0.0}, {4.0, 0.0}};
+  EXPECT_DOUBLE_EQ(nearestForwardRange(pts, 6.0, 20.0), 4.0);
+}
+
+TEST(Classify, StopDominatesSlowdownAndClear)
+{
+  EXPECT_EQ(classify(/*stop=*/3.0, /*slow=*/3.0, /*len=*/15.0), Zone::Stop);
+  EXPECT_EQ(
+    classify(std::numeric_limits<double>::infinity(), 10.0, 15.0), Zone::Slowdown);
+  EXPECT_EQ(
+    classify(
+      std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity(), 15.0),
+    Zone::Clear);
+  // Slow range beyond the dynamic length -> Clear.
+  EXPECT_EQ(classify(std::numeric_limits<double>::infinity(), 20.0, 15.0), Zone::Clear);
+}
+
+TEST(SlowdownScale, RampsFromStopToSlowdown)
+{
+  EXPECT_DOUBLE_EQ(slowdownScale(15.0, 15.0, 5.0), 1.0);  // at outer edge
+  EXPECT_DOUBLE_EQ(slowdownScale(20.0, 15.0, 5.0), 1.0);  // beyond -> clamped 1
+  EXPECT_DOUBLE_EQ(slowdownScale(5.0, 15.0, 5.0), 0.0);   // at stop boundary
+  EXPECT_DOUBLE_EQ(slowdownScale(10.0, 15.0, 5.0), 0.5);  // midpoint
+  // Degenerate range -> hard step at stop_len.
+  EXPECT_DOUBLE_EQ(slowdownScale(6.0, 5.0, 5.0), 1.0);
+  EXPECT_DOUBLE_EQ(slowdownScale(4.0, 5.0, 5.0), 0.0);
+}
+
+TEST(ApplySlowdown, ReducesForwardKeepsFloorPreservesYaw)
+{
+  Twist2 in{2.0, 0.7};
+  // scale 0.5 -> 1.0, but floor keeps it above 0.1
+  Twist2 out = applySlowdown(in, 0.5, 0.1);
+  EXPECT_DOUBLE_EQ(out.linear_x, 1.0);
+  EXPECT_DOUBLE_EQ(out.angular_z, 0.7);  // yaw untouched
+
+  // scale 0 -> floored to speed_floor (not zero) so yaw authority survives
+  out = applySlowdown(in, 0.0, 0.1);
+  EXPECT_DOUBLE_EQ(out.linear_x, 0.1);
+  EXPECT_DOUBLE_EQ(out.angular_z, 0.7);
+
+  // never speeds up
+  out = applySlowdown(in, 5.0, 0.1);
+  EXPECT_DOUBLE_EQ(out.linear_x, 2.0);
+}
+
+TEST(ApplySlowdown, LeavesNonPositiveForwardAlone)
+{
+  Twist2 in{-0.5, 0.3};
+  Twist2 out = applySlowdown(in, 0.0, 0.1);
+  EXPECT_DOUBLE_EQ(out.linear_x, -0.5);  // not driving forward; untouched
+  EXPECT_DOUBLE_EQ(out.angular_z, 0.3);
+}
+
+TEST(ApplyStop, ReverseWhileMovingHoldZeroWhenStopped)
+{
+  SafetyParams p = defaultParams();
+  p.reverse_speed = 0.6;
+  p.cancel_yaw_during_reverse = true;
+  Twist2 in{1.0, 0.4};
+
+  // moving forward + allowed -> reverse thrust, yaw cancelled
+  Twist2 out = applyStop(in, /*measured=*/0.8, /*allowed=*/true, p, /*eps=*/0.05);
+  EXPECT_DOUBLE_EQ(out.linear_x, -0.6);
+  EXPECT_DOUBLE_EQ(out.angular_z, 0.0);
+
+  // essentially stopped -> hold zero
+  out = applyStop(in, /*measured=*/0.01, /*allowed=*/true, p, /*eps=*/0.05);
+  EXPECT_DOUBLE_EQ(out.linear_x, 0.0);
+
+  // backstop hit (not allowed) -> hold zero even if moving
+  out = applyStop(in, /*measured=*/0.8, /*allowed=*/false, p, /*eps=*/0.05);
+  EXPECT_DOUBLE_EQ(out.linear_x, 0.0);
+}
+
+TEST(ApplyStop, YawPassthroughWhenNotCancelled)
+{
+  SafetyParams p = defaultParams();
+  p.cancel_yaw_during_reverse = false;
+  Twist2 in{1.0, 0.4};
+  Twist2 out = applyStop(in, 0.8, true, p, 0.05);
+  EXPECT_DOUBLE_EQ(out.angular_z, 0.4);
+}
+
+TEST(ForwardBoxCorners, ProducesCenteredForwardRectangle)
+{
+  const auto c = forwardBoxCorners(10.0, 4.0);
+  EXPECT_DOUBLE_EQ(c[0].x, 10.0);
+  EXPECT_DOUBLE_EQ(c[0].y, 2.0);
+  EXPECT_DOUBLE_EQ(c[2].x, 0.0);
+  EXPECT_DOUBLE_EQ(c[2].y, -2.0);
+}

--- a/marine_nav_ca_safety/test/test_ca_safety_launch.py
+++ b/marine_nav_ca_safety/test/test_ca_safety_launch.py
@@ -16,6 +16,7 @@ import launch_ros.actions
 import launch_testing
 import launch_testing.actions
 from nav2_msgs.msg import CollisionMonitorState
+from nav_msgs.msg import Odometry
 import pytest
 import rclpy
 from rclpy.qos import QoSProfile, ReliabilityPolicy
@@ -111,6 +112,50 @@ class TestCaSafetyNode(unittest.TestCase):
 
         self.assertTrue(braked, 'node did not brake with an obstacle in the stop box')
         self.assertTrue(stop_state, 'no STOP CollisionMonitorState published for CAMP fill')
+
+    def test_closed_loop_stop_with_odom(self):
+        reliable = QoSProfile(depth=1, reliability=ReliabilityPolicy.RELIABLE)
+        best_effort = QoSProfile(depth=5, reliability=ReliabilityPolicy.BEST_EFFORT)
+        cmd_pub = self.node.create_publisher(TwistStamped, 'cmd_vel_smoothed', reliable)
+        cloud_pub = self.node.create_publisher(
+            PointCloud2, 'collision_monitor/pointcloud', best_effort)
+        odom_pub = self.node.create_publisher(Odometry, 'odom', reliable)
+        outputs = []
+        self.node.create_subscription(
+            TwistStamped, 'piloting_mode/autonomous/cmd_vel',
+            lambda m: outputs.append(m), reliable)
+        self._spin(1.0)
+
+        def publish(odom_speed):
+            cloud_pub.publish(point_cloud2.create_cloud_xyz32(
+                _header(self.node, 'cloud_frame'), [(3.0, 0.0, 0.0)]))
+            cmd = TwistStamped()
+            cmd.twist.linear.x = 1.0
+            cmd_pub.publish(cmd)
+            odom = Odometry()
+            odom.twist.twist.linear.x = odom_speed
+            odom_pub.publish(odom)
+
+        # Moving forward in the stop box: should command reverse thrust to brake.
+        reversed_seen = False
+        deadline = time.time() + 8.0
+        while time.time() < deadline and not reversed_seen:
+            publish(1.0)
+            self._spin(0.2)
+            if outputs and outputs[-1].twist.linear.x < 0.0:
+                reversed_seen = True
+        self.assertTrue(reversed_seen, 'expected reverse thrust moving forward in stop box')
+
+        # Now report stopped: should hold zero, not keep reversing.
+        outputs.clear()
+        held_zero = False
+        deadline = time.time() + 8.0
+        while time.time() < deadline and not held_zero:
+            publish(0.0)
+            self._spin(0.2)
+            if outputs and outputs[-1].twist.linear.x == 0.0:
+                held_zero = True
+        self.assertTrue(held_zero, 'expected hold-zero once odom reports the boat stopped')
 
     def test_single_output_publisher(self):
         self._spin(1.0)

--- a/marine_nav_ca_safety/test/test_ca_safety_launch.py
+++ b/marine_nav_ca_safety/test/test_ca_safety_launch.py
@@ -1,0 +1,132 @@
+"""
+Cross-process integration test for the CA safety node.
+
+Validates what in-process unit tests cannot: QoS interop over real DDS
+(best-effort reflex cloud + reliable cmd_vel), the TF transform of a real
+PointCloud2 into the base frame, the braking reaction when an obstacle sits in
+the stop box, and that the node is the sole publisher on the output topic.
+"""
+
+import time
+import unittest
+
+from geometry_msgs.msg import TwistStamped
+import launch
+import launch_ros.actions
+import launch_testing
+import launch_testing.actions
+from nav2_msgs.msg import CollisionMonitorState
+import pytest
+import rclpy
+from rclpy.qos import QoSProfile, ReliabilityPolicy
+from sensor_msgs.msg import PointCloud2
+from sensor_msgs_py import point_cloud2
+from std_msgs.msg import Header
+
+
+@pytest.mark.launch_test
+def generate_test_description():
+    ca_safety = launch_ros.actions.Node(
+        package='marine_nav_ca_safety',
+        executable='ca_safety_node',
+        name='ca_safety',
+        parameters=[{'source_timeout': 2.0}],
+    )
+    # Identity transform base_link <- cloud_frame so the published cloud lands in
+    # the base frame unchanged.
+    static_tf = launch_ros.actions.Node(
+        package='tf2_ros',
+        executable='static_transform_publisher',
+        arguments=['0', '0', '0', '0', '0', '0', 'base_link', 'cloud_frame'],
+    )
+    return (
+        launch.LaunchDescription([
+            ca_safety,
+            static_tf,
+            launch_testing.actions.ReadyToTest(),
+        ]),
+        {},
+    )
+
+
+class TestCaSafetyNode(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls.node = rclpy.create_node('ca_safety_integration_test')
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.node.destroy_node()
+        rclpy.shutdown()
+
+    def _spin(self, seconds):
+        end = time.time() + seconds
+        while time.time() < end:
+            rclpy.spin_once(self.node, timeout_sec=0.05)
+
+    def test_brakes_on_obstacle_in_stop_box(self):
+        reliable = QoSProfile(depth=1, reliability=ReliabilityPolicy.RELIABLE)
+        best_effort = QoSProfile(depth=5, reliability=ReliabilityPolicy.BEST_EFFORT)
+
+        cmd_pub = self.node.create_publisher(
+            TwistStamped, 'cmd_vel_smoothed', reliable)
+        cloud_pub = self.node.create_publisher(
+            PointCloud2, 'collision_monitor/pointcloud', best_effort)
+
+        outputs = []
+        states = []
+        self.node.create_subscription(
+            TwistStamped, 'piloting_mode/autonomous/cmd_vel',
+            lambda m: outputs.append(m), reliable)
+        self.node.create_subscription(
+            CollisionMonitorState, 'collision_monitor_state',
+            lambda m: states.append(m), reliable)
+
+        # Let discovery + static TF settle.
+        self._spin(1.0)
+
+        braked = False
+        stop_state = False
+        deadline = time.time() + 10.0
+        while time.time() < deadline and not (braked and stop_state):
+            cloud = point_cloud2.create_cloud_xyz32(
+                _header(self.node, 'cloud_frame'),
+                [(3.0, 0.0, 0.0)])  # inside the 5 m x 4 m stop box
+            cloud_pub.publish(cloud)
+
+            cmd = TwistStamped()
+            cmd.twist.linear.x = 1.0
+            cmd_pub.publish(cmd)
+
+            self._spin(0.2)
+            # Forward command must be braked (reverse or zero) once the obstacle
+            # is seen — proving cloud QoS interop + TF + modulation across processes.
+            if outputs and outputs[-1].twist.linear.x <= 0.0:
+                braked = True
+            # The viz timer must report STOP so CAMP fills the stop box.
+            if any(s.action_type == CollisionMonitorState.STOP for s in states):
+                stop_state = True
+
+        self.assertTrue(braked, 'node did not brake with an obstacle in the stop box')
+        self.assertTrue(stop_state, 'no STOP CollisionMonitorState published for CAMP fill')
+
+    def test_single_output_publisher(self):
+        self._spin(1.0)
+        count = self.node.count_publishers('/piloting_mode/autonomous/cmd_vel')
+        self.assertEqual(count, 1, 'expected exactly one publisher on the helm output topic')
+
+
+def _header(node, frame_id):
+    header = Header()
+    header.stamp = node.get_clock().now().to_msg()
+    header.frame_id = frame_id
+    return header
+
+
+@launch_testing.post_shutdown_test()
+class TestProcessOutput(unittest.TestCase):
+
+    def test_exit_codes(self, proc_info):
+        launch_testing.asserts.assertExitCodes(proc_info)

--- a/marine_nav_ca_safety/test/test_ca_safety_launch.py
+++ b/marine_nav_ca_safety/test/test_ca_safety_launch.py
@@ -157,6 +157,38 @@ class TestCaSafetyNode(unittest.TestCase):
                 held_zero = True
         self.assertTrue(held_zero, 'expected hold-zero once odom reports the boat stopped')
 
+    def test_brakes_with_nan_odom(self):
+        # A NaN odom speed must NOT make the node read "stopped" and hold zero in
+        # the stop box; the non-finite sample is dropped → odom goes stale →
+        # reverse brake falls back to the duration backstop. Output must be <= 0.
+        reliable = QoSProfile(depth=1, reliability=ReliabilityPolicy.RELIABLE)
+        best_effort = QoSProfile(depth=5, reliability=ReliabilityPolicy.BEST_EFFORT)
+        cmd_pub = self.node.create_publisher(TwistStamped, 'cmd_vel_smoothed', reliable)
+        cloud_pub = self.node.create_publisher(
+            PointCloud2, 'collision_monitor/pointcloud', best_effort)
+        odom_pub = self.node.create_publisher(Odometry, 'odom', reliable)
+        outputs = []
+        self.node.create_subscription(
+            TwistStamped, 'piloting_mode/autonomous/cmd_vel',
+            lambda m: outputs.append(m), reliable)
+        self._spin(1.0)
+
+        braked = False
+        deadline = time.time() + 10.0
+        while time.time() < deadline and not braked:
+            cloud_pub.publish(point_cloud2.create_cloud_xyz32(
+                _header(self.node, 'cloud_frame'), [(3.0, 0.0, 0.0)]))
+            cmd = TwistStamped()
+            cmd.twist.linear.x = 1.0
+            cmd_pub.publish(cmd)
+            odom = Odometry()
+            odom.twist.twist.linear.x = float('nan')
+            odom_pub.publish(odom)
+            self._spin(0.2)
+            if outputs and outputs[-1].twist.linear.x <= 0.0:
+                braked = True
+        self.assertTrue(braked, 'NaN odom must not suppress braking in the stop box')
+
     def test_single_output_publisher(self):
         self._spin(1.0)
         count = self.node.count_publishers('/piloting_mode/autonomous/cmd_vel')

--- a/marine_nav_ca_safety/test/test_ca_safety_node.cpp
+++ b/marine_nav_ca_safety/test/test_ca_safety_node.cpp
@@ -1,0 +1,160 @@
+#include <chrono>
+#include <cmath>
+#include <limits>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "geometry_msgs/msg/twist_stamped.hpp"
+#include "marine_nav_ca_safety/ca_safety_node.h"
+#include "nav2_msgs/msg/collision_monitor_state.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+using marine_nav_ca_safety::CaSafetyNode;
+using namespace std::chrono_literals;
+
+class CaSafetyNodeTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+    node_ = std::make_shared<CaSafetyNode>(rclcpp::NodeOptions());
+  }
+  void TearDown() override
+  {
+    node_.reset();
+    rclcpp::shutdown();
+  }
+  std::shared_ptr<CaSafetyNode> node_;
+};
+
+TEST_F(CaSafetyNodeTest, DefaultsAreSane)
+{
+  EXPECT_DOUBLE_EQ(node_->get_parameter("ttc_time_constant").as_double(), 4.0);
+  EXPECT_DOUBLE_EQ(node_->get_parameter("slowdown_min_length").as_double(), 5.0);
+  EXPECT_DOUBLE_EQ(node_->get_parameter("reverse_speed").as_double(), 0.5);
+  EXPECT_TRUE(node_->get_parameter("cancel_yaw_during_reverse").as_bool());
+  EXPECT_EQ(node_->get_parameter("base_frame").as_string(), "base_link");
+  EXPECT_EQ(node_->get_parameter("source_loss_behavior").as_string(), "passthrough");
+}
+
+TEST_F(CaSafetyNodeTest, ValidDynamicUpdateApplied)
+{
+  const auto r = node_->set_parameter(rclcpp::Parameter("ttc_time_constant", 6.0));
+  EXPECT_TRUE(r.successful);
+  EXPECT_DOUBLE_EQ(node_->get_parameter("ttc_time_constant").as_double(), 6.0);
+}
+
+TEST_F(CaSafetyNodeTest, InvalidNumericRejectedValueUnchanged)
+{
+  for (const double bad : {0.0, -1.0, std::nan(""), std::numeric_limits<double>::infinity()}) {
+    const auto r = node_->set_parameter(rclcpp::Parameter("reverse_speed", bad));
+    EXPECT_FALSE(r.successful) << "bad=" << bad;
+    EXPECT_DOUBLE_EQ(node_->get_parameter("reverse_speed").as_double(), 0.5) << "bad=" << bad;
+  }
+}
+
+TEST_F(CaSafetyNodeTest, IntegerCoercedToDouble)
+{
+  const auto r = node_->set_parameter(rclcpp::Parameter("stop_length", 8));
+  EXPECT_TRUE(r.successful);
+  EXPECT_EQ(node_->get_parameter("stop_length").as_int(), 8);
+}
+
+TEST_F(CaSafetyNodeTest, NonNumericRejected)
+{
+  const auto r =
+    node_->set_parameter(rclcpp::Parameter("stop_length", std::string("close")));
+  EXPECT_FALSE(r.successful);
+}
+
+TEST_F(CaSafetyNodeTest, BoolToggleApplied)
+{
+  const auto r = node_->set_parameter(rclcpp::Parameter("cancel_yaw_during_reverse", false));
+  EXPECT_TRUE(r.successful);
+  EXPECT_FALSE(node_->get_parameter("cancel_yaw_during_reverse").as_bool());
+}
+
+// With no obstacle source, the default passthrough policy must forward cmd_vel
+// unchanged (the node never silently stops the boat for lack of data).
+TEST_F(CaSafetyNodeTest, PassthroughWhenNoCloud)
+{
+  auto helper = std::make_shared<rclcpp::Node>("ca_safety_test_helper");
+  auto pub = helper->create_publisher<geometry_msgs::msg::TwistStamped>(
+    "cmd_vel_smoothed", rclcpp::QoS(1));
+  geometry_msgs::msg::TwistStamped received;
+  bool got = false;
+  auto sub = helper->create_subscription<geometry_msgs::msg::TwistStamped>(
+    "piloting_mode/autonomous/cmd_vel", rclcpp::QoS(1),
+    [&](const geometry_msgs::msg::TwistStamped & m) {received = m; got = true;});
+
+  rclcpp::executors::SingleThreadedExecutor exec;
+  exec.add_node(node_);
+  exec.add_node(helper);
+
+  geometry_msgs::msg::TwistStamped cmd;
+  cmd.twist.linear.x = 1.0;
+  cmd.twist.angular.z = 0.5;
+
+  const auto deadline = std::chrono::steady_clock::now() + 5s;
+  while (!got && std::chrono::steady_clock::now() < deadline) {
+    pub->publish(cmd);
+    exec.spin_some();
+    std::this_thread::sleep_for(20ms);
+  }
+  ASSERT_TRUE(got) << "no cmd_vel_out received";
+  EXPECT_DOUBLE_EQ(received.twist.linear.x, 1.0);
+  EXPECT_DOUBLE_EQ(received.twist.angular.z, 0.5);
+}
+
+// The viz timer must publish CollisionMonitorState (DO_NOTHING while clear) so
+// CAMP's 2 s fill watchdog stays fed even when cmd_vel is idle.
+TEST_F(CaSafetyNodeTest, PublishesStateOnTimer)
+{
+  auto helper = std::make_shared<rclcpp::Node>("ca_safety_test_helper");
+  nav2_msgs::msg::CollisionMonitorState state;
+  bool got = false;
+  auto sub = helper->create_subscription<nav2_msgs::msg::CollisionMonitorState>(
+    "collision_monitor_state", rclcpp::QoS(1),
+    [&](const nav2_msgs::msg::CollisionMonitorState & m) {state = m; got = true;});
+
+  rclcpp::executors::SingleThreadedExecutor exec;
+  exec.add_node(node_);
+  exec.add_node(helper);
+
+  const auto deadline = std::chrono::steady_clock::now() + 5s;
+  while (!got && std::chrono::steady_clock::now() < deadline) {
+    exec.spin_some();
+    std::this_thread::sleep_for(20ms);
+  }
+  ASSERT_TRUE(got) << "no CollisionMonitorState received";
+  EXPECT_EQ(state.action_type, nav2_msgs::msg::CollisionMonitorState::DO_NOTHING);
+}
+
+// Guard the safety-critical QoS choices against silent regression to a policy
+// that would not match the reflex cloud (best-effort) — cf. #56.
+TEST_F(CaSafetyNodeTest, PointcloudSubscriptionIsBestEffort)
+{
+  rclcpp::executors::SingleThreadedExecutor exec;
+  exec.add_node(node_);
+  std::vector<rclcpp::TopicEndpointInfo> infos;
+  const auto deadline = std::chrono::steady_clock::now() + 5s;
+  while (std::chrono::steady_clock::now() < deadline) {
+    infos = node_->get_subscriptions_info_by_topic("/collision_monitor/pointcloud");
+    if (!infos.empty()) {break;}
+    exec.spin_some();
+    std::this_thread::sleep_for(20ms);
+  }
+  ASSERT_FALSE(infos.empty()) << "no subscription on the pointcloud topic";
+  bool best_effort = false;
+  for (const auto & info : infos) {
+    if (info.qos_profile().reliability() == rclcpp::ReliabilityPolicy::BestEffort) {
+      best_effort = true;
+    }
+  }
+  EXPECT_TRUE(best_effort) << "pointcloud sub must be best-effort to match the reflex cloud (#56)";
+}

--- a/marine_nav_ca_safety/test/test_ca_safety_node.cpp
+++ b/marine_nav_ca_safety/test/test_ca_safety_node.cpp
@@ -79,6 +79,62 @@ TEST_F(CaSafetyNodeTest, BoolToggleApplied)
   EXPECT_FALSE(node_->get_parameter("cancel_yaw_during_reverse").as_bool());
 }
 
+TEST_F(CaSafetyNodeTest, StopSpeedEpsValidatedAndDynamic)
+{
+  EXPECT_DOUBLE_EQ(node_->get_parameter("stop_speed_eps").as_double(), 0.05);
+  for (const double bad : {0.0, -0.1, std::nan(""), std::numeric_limits<double>::infinity()}) {
+    const auto r = node_->set_parameter(rclcpp::Parameter("stop_speed_eps", bad));
+    EXPECT_FALSE(r.successful) << "bad=" << bad;
+    EXPECT_DOUBLE_EQ(node_->get_parameter("stop_speed_eps").as_double(), 0.05);
+  }
+}
+
+TEST_F(CaSafetyNodeTest, SlowdownMinMaxOrderingEnforced)
+{
+  // default min 5, max 25 — pushing min above max must be rejected (cross-field).
+  const auto r = node_->set_parameter(rclcpp::Parameter("slowdown_min_length", 30.0));
+  EXPECT_FALSE(r.successful);
+  EXPECT_DOUBLE_EQ(node_->get_parameter("slowdown_min_length").as_double(), 5.0);
+  // A consistent pair set together is accepted.
+  const auto ok = node_->set_parameters(
+    {rclcpp::Parameter("slowdown_min_length", 8.0),
+      rclcpp::Parameter("slowdown_max_length", 20.0)});
+  EXPECT_TRUE(ok[0].successful);
+}
+
+// A non-finite upstream command must never reach the helm.
+TEST_F(CaSafetyNodeTest, NonFiniteCmdVelSanitized)
+{
+  auto helper = std::make_shared<rclcpp::Node>("ca_safety_test_helper");
+  auto pub = helper->create_publisher<geometry_msgs::msg::TwistStamped>(
+    "cmd_vel_smoothed", rclcpp::QoS(1));
+  geometry_msgs::msg::TwistStamped received;
+  bool got = false;
+  auto sub = helper->create_subscription<geometry_msgs::msg::TwistStamped>(
+    "piloting_mode/autonomous/cmd_vel", rclcpp::QoS(1),
+    [&](const geometry_msgs::msg::TwistStamped & m) {received = m; got = true;});
+
+  rclcpp::executors::SingleThreadedExecutor exec;
+  exec.add_node(node_);
+  exec.add_node(helper);
+
+  geometry_msgs::msg::TwistStamped cmd;
+  cmd.twist.linear.x = std::nan("");
+  cmd.twist.angular.z = std::numeric_limits<double>::infinity();
+
+  const auto deadline = std::chrono::steady_clock::now() + 5s;
+  while (!got && std::chrono::steady_clock::now() < deadline) {
+    pub->publish(cmd);
+    exec.spin_some();
+    std::this_thread::sleep_for(20ms);
+  }
+  ASSERT_TRUE(got) << "no cmd_vel_out received";
+  EXPECT_TRUE(std::isfinite(received.twist.linear.x));
+  EXPECT_TRUE(std::isfinite(received.twist.angular.z));
+  EXPECT_DOUBLE_EQ(received.twist.linear.x, 0.0);
+  EXPECT_DOUBLE_EQ(received.twist.angular.z, 0.0);
+}
+
 // With no obstacle source, the default passthrough policy must forward cmd_vel
 // unchanged (the node never silently stops the boat for lack of data).
 TEST_F(CaSafetyNodeTest, PassthroughWhenNoCloud)


### PR DESCRIPTION
Closes #64

# Plan: CA safety node — speed-scaled yaw-preserving slowdown + reverse-assisted stop

## Issue

https://github.com/rolker/unh_marine_navigation/issues/64

## Context

On EchoBoat 240 (vectored thrust) a hard emergency stop zeroes yaw authority, so the
boat gets stuck pointed at an obstacle. This node **replaces** the nav2 Collision Monitor
with a graduated **safety brake** (not a maneuvering/escape node): it slows earlier and
proportionally to speed while *preserving the avoider's yaw authority*, then brakes to a
stop with reverse thrust over a short distance. It also takes over the CM's zone
visualization (CAMP's yellow/red boxes; the fill is driven by a separate
`nav2_msgs/CollisionMonitorState`, so the node publishes both).

**The node is platform-agnostic.** It lives in the generic `unh_marine_navigation` core,
so it uses **generic relative topic names and unprefixed frame-param defaults**; all
namespacing and frame-prefixing (the deployment's namespace + its roll/pitch-stabilized
`…/base_link_level` frame) is applied externally by the launch/config (seafloor#43). This PR delivers the
**node + tests only**.

## Approach

1. **New package `marine_nav_ca_safety`** (executable `ca_safety_node`), mirroring the
   `marine_nav_utilities` standalone-node pattern (ament_cmake, `package.xml` format 2,
   BSD, C++17). REP-144 naming: package by domain, executable by role.
2. **ROS-free core header `ca_safety.h`** — pure, gtest-able functions: slowdown length
   `L = clamp(v·T + L_min, L_min, L_max)` (≡ time-to-collision); nearest forward-sector
   obstacle range from points already in the computation frame; twist modulation
   {slowdown scale keeping `linear.x` ≥ a positive floor; pass `angular.z`; stop-zone →
   reverse-brake setpoint}; zone-polygon geometry; validation predicates (finite + domain).
   Mirrors `costmap_window.h`.
3. **Node `ca_safety_node.h`** (`rclcpp::Node`): subs `cmd_vel_in` (TwistStamped),
   pointcloud (PointCloud2), odom (Odometry); pub `cmd_vel_out` (TwistStamped).
   **Transform:** `tf2_ros::Buffer`/`Listener` + `tf2_sensor_msgs::doTransform` to bring the
   PointCloud2 into `base_frame` before range computation — the live cloud is in a
   roll/pitch-stabilized frame, and `base_frame` is a **generic param** (default
   `base_link`; deployment supplies e.g. `…/base_link_level`). On each cmd_vel: derive zone
   from latest cloud range + measured speed, modulate, publish `cmd_vel_out`. If input
   cmd_vel pauses, the node stops emitting `cmd_vel_out` (the FCU's own GUIDED watchdog
   handles a stale command, cf. #28).
4. **Reverse-assisted stop** — closed-loop on odom forward speed to ~0, with a **hard
   backstop independent of odom**: reverse ends at `reverse_distance` (integrated from
   reverse-start) or `reverse_duration`, whichever first — a mid-reverse odom dropout
   cannot cause aft runaway. `cancel_yaw_during_reverse` dynamic param, **default `true`**
   (straight brake — the safe path). **The yaw-passthrough path (`false`) ships disabled
   and is enabled only after the sim yaw-sign-in-reverse test passes** (the issue's blocker;
   wrong sign would swing the bow *into* the obstacle).
5. **Visualization — timer-driven, both parts.** An independent timer (`viz_rate`, default
   2 Hz, well inside CAMP's 2 s watchdog) publishes: (a) `geometry_msgs/PolygonStamped` on
   the slowdown/stop polygon topics (slowdown sized live by `L`), in `base_frame` — CAMP
   colors by topic name; (b) `nav2_msgs/CollisionMonitorState.action_type`
   (`DO_NOTHING`/`SLOWDOWN`/`STOP`) — CAMP's frame-vs-fill. Driving these from a timer (not
   cmd_vel) keeps fills from blanking when cmd_vel pauses. Gated by `publish_visualization`.
6. **Source-loss handling** — cloud: use the last cloud until `source_timeout`, then
   `source_loss_behavior` (`hold`|`passthrough`|`stop`, default `passthrough`+warn; `stop`
   reintroduces the deadlock). odom: covered by the reverse hard backstop (4).
7. **Explicit QoS per endpoint** (mirroring `costmap_window_node`'s QoS rationale, which
   exists precisely because implicit QoS caused a silent no-data bug, #56): pointcloud =
   **sensor-data/best-effort** (nav2 sensor sources are best-effort; a reliable sub gets
   nothing); cmd_vel in/out = reliable, depth 1, volatile (match `velocity_smoother` out /
   `echo_helm` in — a mismatch means **no helm commands**); odom = reliable, depth 5;
   polygons + state = reliable, depth 1, volatile (match CAMP's `QoS(1)`).
8. **Sole-helm-publisher invariant** — exactly one publisher on `cmd_vel_out` at any time.
   The CM must be removed from the chain/lifecycle at cutover (wiring = seafloor#43); the
   node logs a warning if it detects another publisher on `cmd_vel_out`. (CM currently runs
   as a pass-through on non-reflex boats — cutover handled per-boat in #43.)
9. **Dynamic parameter validation** per the #62 `CostmapWindowNode` precedent (pre-set
   `onSetParameters` validates finite/domain + int→double; post-set applies to `std::atomic`).
10. **`main()`** in `src/ca_safety_node.cpp`.
11. **Tests.** `test_ca_safety.cpp` (pure: zone sizing at speed extremes; slowdown floor
    keeps `linear.x` > 0; reverse-brake terminates at ~0; reverse hard backstop on odom
    loss; cancel-yaw both ways; polygon tracks `L`; `action_type` mapping; param validation
    incl. NaN/inf/domain). `test_ca_safety_node.cpp` (param defaults, dynamic accept/reject,
    viz+state published on timer). **`test_ca_safety_launch.py` (launch_testing):** QoS
    interop (best-effort cloud + cmd_vel actually flow), TF transform of a real cloud into
    `base_frame`, single-publisher on `cmd_vel_out`. **Sim gates (before water):**
    yaw-preserving slowdown at speed extremes; reverse termination / no aft runaway; escape
    when the avoider has given up; source-loss passthrough; **yaw-sign-in-reverse sign test
    (gates enabling the passthrough path)** — recorded via sim bag (ensure CA/reverse state
    is in the recording, cf. marine_simulation #62/#63).
12. **Package README**: params, topics, QoS, chain placement, the platform-agnostic naming
    note, and the safety-behavior rationale (Q4 — documented with the node).

## Files to Change

| File (new, under `marine_nav_ca_safety/`) | Change |
|---|---|
| `package.xml` | format 2, BSD; deps: rclcpp, geometry_msgs, sensor_msgs, nav_msgs, nav2_msgs (for `CollisionMonitorState` — CAMP keys off this exact type), tf2, tf2_ros, tf2_geometry_msgs, **tf2_sensor_msgs** (PointCloud2 `doTransform`), rcl_interfaces |
| `CMakeLists.txt` | library + `ca_safety_node` exec → `lib/${PROJECT_NAME}`; gtest + launch_testing registration |
| `include/marine_nav_ca_safety/ca_safety.h` | pure logic: zone sizing, range, twist modulation, polygon geometry, validation |
| `include/marine_nav_ca_safety/ca_safety_node.h` | node: subs/pub, tf transform, timer-driven viz+state, param declare+validate, modulation loop |
| `src/ca_safety_node.cpp` | `main()` |
| `test/test_ca_safety.cpp` | pure-logic unit tests |
| `test/test_ca_safety_node.cpp` | node param/flow/viz tests |
| `test/test_ca_safety_launch.py` | launch_testing: QoS / TF / single-publisher interop |
| `README.md` | params, topics, QoS, chain, platform-agnostic note, safety rationale |

## Parameters (generic/unprefixed defaults; geometry/reverse/viz toggles dynamic)

| Param | Type / default | QoS / validation |
|---|---|---|
| `cmd_vel_in_topic` / `cmd_vel_out_topic` | string / `cmd_vel_smoothed`, `piloting_mode/autonomous/cmd_vel` | reliable d1 volatile; non-empty (TwistStamped) |
| `pointcloud_topic` | string / `collision_monitor/pointcloud` | **sensor-data/best-effort** |
| `odom_topic` | string / `odom` | reliable d5 |
| `base_frame` | string / `base_link` | non-empty (generic; deployment supplies prefixed/level frame) |
| `ttc_time_constant` `T` | double / 4.0 s | finite, > 0 |
| `slowdown_min_length` / `slowdown_max_length` | double / 5.0, 25.0 m | finite, > 0, min ≤ max |
| `slowdown_speed_floor` | double / small +ε (m/s) | finite, > 0 (keeps yaw authority) |
| `slowdown_width` / `stop_length` / `stop_width` | double / 6.0, 5.0, 4.0 m | finite, > 0 |
| `reverse_speed` | double / 0.5 m/s | finite, > 0 |
| `reverse_distance` / `reverse_duration` | double / 3.0 m, 4.0 s | finite, > 0 (hard backstop, odom-independent) |
| `cancel_yaw_during_reverse` | bool / true | passthrough path (`false`) disabled until sim sign test |
| `source_timeout` | double / 1.0 s | finite, > 0 |
| `source_loss_behavior` | string / `passthrough` | one of `hold`,`passthrough`,`stop` |
| `publish_visualization` | bool / true | — |
| `viz_rate` | double / 2.0 Hz | finite, > 0 (inside CAMP's 2 s watchdog) |
| `slowdown_polygon_topic` / `stop_polygon_topic` | string / `collision_monitor/slowdown_polygon`, `…/stop_polygon` | reliable d1; name carries color |
| `state_topic` | string / `collision_monitor_state` | reliable d1 (`nav2_msgs/CollisionMonitorState`; CAMP discovers by type) |

## Principles Self-Check

| Principle | Consideration |
|---|---|
| Human control & transparency | All behavior configurable; reverse-yaw toggle live (passthrough gated until tested); zone viz preserved (yellow reflects speed); cmd_vel observable |
| A change includes its consequences | Unit + launch_testing + README; config at seafloor#43; recovery at #67; CM-replacement + sole-publisher cutover reconciled |
| Only what's needed | One small node package; reuses param-validation pattern; reuses CAMP display; pointcloud injected |
| Improve incrementally | Node here; per-240 wiring separate (#43); recovery separate (#67) |
| Test what breaks | Pure tests + launch_testing for the risky interop (QoS, TF, single-publisher) + enumerated sim gates; reverse-yaw passthrough gated on the sign test |
| Workspace vs project separation | Project nav code; **platform-agnostic** — generic relative topics + unprefixed frame defaults, prefix/namespace applied externally |

## ADR Compliance

| ADR | Triggered | How addressed |
|---|---|---|
| 0008 — ROS 2 conventions | Yes | Mirrors `marine_nav_utilities`; **REP-144 naming** (`marine_nav_ca_safety` pkg / `ca_safety_node` exec); explicit QoS; generic frame/topic names (platform-agnostic) |
| 0002 — Worktree isolation | Yes | `feature/issue-64` worktree |
| 0001 — Capture decisions | Yes | Safety-behavior rationale in the package README |
| 0013 — progress.md vocabulary | Yes | `## Plan Authored` / `## Plan Review` entries |

## Consequences

| If we change... | Also update... | In plan? |
|---|---|---|
| Add a new node (params/topics) | Package README; per-240 config | README yes; config → seafloor#43 |
| Replace the Collision Monitor (incl. viz) | nav2 chain wiring + **sole-helm-publisher cutover** (one publisher on `cmd_vel_out`); CAMP viz (polygon topics + `CollisionMonitorState`) | Config → seafloor#43; reconcile #25/#27/#36; CM pass-through on non-reflex boats |
| New `odom` + pointcloud deps + tf transform | Topic supply + `base_frame` value (prefixed/level) | External → seafloor#43 |

## Open Questions

- [ ] (integration, seafloor#43) Confirm the cutover removes the CM cleanly (single helm
      publisher), and that CAMP's polygon coloring keys off the topic names — verify on the
      bench during wiring.

## Estimated Scope

**Single PR** (node + unit + launch_testing) in `unh_marine_navigation`. Config wiring is a
separate PR in `seafloor_echoboat_project11` (#43); recovery BT back-off is #67. Sim gates
must pass before any on-water trust (and gate the reverse-yaw-passthrough path).
