### PR TITLE
Recolor nav path/marker viz off CAMP's reserved red/green (part of #66)

### DIFF
--- a/marine_nav_avoidance_controller/src/avoidance_controller.cpp
+++ b/marine_nav_avoidance_controller/src/avoidance_controller.cpp
@@ -87,8 +87,11 @@ visualization_msgs::msg::MarkerArray buildAvoidanceMarkers(
   }
   arr.markers.push_back(adjusted_m);
 
+  // Amber, not red: CAMP reserves red/green for the plan's editable/locked
+  // state (waypoint.cpp darkRed/darkGreen), so the active-deviation band uses
+  // an amber "caution" hue to stay distinct from an editable plan line.
   auto band_m = base(2, visualization_msgs::msg::Marker::LINE_LIST, 1.6,
-      1.0, 0.15, 0.1, 0.9);
+      1.0, 0.6, 0.0, 0.9);
   for (std::size_t i = 0; i + 1 < stations.size(); ++i) {
     if (std::abs(offsets_d[i]) >= kDeviationEpsilon &&
       std::abs(offsets_d[i + 1]) >= kDeviationEpsilon)
@@ -102,7 +105,7 @@ visualization_msgs::msg::MarkerArray buildAvoidanceMarkers(
   }
 
   auto text_m = base(3, visualization_msgs::msg::Marker::TEXT_VIEW_FACING, 1.0,
-      1.0, 0.2, 0.15, 1.0);
+      1.0, 0.6, 0.0, 1.0);  // amber, matching the deviation band (see above)
   text_m.scale.z = 3.0;
   text_m.text = "AVOIDING";
   text_m.pose.position = adjusted_point(peak_i);

--- a/marine_nav_behaviors/src/hover.cpp
+++ b/marine_nav_behaviors/src/hover.cpp
@@ -243,10 +243,13 @@ void Hover::publish_visualization(rclcpp::Time time)
   marker.type = visualization_msgs::msg::Marker::SPHERE;
   marker.pose.position =  target.pose.position;
   marker.pose.orientation.w = 1.0;
-  marker.color.r = 0.0;
-  marker.color.g = 1.0;
-  marker.color.b = 0.0;
-  marker.color.a = .75;
+  // Violet, not green, and more transparent: CAMP reserves red/green for the
+  // plan's editable/locked state (waypoint.cpp), so the hover radius uses a
+  // violet hue, dimmed so it doesn't dominate the chart underneath.
+  marker.color.r = 0.6;
+  marker.color.g = 0.2;
+  marker.color.b = 0.8;
+  marker.color.a = .35;
   marker.scale.x =  2.0*maximum_radius_;
   marker.scale.y = 2.0*maximum_radius_;
   marker.scale.z = 0.01;
@@ -262,10 +265,10 @@ void Hover::publish_visualization(rclcpp::Time time)
   inmarker.type = visualization_msgs::msg::Marker::SPHERE;
   inmarker.pose.position =  target.pose.position;
   inmarker.pose.orientation.w = 1.0;
-  inmarker.color.r = 0.0;
-  inmarker.color.g = 1.0;
-  inmarker.color.b = 0.2;
-  inmarker.color.a = .75;
+  inmarker.color.r = 0.7;
+  inmarker.color.g = 0.3;
+  inmarker.color.b = 0.9;
+  inmarker.color.a = .35;  // violet (see outer marker), dimmed
   inmarker.scale.x =  2.0*minimum_radius_;
   inmarker.scale.y = 2.0*minimum_radius_;
   inmarker.scale.z = 0.01;

--- a/marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp
+++ b/marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp
@@ -389,10 +389,12 @@ void CrabbingPathFollower::publish_visualization(
   colors[0].g = 0.25;
   colors[0].b = 0.25;
   colors[0].a = 0.5;
-  // current_color
-  colors[1].r = 0.25;
-  colors[1].g = 0.75;
-  colors[1].b = 0.25;
+  // current_color — magenta, not green: CAMP reserves red/green for the plan's
+  // editable/locked state (waypoint.cpp darkRed/darkGreen), so the active
+  // segment uses magenta to stay distinct from a locked (sent) plan line.
+  colors[1].r = 0.85;
+  colors[1].g = 0.1;
+  colors[1].b = 0.85;
   colors[1].a = 0.75;
   // future_color
   colors[2].r = 0.25;


### PR DESCRIPTION
Recolors nav-stack path/marker visualizations so they stop colliding with CAMP's plan-state
convention, making the map legible for on-water PID tuning (part of #66).

CAMP draws the plan in **darkRed when editable / darkGreen when locked** (locked = sent to the
boat; `waypoint.cpp`). These markers reused red/green and were ambiguous against that:

| Element | File | From | To |
|---|---|---|---|
| Avoider deviation band + "AVOIDING" text | `marine_nav_avoidance_controller` | red | **amber** |
| Follower current segment | `marine_nav_crabbing_path_follower` | green | **magenta** |
| Hover spheres (outer + inner) | `marine_nav_behaviors` | green, α 0.75 | **violet, α 0.35** |

Kept deliberately: avoider **nominal** (grey — shows what the boat is working from, useful after
an unlock+modify), avoider **adjusted** (cyan), follower **past/future** (grey/blue). CAMP honors
marker colors, so no CAMP-side change. Builds clean (3 packages).

Follow-up under #66 (separate): cross-track-error display in CAMP (`pid_state` isn't bridged) —
the other on-water tuning-observability gap.

Closes #69.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8`
