### PR TITLE
CrabbingPathFollower: progress-preserving localization + pure-pursuit look-ahead + tunable/clamped yaw (part of #66)

### DIFF
--- a/.agent/work-plans/issue-71/progress.md
+++ b/.agent/work-plans/issue-71/progress.md
@@ -28,3 +28,24 @@ issue: 71
 
 ### Backward-compat (verified)
 Defaults (lookahead 0, gain 1.0, max_yaw_rate π) reproduce the prior behaviour exactly; the localization change in setPlan is intentionally always-on (the teleport bug fix).
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-06-05 02:55 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8)
+
+**PR**: #72 at `4bdc23a`
+**Sources**: 2 (Copilot R3 @ `2b6951c`, prior Local Review)
+**Cross-source confirmations**: 2
+
+### Findings
+- [x] (cross-confirmed: Copilot + Local Review) stall on shorter same-goal re-plan (clamp to "done" sentinel) — fixed earlier (clamp to segment_count-1)
+- [x] (cross-confirmed: Copilot + Local Review) forward-stuck cursor on same-goal reshape — fixed earlier (bounded one-segment backward re-localization)
+- [x] (valid, Copilot) new tuning params unvalidated → `std::clamp` lo>hi UB / NaN into cmd_vel — fixed: params now live-tunable + finite/lower-bound validated, atomic — `crabbing_path_follower.cpp`
+- [x] (valid, Copilot) gtest target setup unconditional (breaks when GTest disabled) — fixed: `if(TARGET ...)` guard — `CMakeLists.txt`
+
+### False positives
+- (Copilot) setPlan mutates plan/cursor without a mutex → data race — Nav2's controller_server serializes setPlan() and computeVelocityCommands() on one thread (only the param-service callback is cross-thread, handled via the atomics). No new race; matches the existing design.
+
+### Bonus
+The validation fix doubled as the on-water-tuning enabler: the new params are now settable via `ros2 param set` (previously configure-time only).

--- a/.agent/work-plans/issue-71/progress.md
+++ b/.agent/work-plans/issue-71/progress.md
@@ -1,0 +1,30 @@
+---
+issue: 71
+---
+
+# Issue #71 — CrabbingPathFollower: progress-preserving localization + look-ahead steering + tunable/clamped yaw rate (part of #66)
+
+## Local Review
+**Status**: complete
+**When**: 2026-06-05 01:51 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8)
+**Verdict**: changes-requested
+
+**PR**: #72 at `7cd4879`
+**Mode**: post-PR
+**Depth**: Standard (reason: substantive Nav2 controller logic, single package)
+**Specialists**: Static (cpplint/cppcheck), Claude Adversarial; Copilot present but not dispatched this pass
+**Must-fix**: 1 fixed, 1 open | **Suggestions**: 2 addressed
+
+### Findings
+- [x] (must-fix) setPlan stall: a shorter/sparser same-goal re-plan clamped current_segment_ to segment_count (the "done" sentinel), parking the boat — fixed, clamp to segment_count-1 — `crabbing_path_follower.cpp` setPlan
+- [ ] (must-fix, borderline) forward-only cursor can stick too far forward on a non-monotone same-goal path reshape (cursor never backs up); bounded one-segment backward correction proposed, pending design call — `crabbing_path_follower.cpp` computeVelocityCommands scan
+- [x] (suggestion) look-ahead speed-scaled horizon uses commanded speed, not trajectory-derived per-pose speed — documented in-code
+- [x] (suggestion) progress passed as start_offset can be negative; lookaheadPoint clamps to 0 (horizon measured from segment start) — documented in-code
+
+### Static analysis
+- cppcheck: clean on changed code (flagged items pre-existing: dt shadow, cos_error_azimuth scope)
+- cpplint: header-guard for path_geometry.hpp fixed; remaining line-length/copyright findings match the package's existing un-enforced style (not new)
+
+### Backward-compat (verified)
+Defaults (lookahead 0, gain 1.0, max_yaw_rate π) reproduce the prior behaviour exactly; the localization change in setPlan is intentionally always-on (the teleport bug fix).

--- a/.agent/work-plans/issue-71/progress.md
+++ b/.agent/work-plans/issue-71/progress.md
@@ -18,7 +18,7 @@ issue: 71
 
 ### Findings
 - [x] (must-fix) setPlan stall: a shorter/sparser same-goal re-plan clamped current_segment_ to segment_count (the "done" sentinel), parking the boat — fixed, clamp to segment_count-1 — `crabbing_path_follower.cpp` setPlan
-- [ ] (must-fix, borderline) forward-only cursor can stick too far forward on a non-monotone same-goal path reshape (cursor never backs up); bounded one-segment backward correction proposed, pending design call — `crabbing_path_follower.cpp` computeVelocityCommands scan
+- [x] (must-fix, borderline) forward-stuck-on-reshape — fixed: bounded one-segment backward re-localization (alongTrackProjection, +3 gtests) — `crabbing_path_follower.cpp` scan
 - [x] (suggestion) look-ahead speed-scaled horizon uses commanded speed, not trajectory-derived per-pose speed — documented in-code
 - [x] (suggestion) progress passed as start_offset can be negative; lookaheadPoint clamps to 0 (horizon measured from segment start) — documented in-code
 

--- a/.agent/work-plans/issue-71/progress.md
+++ b/.agent/work-plans/issue-71/progress.md
@@ -49,3 +49,18 @@ Defaults (lookahead 0, gain 1.0, max_yaw_rate π) reproduce the prior behaviour 
 
 ### Bonus
 The validation fix doubled as the on-water-tuning enabler: the new params are now settable via `ros2 param set` (previously configure-time only).
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-06-05 03:04 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8)
+
+**PR**: #72 (Copilot R4 @ `1769196`)
+**Sources**: 1 (Copilot)
+**Cross-source confirmations**: 0
+
+### Findings
+- [x] (valid, Copilot) configure-time read_validated() used typed get_parameter -> throws on integer YAML (e.g. `max_yaw_rate: 1`) — fixed: generic get + int->double coercion (matches default_speed) — `crabbing_path_follower.cpp`
+
+### Carried-forward (already resolved)
+- stall clamp (segment_count-1): addressed; setPlan data race: false positive (Nav2 same-thread + atomics); bounded backward re-localization: addressed. GitHub re-anchors these unresolved comments to each new head; they describe superseded code.

--- a/marine_nav_crabbing_path_follower/CMakeLists.txt
+++ b/marine_nav_crabbing_path_follower/CMakeLists.txt
@@ -11,6 +11,7 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(control_toolbox REQUIRED)
+find_package(geometry_msgs REQUIRED)
 find_package(marine_nav_utilities REQUIRED)
 find_package(nav2_core REQUIRED)
 find_package(nav2_costmap_2d REQUIRED)
@@ -36,6 +37,7 @@ target_compile_definitions(${PROJECT_NAME} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNC
 
 ament_target_dependencies(${PROJECT_NAME}
   control_toolbox
+  geometry_msgs
   marine_nav_utilities
   nav2_core
   nav2_costmap_2d
@@ -62,6 +64,12 @@ install(FILES plugin.xml
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(test_path_geometry test/test_path_geometry.cpp)
+  target_include_directories(test_path_geometry PRIVATE
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>")
+  ament_target_dependencies(test_path_geometry geometry_msgs)
 endif()
 
 ament_package()

--- a/marine_nav_crabbing_path_follower/CMakeLists.txt
+++ b/marine_nav_crabbing_path_follower/CMakeLists.txt
@@ -67,9 +67,11 @@ if(BUILD_TESTING)
 
   find_package(ament_cmake_gtest REQUIRED)
   ament_add_gtest(test_path_geometry test/test_path_geometry.cpp)
-  target_include_directories(test_path_geometry PRIVATE
-    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>")
-  ament_target_dependencies(test_path_geometry geometry_msgs)
+  if(TARGET test_path_geometry)
+    target_include_directories(test_path_geometry PRIVATE
+      "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>")
+    ament_target_dependencies(test_path_geometry geometry_msgs)
+  endif()
 endif()
 
 ament_package()

--- a/marine_nav_crabbing_path_follower/include/marine_nav_crabbing_path_follower/crabbing_path_follower.h
+++ b/marine_nav_crabbing_path_follower/include/marine_nav_crabbing_path_follower/crabbing_path_follower.h
@@ -87,9 +87,12 @@ protected:
   // heading aims at a point that far ahead on the path (anticipates bends)
   // instead of the local segment azimuth. lookahead_time_ > 0 makes the
   // distance speed-scaled: L = max(lookahead_min_distance_, V * time).
-  // All default to 0 / segment-azimuth behaviour, so nothing changes until
-  // tuned. With look-ahead on, set the cross-track PID to I-only (the look-ahead
-  // distance becomes the cross-track-tightness dial; I keeps the current crab).
+  // Look-ahead is OFF by default: lookahead_distance_ and lookahead_time_ are
+  // both 0, so the base heading stays the segment azimuth (historical
+  // behaviour) until tuned. lookahead_min_distance_ (1.0) is only a floor that
+  // applies once lookahead_time_ > 0. With look-ahead on, set the cross-track
+  // PID to I-only (the look-ahead distance becomes the cross-track-tightness
+  // dial; I keeps the current crab).
   std::atomic<double> lookahead_distance_{0.0};
   std::atomic<double> lookahead_time_{0.0};
   std::atomic<double> lookahead_min_distance_{1.0};

--- a/marine_nav_crabbing_path_follower/include/marine_nav_crabbing_path_follower/crabbing_path_follower.h
+++ b/marine_nav_crabbing_path_follower/include/marine_nav_crabbing_path_follower/crabbing_path_follower.h
@@ -75,8 +75,13 @@ protected:
   // clamp at ±pi == the previous ZeroCentered wrap). The velocity_smoother
   // still enforces the physical rate/accel limits downstream — this clamp is a
   // controller-level safety bound, not a replacement.
-  double heading_rate_gain_ = 1.0;
-  double max_yaw_rate_ = M_PI;
+  //
+  // These are live-tunable via `ros2 param set` (the parameter callback below
+  // validates + updates them), so they are `std::atomic` for the same reason as
+  // desired_speed_: the param-service thread writes while computeVelocityCommands
+  // reads on the controller thread.
+  std::atomic<double> heading_rate_gain_{1.0};
+  std::atomic<double> max_yaw_rate_{M_PI};
 
   // Pure-pursuit look-ahead. When the effective distance is > 0 the base
   // heading aims at a point that far ahead on the path (anticipates bends)
@@ -85,17 +90,19 @@ protected:
   // All default to 0 / segment-azimuth behaviour, so nothing changes until
   // tuned. With look-ahead on, set the cross-track PID to I-only (the look-ahead
   // distance becomes the cross-track-tightness dial; I keeps the current crab).
-  double lookahead_distance_ = 0.0;
-  double lookahead_time_ = 0.0;
-  double lookahead_min_distance_ = 1.0;
+  std::atomic<double> lookahead_distance_{0.0};
+  std::atomic<double> lookahead_time_{0.0};
+  std::atomic<double> lookahead_min_distance_{1.0};
 
   // Progress-preserving localization: keep the segment cursor across the
   // per-cycle setPlan re-issues from the avoidance decorator, resetting only
   // when the goal (final pose) moves more than this — i.e. a genuinely new
   // line. Stops the cross-track reference snapping backward during a weave.
+  // have_last_goal_/last_goal_ are touched only by setPlan (controller thread),
+  // so they stay plain; the tolerance is live-tunable, hence atomic.
   bool have_last_goal_ = false;
   geometry_msgs::msg::Point last_goal_;
-  double new_plan_goal_tolerance_ = 1.0;
+  std::atomic<double> new_plan_goal_tolerance_{1.0};
 
   bool visualize_ = false;
   rclcpp_lifecycle::LifecyclePublisher<visualization_msgs::msg::MarkerArray>::SharedPtr visualization_publisher_;

--- a/marine_nav_crabbing_path_follower/include/marine_nav_crabbing_path_follower/crabbing_path_follower.h
+++ b/marine_nav_crabbing_path_follower/include/marine_nav_crabbing_path_follower/crabbing_path_follower.h
@@ -2,7 +2,9 @@
 #define MARINE_NAV_CRABBING_PATH_FOLLOWER_CRABBING_PATH_FOLLOWER_H
 
 #include <atomic>
+#include <cmath>
 
+#include "geometry_msgs/msg/point.hpp"
 #include "nav2_core/controller.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "pluginlib/class_loader.hpp"
@@ -67,6 +69,33 @@ protected:
   std::shared_ptr<control_toolbox::PidROS> pid_;
   rclcpp::Time last_update_time_;
   rclcpp::Duration pid_reset_threshold_ {1, 0};
+
+  // Inner heading loop: angular.z = clamp(heading_rate_gain_ * heading_error,
+  // ±max_yaw_rate_). Defaults reproduce the historical behaviour (gain 1.0,
+  // clamp at ±pi == the previous ZeroCentered wrap). The velocity_smoother
+  // still enforces the physical rate/accel limits downstream — this clamp is a
+  // controller-level safety bound, not a replacement.
+  double heading_rate_gain_ = 1.0;
+  double max_yaw_rate_ = M_PI;
+
+  // Pure-pursuit look-ahead. When the effective distance is > 0 the base
+  // heading aims at a point that far ahead on the path (anticipates bends)
+  // instead of the local segment azimuth. lookahead_time_ > 0 makes the
+  // distance speed-scaled: L = max(lookahead_min_distance_, V * time).
+  // All default to 0 / segment-azimuth behaviour, so nothing changes until
+  // tuned. With look-ahead on, set the cross-track PID to I-only (the look-ahead
+  // distance becomes the cross-track-tightness dial; I keeps the current crab).
+  double lookahead_distance_ = 0.0;
+  double lookahead_time_ = 0.0;
+  double lookahead_min_distance_ = 1.0;
+
+  // Progress-preserving localization: keep the segment cursor across the
+  // per-cycle setPlan re-issues from the avoidance decorator, resetting only
+  // when the goal (final pose) moves more than this — i.e. a genuinely new
+  // line. Stops the cross-track reference snapping backward during a weave.
+  bool have_last_goal_ = false;
+  geometry_msgs::msg::Point last_goal_;
+  double new_plan_goal_tolerance_ = 1.0;
 
   bool visualize_ = false;
   rclcpp_lifecycle::LifecyclePublisher<visualization_msgs::msg::MarkerArray>::SharedPtr visualization_publisher_;

--- a/marine_nav_crabbing_path_follower/include/marine_nav_crabbing_path_follower/path_geometry.hpp
+++ b/marine_nav_crabbing_path_follower/include/marine_nav_crabbing_path_follower/path_geometry.hpp
@@ -1,5 +1,5 @@
-#ifndef MARINE_NAV_CRABBING_PATH_FOLLOWER_PATH_GEOMETRY_H
-#define MARINE_NAV_CRABBING_PATH_FOLLOWER_PATH_GEOMETRY_H
+#ifndef MARINE_NAV_CRABBING_PATH_FOLLOWER__PATH_GEOMETRY_HPP_
+#define MARINE_NAV_CRABBING_PATH_FOLLOWER__PATH_GEOMETRY_HPP_
 
 #include <algorithm>
 #include <cmath>
@@ -63,4 +63,4 @@ inline geometry_msgs::msg::Point lookaheadPoint(
 
 }  // namespace marine_nav_crabbing_path_follower
 
-#endif  // MARINE_NAV_CRABBING_PATH_FOLLOWER_PATH_GEOMETRY_H
+#endif  // MARINE_NAV_CRABBING_PATH_FOLLOWER__PATH_GEOMETRY_HPP_

--- a/marine_nav_crabbing_path_follower/include/marine_nav_crabbing_path_follower/path_geometry.hpp
+++ b/marine_nav_crabbing_path_follower/include/marine_nav_crabbing_path_follower/path_geometry.hpp
@@ -61,6 +61,23 @@ inline geometry_msgs::msg::Point lookaheadPoint(
   return poses[last].pose.position;
 }
 
+/// Signed along-track distance of point `p` projected onto the segment a->b,
+/// measured from `a`. Negative means `p` is behind the segment start. A
+/// degenerate (zero-length) segment returns 0.
+inline double alongTrackProjection(
+  const geometry_msgs::msg::Point & a,
+  const geometry_msgs::msg::Point & b,
+  const geometry_msgs::msg::Point & p)
+{
+  const double sx = b.x - a.x;
+  const double sy = b.y - a.y;
+  const double seg_len = std::hypot(sx, sy);
+  if (seg_len < 1e-9) {
+    return 0.0;
+  }
+  return ((p.x - a.x) * sx + (p.y - a.y) * sy) / seg_len;
+}
+
 }  // namespace marine_nav_crabbing_path_follower
 
 #endif  // MARINE_NAV_CRABBING_PATH_FOLLOWER__PATH_GEOMETRY_HPP_

--- a/marine_nav_crabbing_path_follower/include/marine_nav_crabbing_path_follower/path_geometry.hpp
+++ b/marine_nav_crabbing_path_follower/include/marine_nav_crabbing_path_follower/path_geometry.hpp
@@ -1,0 +1,66 @@
+#ifndef MARINE_NAV_CRABBING_PATH_FOLLOWER_PATH_GEOMETRY_H
+#define MARINE_NAV_CRABBING_PATH_FOLLOWER_PATH_GEOMETRY_H
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+#include "geometry_msgs/msg/point.hpp"
+#include "geometry_msgs/msg/pose_stamped.hpp"
+
+namespace marine_nav_crabbing_path_follower
+{
+
+/// Walk `lookahead` metres forward along a piecewise-linear path and return the
+/// point reached — the pure-pursuit "look-ahead point".
+///
+/// The walk starts `start_offset` metres into segment `start_seg` (i.e. the
+/// vehicle's projection onto that segment) and advances **forward only**. If the
+/// look-ahead distance runs past the end of the path, the final path point (the
+/// goal) is returned, so the follower converges onto the goal instead of
+/// over-running it. Degenerate inputs (empty path, single point, out-of-range
+/// start) return a sensible point rather than reading out of bounds.
+inline geometry_msgs::msg::Point lookaheadPoint(
+  const std::vector<geometry_msgs::msg::PoseStamped> & poses,
+  int start_seg, double start_offset, double lookahead)
+{
+  geometry_msgs::msg::Point p;
+  if (poses.empty()) {
+    return p;
+  }
+  const int last = static_cast<int>(poses.size()) - 1;
+  if (last == 0) {
+    return poses[0].pose.position;
+  }
+  if (start_seg < 0) {
+    start_seg = 0;
+  }
+  if (start_seg > last - 1) {
+    return poses[last].pose.position;
+  }
+
+  double remaining = std::max(0.0, lookahead);
+  for (int i = start_seg; i < last; ++i) {
+    const auto & a = poses[i].pose.position;
+    const auto & b = poses[i + 1].pose.position;
+    const double seg_len = std::hypot(b.x - a.x, b.y - a.y);
+    const double offset = (i == start_seg) ? std::clamp(start_offset, 0.0, seg_len) : 0.0;
+    const double avail = seg_len - offset;
+
+    // Last segment, or the look-ahead lands within this segment: interpolate.
+    if (remaining <= avail || i == last - 1) {
+      const double along = std::min(offset + remaining, seg_len);
+      const double f = (seg_len > 1e-9) ? along / seg_len : 0.0;
+      p.x = a.x + f * (b.x - a.x);
+      p.y = a.y + f * (b.y - a.y);
+      p.z = a.z + f * (b.z - a.z);
+      return p;
+    }
+    remaining -= avail;
+  }
+  return poses[last].pose.position;
+}
+
+}  // namespace marine_nav_crabbing_path_follower
+
+#endif  // MARINE_NAV_CRABBING_PATH_FOLLOWER_PATH_GEOMETRY_H

--- a/marine_nav_crabbing_path_follower/package.xml
+++ b/marine_nav_crabbing_path_follower/package.xml
@@ -10,6 +10,7 @@
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
   <depend>control_toolbox</depend>
+  <depend>geometry_msgs</depend>
   <depend>marine_nav_utilities</depend>
   <depend>nav2_core</depend>
   <depend>nav2_costmap_2d</depend>
@@ -22,6 +23,7 @@
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp
+++ b/marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp
@@ -1,7 +1,10 @@
 #include "marine_nav_crabbing_path_follower/crabbing_path_follower.h"
 
+#include <algorithm>
 #include <cmath>
 #include <limits>
+
+#include "marine_nav_crabbing_path_follower/path_geometry.hpp"
 
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "nav2_util/node_utils.hpp"
@@ -173,6 +176,23 @@ void CrabbingPathFollower::configure(
 
   nav2_util::declare_parameter_if_not_declared(node, plugin_name_ + ".transform_tolerance", rclcpp::ParameterValue(transform_tolerance_));
   node->get_parameter(plugin_name_ + ".transform_tolerance", transform_tolerance_);
+
+  // Inner heading loop + pure-pursuit look-ahead (see header). All defaults
+  // reproduce the historical segment-azimuth behaviour, so nothing changes
+  // until these are tuned on the water.
+  nav2_util::declare_parameter_if_not_declared(node, plugin_name_ + ".heading_rate_gain", rclcpp::ParameterValue(heading_rate_gain_));
+  node->get_parameter(plugin_name_ + ".heading_rate_gain", heading_rate_gain_);
+  nav2_util::declare_parameter_if_not_declared(node, plugin_name_ + ".max_yaw_rate", rclcpp::ParameterValue(max_yaw_rate_));
+  node->get_parameter(plugin_name_ + ".max_yaw_rate", max_yaw_rate_);
+  nav2_util::declare_parameter_if_not_declared(node, plugin_name_ + ".lookahead_distance", rclcpp::ParameterValue(lookahead_distance_));
+  node->get_parameter(plugin_name_ + ".lookahead_distance", lookahead_distance_);
+  nav2_util::declare_parameter_if_not_declared(node, plugin_name_ + ".lookahead_time", rclcpp::ParameterValue(lookahead_time_));
+  node->get_parameter(plugin_name_ + ".lookahead_time", lookahead_time_);
+  nav2_util::declare_parameter_if_not_declared(node, plugin_name_ + ".lookahead_min_distance", rclcpp::ParameterValue(lookahead_min_distance_));
+  node->get_parameter(plugin_name_ + ".lookahead_min_distance", lookahead_min_distance_);
+  nav2_util::declare_parameter_if_not_declared(node, plugin_name_ + ".new_plan_goal_tolerance", rclcpp::ParameterValue(new_plan_goal_tolerance_));
+  node->get_parameter(plugin_name_ + ".new_plan_goal_tolerance", new_plan_goal_tolerance_);
+
   global_pub_ = node->create_publisher<nav_msgs::msg::Path>("received_global_plan", 1);
 }
 
@@ -218,18 +238,38 @@ void CrabbingPathFollower::setSpeedLimit(
 void CrabbingPathFollower::setPlan(const nav_msgs::msg::Path & path)
 {
   global_pub_->publish(path);
-  global_plan_ = path;
-  current_segment_ = 0;
-  // Intentionally do NOT reset the PID here. A decorator controller
+
+  // Progress-preserving localization. The avoidance decorator
   // (marine_nav_avoidance_controller, #59) re-issues setPlan every control
-  // cycle to feed a freshly reshaped path; an unconditional reset would wipe
-  // the cross-track integrator each tick and destroy crab compensation. The
-  // PID is instead reset only when it has gone stale — idle longer than
-  // pid_reset_threshold_ ("N seconds") — by the staleness guard in
-  // computeVelocityCommands, which is the genuine "new goal after a pause"
-  // case. current_segment_ is reset to 0 and re-advanced by the forward scan
-  // in computeVelocityCommands, so a same-tick re-plan still localises onto
-  // the boat's current segment.
+  // cycle with a freshly reshaped — but same-goal — path; a same-goal replan
+  // (IsPathValid failure) does likewise. Resetting current_segment_ to 0 each
+  // time made the forward scan in computeVelocityCommands re-localise from the
+  // path start, which during a weave/loop snaps the cursor *backward* and steps
+  // the cross-track reference 5-9 m (kicking the PID — root-caused 2026-06-04).
+  // Keep the cursor across same-goal re-issues; reset only when the goal (final
+  // pose) moves more than new_plan_goal_tolerance_ — a genuinely new line — so
+  // each new line still starts from its beginning. The PID is likewise not
+  // reset here (only by the staleness guard in computeVelocityCommands).
+  const auto & poses = path.poses;
+  bool new_line = true;
+  if (!poses.empty() && have_last_goal_) {
+    const auto & g = poses.back().pose.position;
+    const double moved = std::hypot(g.x - last_goal_.x, g.y - last_goal_.y);
+    new_line = moved > new_plan_goal_tolerance_;
+  }
+  if (new_line || current_segment_ < 0) {
+    current_segment_ = 0;
+  }
+  const int segment_count = std::max<int>(0, static_cast<int>(poses.size()) - 1);
+  if (current_segment_ > segment_count) {
+    current_segment_ = segment_count;  // new path is shorter than our progress
+  }
+  if (!poses.empty()) {
+    last_goal_ = poses.back().pose.position;
+    have_last_goal_ = true;
+  }
+
+  global_plan_ = path;
 }
 
 
@@ -349,9 +389,34 @@ geometry_msgs::msg::TwistStamped CrabbingPathFollower::computeVelocityCommands(
 
   RCLCPP_DEBUG_STREAM(logger_, "CrabbingPathFollower: progress: " << progress << " cross_track_error: " << cross_track_error << " crab_angle: " << crab_angle.value() << " heading: " << heading.value() << " segment_azimuth: " << segment_azimuth.value());
 
-  AngleRadians target_heading = segment_azimuth +	crab_angle;
+  // Base heading: the local segment azimuth (default), or — with look-ahead
+  // enabled — the pure-pursuit bearing to a point `lookahead` metres ahead on
+  // the path, which anticipates bends instead of reacting to them. The look-
+  // ahead distance is fixed (lookahead_distance_) or speed-scaled
+  // (lookahead_time_ > 0: L = max(lookahead_min_distance_, V*time)).
+  AngleRadians base_heading = segment_azimuth;
+  double lookahead = lookahead_distance_;
+  if (lookahead_time_ > 0.0) {
+    lookahead = std::max(lookahead_min_distance_, target_speed * lookahead_time_);
+  }
+  if (lookahead > 0.0) {
+    const auto la = lookaheadPoint(
+      global_plan_.poses, current_segment_, progress, lookahead);
+    base_heading = AngleRadians(atan2(
+      la.y - pose_in_plan.pose.position.y,
+      la.x - pose_in_plan.pose.position.x));
+  }
 
-  cmd_vel.twist.angular.z = AngleRadiansZeroCentered(target_heading-heading).value();
+  AngleRadians target_heading = base_heading + crab_angle;
+
+  // Inner heading loop: proportional heading-error -> yaw rate, with a tunable
+  // gain and a clamp to the achievable yaw envelope. Defaults (gain 1.0, clamp
+  // +/-pi) reproduce the previous ZeroCentered-wrap behaviour. The
+  // velocity_smoother still enforces the physical rate/accel limits downstream.
+  const double heading_error =
+    AngleRadiansZeroCentered(target_heading - heading).value();
+  cmd_vel.twist.angular.z =
+    std::clamp(heading_rate_gain_ * heading_error, -max_yaw_rate_, max_yaw_rate_);
 
   rclcpp::Time segment_start_time = p1.header.stamp;
   rclcpp::Time segment_end_time = p2.header.stamp;

--- a/marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp
+++ b/marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp
@@ -256,7 +256,21 @@ void CrabbingPathFollower::configure(
       double v = target.load();
       const std::string pname = plugin_name_ + suffix;
       nav2_util::declare_parameter_if_not_declared(node, pname, rclcpp::ParameterValue(v));
-      node->get_parameter(pname, v);
+      // Read generically and coerce integer -> double so `max_yaw_rate: 1` in
+      // YAML (parsed as an integer) doesn't throw InvalidParameterTypeException
+      // — the same operator footgun handled for default_speed above.
+      const rclcpp::Parameter param = node->get_parameter(pname);
+      const auto ptype = param.get_type();
+      if (ptype == rclcpp::ParameterType::PARAMETER_DOUBLE) {
+        v = param.as_double();
+      } else if (ptype == rclcpp::ParameterType::PARAMETER_INTEGER) {
+        v = static_cast<double>(param.as_int());
+      } else {
+        RCLCPP_WARN(
+          logger_, "CrabbingPathFollower: %s has non-numeric type; keeping %.3f",
+          pname.c_str(), target.load());
+        return;
+      }
       if (std::isfinite(v) && (exclusive_lo ? v > lo : v >= lo)) {
         target.store(v);
       } else {

--- a/marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp
+++ b/marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp
@@ -262,7 +262,11 @@ void CrabbingPathFollower::setPlan(const nav_msgs::msg::Path & path)
   }
   const int segment_count = std::max<int>(0, static_cast<int>(poses.size()) - 1);
   if (current_segment_ > segment_count) {
-    current_segment_ = segment_count;  // new path is shorter than our progress
+    // A sparser/shorter same-goal re-plan left the cursor past the new path.
+    // Re-localize onto the last *traversable* segment, not segment_count —
+    // current_segment_ == segment_count is the "done" sentinel in
+    // computeVelocityCommands, which would stall the boat (zero cmd_vel).
+    current_segment_ = std::max(0, segment_count - 1);
   }
   if (!poses.empty()) {
     last_goal_ = poses.back().pose.position;
@@ -397,9 +401,16 @@ geometry_msgs::msg::TwistStamped CrabbingPathFollower::computeVelocityCommands(
   AngleRadians base_heading = segment_azimuth;
   double lookahead = lookahead_distance_;
   if (lookahead_time_ > 0.0) {
+    // Speed-scaled horizon. Note target_speed here is the commanded speed
+    // (default_speed / speed-limit); the per-pose-timestamp trajectory speed
+    // is derived later (below), so lookahead_time_ scales off the commanded
+    // speed, not the trajectory-derived one.
     lookahead = std::max(lookahead_min_distance_, target_speed * lookahead_time_);
   }
   if (lookahead > 0.0) {
+    // progress is the boat's signed projection along the current segment; it is
+    // clamped to [0, seg_len] inside lookaheadPoint, so a boat sitting behind
+    // the segment start measures the horizon from the segment start.
     const auto la = lookaheadPoint(
       global_plan_.poses, current_segment_, progress, lookahead);
     base_heading = AngleRadians(atan2(

--- a/marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp
+++ b/marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp
@@ -116,10 +116,42 @@ void CrabbingPathFollower::configure(
     [this, default_speed_name](const std::vector<rclcpp::Parameter> & params) {
       rcl_interfaces::msg::SetParametersResult result;
       result.successful = true;
-      for (const auto & p : params) {
-        if (p.get_name() != default_speed_name) {
-          continue;
+
+      // Coerce a numeric (double or integer) parameter; sets result.reason and
+      // returns false for a non-numeric type.
+      auto as_number = [&result](const rclcpp::Parameter & p, double & out) -> bool {
+        const auto t = p.get_type();
+        if (t == rclcpp::ParameterType::PARAMETER_DOUBLE) {out = p.as_double(); return true;}
+        if (t == rclcpp::ParameterType::PARAMETER_INTEGER) {
+          out = static_cast<double>(p.as_int());
+          return true;
         }
+        result.successful = false;
+        result.reason = p.get_name() +
+          " must be numeric (double or integer); got '" + p.value_to_string() + "'";
+        return false;
+      };
+      // Validate (finite + lower bound) and live-update one tuning atomic.
+      auto update = [this, &result](
+          std::atomic<double> & target, double v, double lo, bool exclusive_lo,
+          const char * pn) -> bool {
+        if (!(std::isfinite(v) && (exclusive_lo ? v > lo : v >= lo))) {
+          result.successful = false;
+          result.reason = std::string(pn) + " must be finite and " +
+            (exclusive_lo ? "> " : ">= ") + std::to_string(lo) + "; got " + std::to_string(v);
+          return false;
+        }
+        const double prev = target.load();
+        if (v != prev) {
+          target.store(v);
+          RCLCPP_INFO(logger_, "CrabbingPathFollower: %s updated %.3f -> %.3f", pn, prev, v);
+        }
+        return true;
+      };
+      const std::string base = plugin_name_;
+      for (const auto & p : params) {
+        const std::string & name = p.get_name();
+        if (name == default_speed_name) {
         // Accept PARAMETER_DOUBLE and PARAMETER_INTEGER (CLI `ros2 param set
         // ... 2` parses as integer; common operator mistake worth coercing).
         // Reject other types explicitly so callers see the error instead of
@@ -162,6 +194,43 @@ void CrabbingPathFollower::configure(
             "CrabbingPathFollower: default_speed updated %.3f -> %.3f m/s",
             prev_value, new_value);
         }
+        } else if (name == base + ".heading_rate_gain") {
+          double v;
+          if (!as_number(p, v) || !update(heading_rate_gain_, v, 0.0, true, "heading_rate_gain")) {
+            return result;
+          }
+        } else if (name == base + ".max_yaw_rate") {
+          double v;
+          if (!as_number(p, v) || !update(max_yaw_rate_, v, 0.0, true, "max_yaw_rate")) {
+            return result;
+          }
+        } else if (name == base + ".lookahead_distance") {
+          double v;
+          if (!as_number(p, v) ||
+            !update(lookahead_distance_, v, 0.0, false, "lookahead_distance"))
+          {
+            return result;
+          }
+        } else if (name == base + ".lookahead_time") {
+          double v;
+          if (!as_number(p, v) || !update(lookahead_time_, v, 0.0, false, "lookahead_time")) {
+            return result;
+          }
+        } else if (name == base + ".lookahead_min_distance") {
+          double v;
+          if (!as_number(p, v) ||
+            !update(lookahead_min_distance_, v, 0.0, false, "lookahead_min_distance"))
+          {
+            return result;
+          }
+        } else if (name == base + ".new_plan_goal_tolerance") {
+          double v;
+          if (!as_number(p, v) ||
+            !update(new_plan_goal_tolerance_, v, 0.0, false, "new_plan_goal_tolerance"))
+          {
+            return result;
+          }
+        }
       }
       return result;
     });
@@ -179,19 +248,29 @@ void CrabbingPathFollower::configure(
 
   // Inner heading loop + pure-pursuit look-ahead (see header). All defaults
   // reproduce the historical segment-azimuth behaviour, so nothing changes
-  // until these are tuned on the water.
-  nav2_util::declare_parameter_if_not_declared(node, plugin_name_ + ".heading_rate_gain", rclcpp::ParameterValue(heading_rate_gain_));
-  node->get_parameter(plugin_name_ + ".heading_rate_gain", heading_rate_gain_);
-  nav2_util::declare_parameter_if_not_declared(node, plugin_name_ + ".max_yaw_rate", rclcpp::ParameterValue(max_yaw_rate_));
-  node->get_parameter(plugin_name_ + ".max_yaw_rate", max_yaw_rate_);
-  nav2_util::declare_parameter_if_not_declared(node, plugin_name_ + ".lookahead_distance", rclcpp::ParameterValue(lookahead_distance_));
-  node->get_parameter(plugin_name_ + ".lookahead_distance", lookahead_distance_);
-  nav2_util::declare_parameter_if_not_declared(node, plugin_name_ + ".lookahead_time", rclcpp::ParameterValue(lookahead_time_));
-  node->get_parameter(plugin_name_ + ".lookahead_time", lookahead_time_);
-  nav2_util::declare_parameter_if_not_declared(node, plugin_name_ + ".lookahead_min_distance", rclcpp::ParameterValue(lookahead_min_distance_));
-  node->get_parameter(plugin_name_ + ".lookahead_min_distance", lookahead_min_distance_);
-  nav2_util::declare_parameter_if_not_declared(node, plugin_name_ + ".new_plan_goal_tolerance", rclcpp::ParameterValue(new_plan_goal_tolerance_));
-  node->get_parameter(plugin_name_ + ".new_plan_goal_tolerance", new_plan_goal_tolerance_);
+  // until tuned. Declared + validated here, kept live-tunable by the parameter
+  // callback below (same finite/lower-bound validation). exclusive_lo gates
+  // ">lo" (gains, max_yaw_rate) vs ">=lo" (look-ahead distances / tolerance).
+  auto read_validated = [&](const std::string & suffix, std::atomic<double> & target,
+      double lo, bool exclusive_lo) {
+      double v = target.load();
+      const std::string pname = plugin_name_ + suffix;
+      nav2_util::declare_parameter_if_not_declared(node, pname, rclcpp::ParameterValue(v));
+      node->get_parameter(pname, v);
+      if (std::isfinite(v) && (exclusive_lo ? v > lo : v >= lo)) {
+        target.store(v);
+      } else {
+        RCLCPP_WARN(
+          logger_, "CrabbingPathFollower: %s=%.3f invalid; keeping %.3f",
+          pname.c_str(), v, target.load());
+      }
+    };
+  read_validated(".heading_rate_gain", heading_rate_gain_, 0.0, true);
+  read_validated(".max_yaw_rate", max_yaw_rate_, 0.0, true);
+  read_validated(".lookahead_distance", lookahead_distance_, 0.0, false);
+  read_validated(".lookahead_time", lookahead_time_, 0.0, false);
+  read_validated(".lookahead_min_distance", lookahead_min_distance_, 0.0, false);
+  read_validated(".new_plan_goal_tolerance", new_plan_goal_tolerance_, 0.0, false);
 
   global_pub_ = node->create_publisher<nav_msgs::msg::Path>("received_global_plan", 1);
 }
@@ -255,7 +334,7 @@ void CrabbingPathFollower::setPlan(const nav_msgs::msg::Path & path)
   if (!poses.empty() && have_last_goal_) {
     const auto & g = poses.back().pose.position;
     const double moved = std::hypot(g.x - last_goal_.x, g.y - last_goal_.y);
-    new_line = moved > new_plan_goal_tolerance_;
+    new_line = moved > new_plan_goal_tolerance_.load();
   }
   if (new_line || current_segment_ < 0) {
     current_segment_ = 0;
@@ -417,14 +496,20 @@ geometry_msgs::msg::TwistStamped CrabbingPathFollower::computeVelocityCommands(
   // the path, which anticipates bends instead of reacting to them. The look-
   // ahead distance is fixed (lookahead_distance_) or speed-scaled
   // (lookahead_time_ > 0: L = max(lookahead_min_distance_, V*time)).
+  // Snapshot the live-tunable atomics once so a mid-cycle `ros2 param set`
+  // can't tear the control law.
+  const double lookahead_distance = lookahead_distance_.load();
+  const double lookahead_time = lookahead_time_.load();
+  const double lookahead_min_distance = lookahead_min_distance_.load();
+
   AngleRadians base_heading = segment_azimuth;
-  double lookahead = lookahead_distance_;
-  if (lookahead_time_ > 0.0) {
+  double lookahead = lookahead_distance;
+  if (lookahead_time > 0.0) {
     // Speed-scaled horizon. Note target_speed here is the commanded speed
     // (default_speed / speed-limit); the per-pose-timestamp trajectory speed
-    // is derived later (below), so lookahead_time_ scales off the commanded
+    // is derived later (below), so lookahead_time scales off the commanded
     // speed, not the trajectory-derived one.
-    lookahead = std::max(lookahead_min_distance_, target_speed * lookahead_time_);
+    lookahead = std::max(lookahead_min_distance, target_speed * lookahead_time);
   }
   if (lookahead > 0.0) {
     // progress is the boat's signed projection along the current segment; it is
@@ -445,8 +530,10 @@ geometry_msgs::msg::TwistStamped CrabbingPathFollower::computeVelocityCommands(
   // velocity_smoother still enforces the physical rate/accel limits downstream.
   const double heading_error =
     AngleRadiansZeroCentered(target_heading - heading).value();
+  const double heading_rate_gain = heading_rate_gain_.load();
+  const double max_yaw_rate = max_yaw_rate_.load();
   cmd_vel.twist.angular.z =
-    std::clamp(heading_rate_gain_ * heading_error, -max_yaw_rate_, max_yaw_rate_);
+    std::clamp(heading_rate_gain * heading_error, -max_yaw_rate, max_yaw_rate);
 
   rclcpp::Time segment_start_time = p1.header.stamp;
   rclcpp::Time segment_end_time = p2.header.stamp;

--- a/marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp
+++ b/marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp
@@ -336,6 +336,25 @@ geometry_msgs::msg::TwistStamped CrabbingPathFollower::computeVelocityCommands(
   geometry_msgs::msg::PoseStamped p2;
   AngleRadians segment_azimuth;
 
+  // Bounded backward re-localization (at most one segment per cycle). The
+  // forward scan below only ever advances the cursor; if a same-goal path
+  // reshape moved a vertex *ahead* of the boat, the cursor would stay too far
+  // forward and measure cross-track against a segment the boat hasn't reached.
+  // If the boat now projects behind the current segment's start, step back one
+  // segment. The single-step bound is deliberate: it lets a reshape re-localize
+  // without a weave/loop snapping the cursor all the way back to the start (the
+  // regression this change fixes). current_segment_ is in [1, segment_count-1]
+  // inside this guard, so indexing current_segment_+1 stays in range.
+  if (current_segment_ > 0) {
+    const double proj = alongTrackProjection(
+      global_plan_.poses[current_segment_].pose.position,
+      global_plan_.poses[current_segment_ + 1].pose.position,
+      pose_in_plan.pose.position);
+    if (proj < 0.0) {
+      current_segment_--;
+    }
+  }
+
   bool current_segment_is_good = false;
 
   while(!current_segment_is_good)

--- a/marine_nav_crabbing_path_follower/test/test_path_geometry.cpp
+++ b/marine_nav_crabbing_path_follower/test/test_path_geometry.cpp
@@ -86,6 +86,45 @@ TEST(LookaheadPoint, OutOfRangeStartSegmentReturnsGoal)
   EXPECT_NEAR(p.x, 20.0, 1e-6);
 }
 
+namespace
+{
+geometry_msgs::msg::Point pt(double x, double y)
+{
+  geometry_msgs::msg::Point p;
+  p.x = x;
+  p.y = y;
+  return p;
+}
+}  // namespace
+
+using marine_nav_crabbing_path_follower::alongTrackProjection;
+
+// Along-track projection: sign and magnitude relative to the segment start.
+TEST(AlongTrackProjection, PositiveAheadNegativeBehind)
+{
+  auto a = pt(0, 0);
+  auto b = pt(10, 0);          // segment points +x
+  EXPECT_NEAR(alongTrackProjection(a, b, pt(4, 3)), 4.0, 1e-9);   // ahead (lateral offset ignored)
+  EXPECT_NEAR(alongTrackProjection(a, b, pt(0, 5)), 0.0, 1e-9);   // at the start
+  EXPECT_LT(alongTrackProjection(a, b, pt(-2, 1)), 0.0);          // behind the start -> negative
+}
+
+// The backward-correction trigger: a boat behind the current segment start.
+TEST(AlongTrackProjection, NegativeIsTheBackwardStepTrigger)
+{
+  auto a = pt(5, 5);
+  auto b = pt(5, 15);          // segment points +y
+  EXPECT_LT(alongTrackProjection(a, b, pt(7, 2)), 0.0);           // below a -> behind
+  EXPECT_GT(alongTrackProjection(a, b, pt(7, 9)), 0.0);           // above a -> ahead
+}
+
+// Degenerate (zero-length) segment must not divide by zero.
+TEST(AlongTrackProjection, ZeroLengthSegmentReturnsZero)
+{
+  auto a = pt(3, 3);
+  EXPECT_EQ(alongTrackProjection(a, a, pt(9, 9)), 0.0);
+}
+
 int main(int argc, char ** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/marine_nav_crabbing_path_follower/test/test_path_geometry.cpp
+++ b/marine_nav_crabbing_path_follower/test/test_path_geometry.cpp
@@ -1,0 +1,93 @@
+#include <cmath>
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "marine_nav_crabbing_path_follower/path_geometry.hpp"
+
+using marine_nav_crabbing_path_follower::lookaheadPoint;
+
+namespace
+{
+std::vector<geometry_msgs::msg::PoseStamped> makePath(
+  const std::vector<std::pair<double, double>> & pts)
+{
+  std::vector<geometry_msgs::msg::PoseStamped> path;
+  for (const auto & p : pts) {
+    geometry_msgs::msg::PoseStamped ps;
+    ps.pose.position.x = p.first;
+    ps.pose.position.y = p.second;
+    path.push_back(ps);
+  }
+  return path;
+}
+}  // namespace
+
+// Walk L forward along a straight segment.
+TEST(LookaheadPoint, WalksForwardAlongStraightLine)
+{
+  auto path = makePath({{0, 0}, {20, 0}});
+  auto p = lookaheadPoint(path, 0, 5.0, 10.0);  // 5 m in, +10 m -> x = 15
+  EXPECT_NEAR(p.x, 15.0, 1e-6);
+  EXPECT_NEAR(p.y, 0.0, 1e-6);
+}
+
+// The worked example: the look-ahead point reaches *around* the bend, which is
+// exactly the anticipation we want (boat still on the straight, point past the
+// corner).
+TEST(LookaheadPoint, AnticipatesAroundABend)
+{
+  // A(0,0) -> B(20,0) -> C(30,10): straight east, then a left bend at B.
+  auto path = makePath({{0, 0}, {20, 0}, {30, 10}});
+  // Projected at x = 16 on segment 0 (offset 16), look 10 m: consume 4 m to B,
+  // then 6 m up B->C (unit (sqrt(0.5), sqrt(0.5))).
+  auto p = lookaheadPoint(path, 0, 16.0, 10.0);
+  EXPECT_NEAR(p.x, 20.0 + 6.0 * std::sqrt(0.5), 1e-3);
+  EXPECT_NEAR(p.y, 6.0 * std::sqrt(0.5), 1e-3);
+  EXPECT_GT(p.y, 0.0);  // past the corner == anticipating the turn
+}
+
+// Past the end of the path, clamp to the final point (the goal) so the boat
+// converges onto it rather than over-running.
+TEST(LookaheadPoint, ClampsToGoalPastEnd)
+{
+  auto path = makePath({{0, 0}, {20, 0}});
+  auto p = lookaheadPoint(path, 0, 5.0, 1000.0);
+  EXPECT_NEAR(p.x, 20.0, 1e-6);
+  EXPECT_NEAR(p.y, 0.0, 1e-6);
+}
+
+// Honour the starting segment + offset.
+TEST(LookaheadPoint, StartsFromGivenSegmentAndOffset)
+{
+  auto path = makePath({{0, 0}, {10, 0}, {20, 0}});
+  auto p = lookaheadPoint(path, 1, 2.0, 3.0);  // seg 1 (10..20), 2 in, +3 -> x = 15
+  EXPECT_NEAR(p.x, 15.0, 1e-6);
+}
+
+// Degenerate paths must not read out of bounds.
+TEST(LookaheadPoint, HandlesDegeneratePaths)
+{
+  geometry_msgs::msg::Point z;
+  EXPECT_NO_THROW(z = lookaheadPoint({}, 0, 0.0, 5.0));
+  auto single = makePath({{3, 4}});
+  auto p = lookaheadPoint(single, 0, 0.0, 5.0);
+  EXPECT_NEAR(p.x, 3.0, 1e-6);
+  EXPECT_NEAR(p.y, 4.0, 1e-6);
+}
+
+// A start segment past the end returns the goal rather than reading past the end.
+TEST(LookaheadPoint, OutOfRangeStartSegmentReturnsGoal)
+{
+  auto path = makePath({{0, 0}, {20, 0}});
+  auto p = lookaheadPoint(path, 5, 0.0, 3.0);
+  EXPECT_NEAR(p.x, 20.0, 1e-6);
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Makes `CrabbingPathFollower` robust to weaves/replans and ready for on-water tuning (part of #66).
**Everything defaults to today's behaviour** — each piece is opt-in via parameters, so nothing
changes until it's dialed in on the water.

## Changes

1. **Progress-preserving localization — fixes the cross-track "teleport."**
   `setPlan` reset `current_segment_ = 0` on every tick; since the avoidance decorator re-issues
   `setPlan` each cycle, the forward scan re-localized from the path start and **snapped the cursor
   backward** during a weave/loop, stepping the cross-track reference 5–9 m and kicking the PID
   (root-caused 2026-06-04 — `pid_state` vs a static-`/plan` reconstruction showed the segment
   index jumping 3→0). Now the cursor persists across same-goal re-issues and resets only when the
   goal moves past `new_plan_goal_tolerance_` (a genuinely new line).

2. **Tunable, clamped inner heading loop.** `angular.z` was the raw heading error (implicit gain 1.0,
   unbounded except the ±π wrap → it commanded ±2.6 rad/s the hull can't deliver). Now
   `angular.z = clamp(heading_rate_gain_ · heading_error, ±max_yaw_rate_)`. Defaults (1.0, ±π)
   reproduce the old behaviour; the `velocity_smoother` still enforces the physical rate/accel limits.

3. **Pure-pursuit look-ahead (Option 2).** With `lookahead_distance_` (or speed-scaled via
   `lookahead_time_`, `L = max(min, V·T)`) > 0, the base heading aims at a point `L` ahead on the
   path — anticipating bends — instead of the local segment azimuth. Default 0 = segment-azimuth =
   today. With look-ahead on, `L` becomes the cross-track-tightness dial and the cross-track PID is
   tuned to **I-only** (keeps the auto-current crab).

## Tests

New pure helper `lookaheadPoint()` (`path_geometry.hpp`) with **6 gtests** — walk-forward, the
around-a-bend anticipation (the worked example), end-of-path clamp-to-goal, start segment/offset,
and degenerate paths. All pass; package builds clean. (Addresses the test gap in nav#5.)

## Follow-ups (on the water, under #66)
Tune `Kp_h`, the cross-track PID rebalance (P↓/D↑ or I-only with look-ahead), and the look-ahead
`L`/`T`. Curvature feed-forward is a possible later step.

Closes #71.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8`
