### PR TITLE
CrabbingPathFollower: slew-limit cross-track error fed to the PID (#66)

### DIFF
--- a/.agent/work-plans/issue-66/plan.md
+++ b/.agent/work-plans/issue-66/plan.md
@@ -8,86 +8,98 @@ https://github.com/rolker/unh_marine_navigation/issues/66
 
 #72/#70 merged (progress-preserving localization in `setPlan`, bounded one-segment
 backward re-localization, conditional-integration anti-windup, pure-pursuit look-ahead)
-and **stopped the full 360° loops**. But the 2026-06-10 deployment (#250) run-bag RCA shows
-**residual hunting that is gated by planner REPLAN CHURN, not speed**: a *stable* reference
-tracks sub-metre even at ~3 kn; mid-line re-sends / `override goto` / `replace_task` trigger
-replan bursts that step the cross-track reference and saturate the (currently pure-proportional:
-Kp=1.0, Ki=Kd=0) controller. Two churn sources remain after #72:
+and **stopped the full 360° loops**. The 2026-06-10 deployment (#250) run-bag RCA showed
+**residual hunting gated by planner REPLAN CHURN, not speed**: a *stable* reference tracks
+sub-metre even at ~3 kn; mid-line re-sends / `override goto` / `replace_task` trigger replan
+bursts that step the cross-track reference and saturate the (pure-proportional: Kp=1.0,
+Ki=Kd=0) controller. Two churn sources remain: the `AvoidanceController` reshapes + re-issues
+`setPlan` every cycle, and the global planner re-emits `/bizzy/plan` on replans.
 
-1. **`AvoidanceController`** reshapes the path and re-issues `primary_->setPlan(reshaped)`
-   **every control cycle** (`computeVelocityCommands`), so the near-boat geometry varies each
-   tick even on clear water (`kDeviationEpsilon=0.05` is only used for viz today, not to
-   suppress churn).
-2. **The BT / global planner re-emits `/bizzy/plan`** on replans (`run_tasks.xml`), each new
-   short/curved path stepping the cross-track reference.
-
-Fix both fronts (per the #250 analysis: stabilize the reference at source **and** make the
-controller robust to residual steps).
+This is delivered in **first-cut + follow-ups** so there's a testable artifact fast: the
+first cut makes the controller robust to *any* reference step regardless of source; the
+follow-ups reduce the churn at the source.
 
 ## Approach
 
-**Front A — stabilize the reference at the source**
+### First cut (this PR) — controller robustness, B.3 only
 
-1. **AvoidanceController reshape suppression + hysteresis** — in `computeVelocityCommands`,
-   when peak `|offset|` < `kDeviationEpsilon` (no meaningful obstacle deviation), pass the
-   **nominal** plan to the primary controller and only re-issue `primary_->setPlan` when the
-   reshaped geometry actually changes beyond a threshold — instead of a freshly-resampled
-   near-nominal path every cycle. Removes clear-water churn without touching real avoidance.
-2. **BT replan hysteresis** (`run_tasks.xml`) — don't re-emit a new global plan while the
-   current path is still valid (`IsPathValid`) and the goal is unchanged; rate-limit replans so
-   a still-good survey line is not re-planned out from under the follower.
+**Cross-track-error slew limiter** in `CrabbingPathFollower::computeVelocityCommands`: a pure
+`slewToward()` helper (in `path_geometry.hpp`) caps how fast the cross-track error *fed to
+the PID* may change (`cross_track_error_slew_rate_`, m/s). A discontinuous reference step is
+ramped in instead of slamming the controller; genuine lateral drift (far slower than a sane
+rate) passes through untouched. Re-seeded on the same fresh-start gate as the PID reset so a
+post-gap resume snaps to the current error rather than crawling from a stale value. **Default
+0.0 = disabled (historical behaviour)**; the raw error is still logged as the true tracking
+error. Live-tunable via the existing parameter callback (mirrors the look-ahead/heading param
+plumbing + validation). Unit-tested via `slewToward` (`test_path_geometry.cpp`): ramps a
+step, snaps within a step, never overshoots, disables on rate ≤ 0.
 
-**Front B — make the controller robust to residual reference steps**
+### Follow-ups (separate PRs/issues — NOT in this PR)
 
-3. **CrabbingPathFollower slew limit** — in `computeVelocityCommands`, slew-limit the
-   cross-track **error** fed to the PID (parameterized, finite/domain-validated like the
-   existing `default_speed` handling) so a residual reference step can't slam the yaw output.
-   Decoupled from and upstream of the velocity_smoother hard clamp (the safety floor stays).
-   Optionally add a small derivative term using **derivative-on-measurement** (not on error,
-   to avoid derivative kick on reference steps), param-gated, default 0 pending field tuning.
-4. **Regression tests** (covers nav#5 scope) — a controller unit test feeding a stepping
-   reference and asserting bounded yaw / no limit cycle; a stable-reference-at-speed test
-   asserting sub-metre cross-track at ≥1.5 m/s.
+- **A.1 — AvoidanceController reshape suppression + hysteresis**: pass the nominal path
+  through when peak `|offset|` < `kDeviationEpsilon`, only re-issue `primary_->setPlan` when
+  the reshaped geometry materially changes. Removes clear-water churn at the source.
+- **A.2 — BT replan hysteresis** (`run_tasks.xml`): don't re-emit a global plan while the
+  current path is still valid (`IsPathValid`) and the goal is unchanged (gate
+  `ComputePathToPose` / tune `RateController`). Specific BT mechanism TBD during A.2.
+- **B.3b — derivative-on-measurement term**: add a small damping term computed on the boat's
+  cross-track *position* (not the error, to avoid derivative kick on reference steps),
+  param-gated, default 0 — land disabled, tune in the field.
+- **#66 fix-direction (2) — survey yaw-rate magnitude cap**, decoupled from the smoother's
+  1.0 rad/s capability ceiling. **Deferred:** the slew-limit removes the step *excitation* the
+  data fingered, and #250 showed a stable reference tracks clean at 3 kn — so a magnitude cap
+  is likely unnecessary; revisit only if hunting survives the first cut + A.1/A.2.
 
-## Files to Change
+## Files to Change (this PR)
 
 | File | Change |
 |------|--------|
-| `marine_nav_avoidance_controller/src/avoidance_controller.cpp` | Reshape suppression + hysteresis (A.1) |
-| `marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml` | Replan hysteresis / rate-limit (A.2) |
-| `marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp` (+ `.h`) | Cross-track-error slew limit + optional derivative-on-measurement (B.3) |
-| `marine_nav_crabbing_path_follower/test/*` (+ avoidance test) | Regression tests (B.4) |
-| controller config YAML (params) | New tunables: slew limit, hysteresis thresholds, derivative gain (default 0) |
+| `marine_nav_crabbing_path_follower/include/.../path_geometry.hpp` | `slewToward()` pure helper |
+| `marine_nav_crabbing_path_follower/include/.../crabbing_path_follower.h` | Slew-rate atomic param + slew state members |
+| `marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp` | Declare/validate/live-tune the param; slew the cross-track error before the PID; re-seed on reset |
+| `marine_nav_crabbing_path_follower/test/test_path_geometry.cpp` | `SlewToward` unit tests |
 
 ## Principles Self-Check
 
 | Principle | Consideration |
 |---|---|
-| Quality Standard (robustness + tests) | Fix the over-correction completely on both fronts; ship regression tests, not a partial damp |
-| Validation / no silent failure | New params finite + domain-checked, mirroring the controller's existing `default_speed` validation + param-callback pattern |
-| Safety (robot on open water) | Changes sit upstream of the velocity_smoother clamp and Collision Monitor reflex — the safety floor is unchanged; reshape suppression must not suppress *real* obstacle avoidance |
+| Quality Standard (robustness + tests) | First cut ships with unit tests; default-off so it can't regress unvalidated behaviour |
+| Validation / no silent failure | Param finite + `>= 0` checked, reusing the controller's `read_validated` / callback pattern |
+| Safety (robot on open water) | Slew sits upstream of the velocity_smoother clamp + Collision Monitor reflex — the safety floor is unchanged; default-off means no behaviour change until a deployment opts in |
 
 ## ADR Compliance
 
 | ADR | Triggered | How addressed |
 |---|---|---|
-| ADR-0008 (follow ROS 2 conventions) | Yes | nav2 controller/BT plugin patterns; params via `declare_parameter` with descriptors + validation callbacks |
+| ADR-0008 (follow ROS 2 conventions) | Yes | `declare_parameter_if_not_declared` + validating param callback; nav2 controller plugin idiom |
 
 ## Consequences
 
 | If we change... | Also update... | Included? |
 |---|---|---|
-| Avoidance reshape gating | Verify it still deviates when an obstacle IS present (test clear + obstacle) | Yes (B.4 tests) |
-| BT replan hysteresis | Verify `IsPathValid` still forces a replan on a genuinely blocked path (no avoidance stall) | Yes |
-| New controller params | controller config YAML + package docs | Yes |
+| Add `cross_track_error_slew_rate` param | **Deployed value lives in `unh_echoboats_project11` (`bizzyboat_project11/config/nav2_overlay.yaml`), not this repo** — set it there (e.g. ~3.0) to enable on the boat; sim can `ros2 param set` live | No — cross-repo follow-up, flagged |
 | Controller output dynamics | Re-verify interaction with velocity_smoother clamp + CA gate in sim | Yes (sim gate) |
+| Slew the error | Confirm genuine cross-track recovery still tracks (rate ≥ ~2× lateral drift) — pick the deployed rate in sim | Yes |
 
-## Open Questions
+## Open Questions (resolved)
 
-- Slew-limit the cross-track **error** (preserves PID semantics) vs the **output** yaw (simpler)? Recommend error-side.
-- Enable the derivative-on-measurement term this PR, or land it disabled (default 0) pending field tuning? Recommend disabled-by-default.
-- One PR (A+B+tests) or split A (reference stabilization) → B (controller robustness)? Recommend one cohesive PR; split if review prefers smaller diffs.
+- Slew the **error** (chosen — preserves PID semantics) vs the output yaw.
+- Derivative term: **land disabled / defer to B.3b** (chosen).
+- **Slew-limit first**, A.1/A.2/yaw-cap as follow-ups (chosen, over one big PR).
 
 ## Estimated Scope
 
-Single PR (A+B+tests), medium. Splittable into A then B if review prefers. Sim-verify a jumpy-reference scenario before/after; field-confirm on the next deployment.
+First cut: single small PR (one package, ~80 lines + tests). Follow-ups A.1, A.2, B.3b, and
+the yaw-rate cap are separate. Sim-verify a jumpy-reference scenario with the rate set; field
+test on the next deployment.
+
+## Implementation Notes
+
+- **Descoped to slew-limit-first** (vs the original one-PR-both-fronts): the #250 data says
+  reference-step excitation is the trigger and the slew-limit neutralizes it regardless of
+  which churn source caused the step, so it's the fastest testable artifact and the
+  highest-leverage single change. Source-side churn reduction (A.1/A.2) becomes additive
+  follow-up rather than a prerequisite.
+- **Default 0.0 (disabled)** matches the package convention (look-ahead/heading params all
+  default to historical no-op) and avoids changing a shared controller's behaviour for sim +
+  other platforms without per-platform validation; the deployed config opts in.

--- a/.agent/work-plans/issue-66/plan.md
+++ b/.agent/work-plans/issue-66/plan.md
@@ -103,3 +103,12 @@ test on the next deployment.
 - **Default 0.0 (disabled)** matches the package convention (look-ahead/heading params all
   default to historical no-op) and avoids changing a shared controller's behaviour for sim +
   other platforms without per-platform validation; the deployed config opts in.
+- **Re-acquisition is throttled too, by design** (review-code adversarial finding). The
+  limiter caps the error *magnitude* rate, so a genuinely large offset — mission start far
+  from the line, a big avoidance excursion, or re-acquisition after a gap shorter than
+  `pid_reset_threshold_` — is also ramped in at `rate` m/s, not just replan steps. Choose the
+  deployed rate with re-acquisition in mind (not only anti-hunt); a gap longer than the reset
+  threshold re-seeds and snaps. The slew state lives in the testable `slewLimitError` helper.
+- **`dt <= 0` holds, not passes through** (review-code adversarial finding): a zero /
+  duplicate-stamp control cycle must not let `slewToward`'s "non-positive step = passthrough"
+  leak the raw jump and defeat the limiter; `slewLimitError` holds the previous value there.

--- a/.agent/work-plans/issue-66/plan.md
+++ b/.agent/work-plans/issue-66/plan.md
@@ -1,0 +1,93 @@
+# Plan: Cross-track controller over-corrects into 360° loops on planner paths (yaw-ceiling × path-jump synergy)
+
+## Issue
+
+https://github.com/rolker/unh_marine_navigation/issues/66
+
+## Context
+
+#72/#70 merged (progress-preserving localization in `setPlan`, bounded one-segment
+backward re-localization, conditional-integration anti-windup, pure-pursuit look-ahead)
+and **stopped the full 360° loops**. But the 2026-06-10 deployment (#250) run-bag RCA shows
+**residual hunting that is gated by planner REPLAN CHURN, not speed**: a *stable* reference
+tracks sub-metre even at ~3 kn; mid-line re-sends / `override goto` / `replace_task` trigger
+replan bursts that step the cross-track reference and saturate the (currently pure-proportional:
+Kp=1.0, Ki=Kd=0) controller. Two churn sources remain after #72:
+
+1. **`AvoidanceController`** reshapes the path and re-issues `primary_->setPlan(reshaped)`
+   **every control cycle** (`computeVelocityCommands`), so the near-boat geometry varies each
+   tick even on clear water (`kDeviationEpsilon=0.05` is only used for viz today, not to
+   suppress churn).
+2. **The BT / global planner re-emits `/bizzy/plan`** on replans (`run_tasks.xml`), each new
+   short/curved path stepping the cross-track reference.
+
+Fix both fronts (per the #250 analysis: stabilize the reference at source **and** make the
+controller robust to residual steps).
+
+## Approach
+
+**Front A — stabilize the reference at the source**
+
+1. **AvoidanceController reshape suppression + hysteresis** — in `computeVelocityCommands`,
+   when peak `|offset|` < `kDeviationEpsilon` (no meaningful obstacle deviation), pass the
+   **nominal** plan to the primary controller and only re-issue `primary_->setPlan` when the
+   reshaped geometry actually changes beyond a threshold — instead of a freshly-resampled
+   near-nominal path every cycle. Removes clear-water churn without touching real avoidance.
+2. **BT replan hysteresis** (`run_tasks.xml`) — don't re-emit a new global plan while the
+   current path is still valid (`IsPathValid`) and the goal is unchanged; rate-limit replans so
+   a still-good survey line is not re-planned out from under the follower.
+
+**Front B — make the controller robust to residual reference steps**
+
+3. **CrabbingPathFollower slew limit** — in `computeVelocityCommands`, slew-limit the
+   cross-track **error** fed to the PID (parameterized, finite/domain-validated like the
+   existing `default_speed` handling) so a residual reference step can't slam the yaw output.
+   Decoupled from and upstream of the velocity_smoother hard clamp (the safety floor stays).
+   Optionally add a small derivative term using **derivative-on-measurement** (not on error,
+   to avoid derivative kick on reference steps), param-gated, default 0 pending field tuning.
+4. **Regression tests** (covers nav#5 scope) — a controller unit test feeding a stepping
+   reference and asserting bounded yaw / no limit cycle; a stable-reference-at-speed test
+   asserting sub-metre cross-track at ≥1.5 m/s.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `marine_nav_avoidance_controller/src/avoidance_controller.cpp` | Reshape suppression + hysteresis (A.1) |
+| `marine_nav_bt_task_navigator/behavior_trees/run_tasks.xml` | Replan hysteresis / rate-limit (A.2) |
+| `marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp` (+ `.h`) | Cross-track-error slew limit + optional derivative-on-measurement (B.3) |
+| `marine_nav_crabbing_path_follower/test/*` (+ avoidance test) | Regression tests (B.4) |
+| controller config YAML (params) | New tunables: slew limit, hysteresis thresholds, derivative gain (default 0) |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Quality Standard (robustness + tests) | Fix the over-correction completely on both fronts; ship regression tests, not a partial damp |
+| Validation / no silent failure | New params finite + domain-checked, mirroring the controller's existing `default_speed` validation + param-callback pattern |
+| Safety (robot on open water) | Changes sit upstream of the velocity_smoother clamp and Collision Monitor reflex — the safety floor is unchanged; reshape suppression must not suppress *real* obstacle avoidance |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| ADR-0008 (follow ROS 2 conventions) | Yes | nav2 controller/BT plugin patterns; params via `declare_parameter` with descriptors + validation callbacks |
+
+## Consequences
+
+| If we change... | Also update... | Included? |
+|---|---|---|
+| Avoidance reshape gating | Verify it still deviates when an obstacle IS present (test clear + obstacle) | Yes (B.4 tests) |
+| BT replan hysteresis | Verify `IsPathValid` still forces a replan on a genuinely blocked path (no avoidance stall) | Yes |
+| New controller params | controller config YAML + package docs | Yes |
+| Controller output dynamics | Re-verify interaction with velocity_smoother clamp + CA gate in sim | Yes (sim gate) |
+
+## Open Questions
+
+- Slew-limit the cross-track **error** (preserves PID semantics) vs the **output** yaw (simpler)? Recommend error-side.
+- Enable the derivative-on-measurement term this PR, or land it disabled (default 0) pending field tuning? Recommend disabled-by-default.
+- One PR (A+B+tests) or split A (reference stabilization) → B (controller robustness)? Recommend one cohesive PR; split if review prefers smaller diffs.
+
+## Estimated Scope
+
+Single PR (A+B+tests), medium. Splittable into A then B if review prefers. Sim-verify a jumpy-reference scenario before/after; field-confirm on the next deployment.

--- a/.agent/work-plans/issue-66/progress.md
+++ b/.agent/work-plans/issue-66/progress.md
@@ -1,0 +1,19 @@
+---
+issue: 66
+---
+
+# Issue #66 — Cross-track controller over-corrects into 360° loops on planner paths (yaw-ceiling × path-jump synergy)
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-06-10 23:39 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Plan**: `.agent/work-plans/issue-66/plan.md` at `f664363`
+**PR**: https://github.com/rolker/unh_marine_navigation/pull/75 (`[PLAN]` prefix)
+**Phases**: single (A reference-stabilization + B controller-robustness + tests; splittable)
+
+### Open questions
+- [ ] Slew-limit the cross-track *error* (preserves PID semantics) vs the *output* yaw — recommend error-side
+- [ ] Derivative-on-measurement term: enable this PR vs land disabled (default 0) pending field tuning — recommend disabled
+- [ ] One cohesive PR (A+B+tests) vs split A→B if review prefers smaller diffs

--- a/.agent/work-plans/issue-66/progress.md
+++ b/.agent/work-plans/issue-66/progress.md
@@ -32,3 +32,19 @@ issue: 66
 - [ ] (must-fix) Cross-repo consequence: deployed controller params live in unh_echoboats_project11 (bizzyboat.yaml / nav2_overlay.yaml), not the nav pkg — add to Consequences — plan.md Consequences
 - [ ] (suggestion) Scope: 3 components / 2 repos — commit to A→B stacked split — plan.md Open Questions/Estimated Scope
 - [ ] (suggestion) Name the nav2 BT replan-hysteresis mechanism (IsPathValid + goal-unchanged gate, or RateController) — plan.md Front A.2
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-11 07:13 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: approved
+**Branch**: feature/issue-66 at `15bc9ed`
+**Mode**: pre-push
+**Depth**: Standard (control-loop change)
+**Must-fix**: 1 (fixed) | **Suggestions**: 2 (addressed)
+
+### Findings
+- [x] (must-fix) dt<=0 cycle leaked the raw jump (defeated the limiter); now holds — fixed in 15bc9ed — `crabbing_path_follower.cpp` / `slewLimitError`
+- [x] (suggestion) integration test gap; extracted testable `slewLimitError` + 5 wiring tests — `test_path_geometry.cpp`
+- [x] (suggestion) re-acquisition is also throttled (tuning hazard) — documented in plan + param guidance
+- Static analysis clean (18/18 gtest); Copilot + Claude adversarial both clear after fixes

--- a/.agent/work-plans/issue-66/progress.md
+++ b/.agent/work-plans/issue-66/progress.md
@@ -48,3 +48,20 @@ issue: 66
 - [x] (suggestion) integration test gap; extracted testable `slewLimitError` + 5 wiring tests — `test_path_geometry.cpp`
 - [x] (suggestion) re-acquisition is also throttled (tuning hazard) — documented in plan + param guidance
 - Static analysis clean (18/18 gtest); Copilot + Claude adversarial both clear after fixes
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-06-11 09:13 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**PR**: #75 at `21045b5`
+**Sources**: 2 (Copilot @ `21045b5`, Local Review (Pre-Push) @ `21045b5`)
+**Cross-source confirmations**: 0
+**CI**: not fetched (network timeout) — re-check before merge
+
+### Findings
+- [ ] (valid, Copilot) `slewLimitError` doc claims rate<=0 disables "without disturbing the held value" but the disabled branch re-seeds `slewed = raw` — fix the DOC (the re-seed is intentional: clean off→on enable from the current error) — `path_geometry.hpp`
+- [ ] (valid, Copilot) PR #75 description still describes the full two-front plan; PR implements only the first-cut slew-limiter — update the PR body to match (plan file already descoped) — PR body
+
+### False positives
+- (none)

--- a/.agent/work-plans/issue-66/progress.md
+++ b/.agent/work-plans/issue-66/progress.md
@@ -17,3 +17,18 @@ issue: 66
 - [ ] Slew-limit the cross-track *error* (preserves PID semantics) vs the *output* yaw — recommend error-side
 - [ ] Derivative-on-measurement term: enable this PR vs land disabled (default 0) pending field tuning — recommend disabled
 - [ ] One cohesive PR (A+B+tests) vs split A→B if review prefers smaller diffs
+
+## Plan Review
+**Status**: complete
+**When**: 2026-06-11 05:44 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context)) (in-context — author self-review)
+
+**Plan**: `.agent/work-plans/issue-66/plan.md` at `f664363`
+**PR**: https://github.com/rolker/unh_marine_navigation/pull/75
+**Verdict**: approve-with-suggestions
+
+### Findings
+- [ ] (must-fix) #66 fix-direction (2) — survey yaw-rate **magnitude** cap, decoupled from the 1.0 rad/s capability ceiling — absent (slew-limit is rate-of-change, not magnitude); add or explicitly defer — plan.md Front B
+- [ ] (must-fix) Cross-repo consequence: deployed controller params live in unh_echoboats_project11 (bizzyboat.yaml / nav2_overlay.yaml), not the nav pkg — add to Consequences — plan.md Consequences
+- [ ] (suggestion) Scope: 3 components / 2 repos — commit to A→B stacked split — plan.md Open Questions/Estimated Scope
+- [ ] (suggestion) Name the nav2 BT replan-hysteresis mechanism (IsPathValid + goal-unchanged gate, or RateController) — plan.md Front A.2

--- a/marine_nav_crabbing_path_follower/include/marine_nav_crabbing_path_follower/crabbing_path_follower.h
+++ b/marine_nav_crabbing_path_follower/include/marine_nav_crabbing_path_follower/crabbing_path_follower.h
@@ -107,6 +107,19 @@ protected:
   geometry_msgs::msg::Point last_goal_;
   std::atomic<double> new_plan_goal_tolerance_{1.0};
 
+  // Cross-track-error slew limiter (#66). Caps how fast the cross-track error
+  // fed to the PID may change (m/s) so a discontinuous reference step — a
+  // planner replan or the avoidance decorator reshaping the line under the boat
+  // — is ramped in rather than slamming the controller into an over-correction
+  // (the hunting / 360-loop family). Genuine lateral drift changes at most at
+  // boat speed, well under a sane rate, so real tracking is untouched. 0.0
+  // disables (the default; historical behaviour until tuned). The rate is
+  // live-tunable, hence atomic; slewed_cross_track_error_ / slew_initialized_
+  // are control-loop state touched only in computeVelocityCommands, so plain.
+  std::atomic<double> cross_track_error_slew_rate_{0.0};
+  double slewed_cross_track_error_{0.0};
+  bool slew_initialized_{false};
+
   bool visualize_ = false;
   rclcpp_lifecycle::LifecyclePublisher<visualization_msgs::msg::MarkerArray>::SharedPtr visualization_publisher_;
 

--- a/marine_nav_crabbing_path_follower/include/marine_nav_crabbing_path_follower/path_geometry.hpp
+++ b/marine_nav_crabbing_path_follower/include/marine_nav_crabbing_path_follower/path_geometry.hpp
@@ -27,6 +27,32 @@ inline double slewToward(double current, double target, double max_step)
   return current + std::clamp(delta, -max_step, max_step);
 }
 
+/// Stateful slew-limit of the value (a cross-track error) fed to the PID (#66).
+/// Holds `slewed`/`initialized` across control cycles. Branches, in order:
+///   - first call after construction or a PID reset (`initialized` false): seed
+///     to `raw` and pass it through (snap, don't ramp), so a post-gap resume
+///     starts from the current error rather than a stale one;
+///   - `rate <= 0`: limiting disabled — pass `raw` unchanged (the historical
+///     default), without disturbing the held value;
+///   - `dt_s <= 0` (a zero / duplicate-stamp cycle): HOLD the previous slewed
+///     value — a replan landing on a zero-dt cycle must not leak the raw jump
+///     through and defeat the limiter;
+///   - otherwise: ramp `slewed` toward `raw` by at most `rate * dt_s`.
+/// Returns the (possibly slewed) value to feed the controller.
+inline double slewLimitError(
+  double & slewed, bool & initialized, double raw, double rate, double dt_s)
+{
+  if (initialized && rate > 0.0) {
+    if (dt_s > 0.0) {
+      slewed = slewToward(slewed, raw, rate * dt_s);
+    }
+    return slewed;
+  }
+  slewed = raw;
+  initialized = true;
+  return raw;
+}
+
 /// Walk `lookahead` metres forward along a piecewise-linear path and return the
 /// point reached — the pure-pursuit "look-ahead point".
 ///

--- a/marine_nav_crabbing_path_follower/include/marine_nav_crabbing_path_follower/path_geometry.hpp
+++ b/marine_nav_crabbing_path_follower/include/marine_nav_crabbing_path_follower/path_geometry.hpp
@@ -32,8 +32,9 @@ inline double slewToward(double current, double target, double max_step)
 ///   - first call after construction or a PID reset (`initialized` false): seed
 ///     to `raw` and pass it through (snap, don't ramp), so a post-gap resume
 ///     starts from the current error rather than a stale one;
-///   - `rate <= 0`: limiting disabled — pass `raw` unchanged (the historical
-///     default), without disturbing the held value;
+///   - `rate <= 0`: limiting disabled — pass `raw` through (the historical
+///     default); the held value is kept in step with `raw` (re-seeded), so a
+///     later enable (rate 0 -> >0) starts cleanly from the current error;
 ///   - `dt_s <= 0` (a zero / duplicate-stamp cycle): HOLD the previous slewed
 ///     value — a replan landing on a zero-dt cycle must not leak the raw jump
 ///     through and defeat the limiter;

--- a/marine_nav_crabbing_path_follower/include/marine_nav_crabbing_path_follower/path_geometry.hpp
+++ b/marine_nav_crabbing_path_follower/include/marine_nav_crabbing_path_follower/path_geometry.hpp
@@ -11,6 +11,22 @@
 namespace marine_nav_crabbing_path_follower
 {
 
+/// Slew `current` toward `target`, advancing by at most `max_step`. A
+/// non-positive `max_step` disables limiting (returns `target` unchanged), so a
+/// zero rate is a clean "off". Used to rate-limit the cross-track error fed to
+/// the cross-track PID (#66): a discontinuous reference step — a planner replan
+/// or the avoidance decorator reshaping the line under the boat — is ramped in
+/// instead of kicking the controller into an over-correction, while genuine
+/// lateral drift (far slower than a sane rate) passes through untouched.
+inline double slewToward(double current, double target, double max_step)
+{
+  if (!(max_step > 0.0)) {
+    return target;
+  }
+  const double delta = target - current;
+  return current + std::clamp(delta, -max_step, max_step);
+}
+
 /// Walk `lookahead` metres forward along a piecewise-linear path and return the
 /// point reached — the pure-pursuit "look-ahead point".
 ///

--- a/marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp
+++ b/marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp
@@ -230,6 +230,13 @@ void CrabbingPathFollower::configure(
           {
             return result;
           }
+        } else if (name == base + ".cross_track_error_slew_rate") {
+          double v;
+          if (!as_number(p, v) ||
+            !update(cross_track_error_slew_rate_, v, 0.0, false, "cross_track_error_slew_rate"))
+          {
+            return result;
+          }
         }
       }
       return result;
@@ -285,6 +292,7 @@ void CrabbingPathFollower::configure(
   read_validated(".lookahead_time", lookahead_time_, 0.0, false);
   read_validated(".lookahead_min_distance", lookahead_min_distance_, 0.0, false);
   read_validated(".new_plan_goal_tolerance", new_plan_goal_tolerance_, 0.0, false);
+  read_validated(".cross_track_error_slew_rate", cross_track_error_slew_rate_, 0.0, false);
 
   global_pub_ = node->create_publisher<nav_msgs::msg::Path>("received_global_plan", 1);
 }
@@ -494,13 +502,37 @@ geometry_msgs::msg::TwistStamped CrabbingPathFollower::computeVelocityCommands(
   if(last_update_time_.nanoseconds() == 0 ||  (timestamp - last_update_time_) > pid_reset_threshold_ || (timestamp - last_update_time_).seconds() < 0.0)
   {
     pid_->reset();
+    // Re-seed the slew limiter on a fresh start (first call / post-gap resume /
+    // clock jump) so the next cycle snaps to the current cross-track error
+    // instead of ramping out from a stale value, matching the PID reset.
+    slew_initialized_ = false;
     last_update_time_ = timestamp;
   }
   auto dt = timestamp - last_update_time_;
   last_update_time_ = timestamp;
 
   auto cross_track_error = vehicle_distance*sin_error_azimuth;
-  auto crab_angle = AngleDegrees(pid_->compute_command(cross_track_error, dt));
+
+  // Slew-limit the cross-track error fed to the PID (#66). A discontinuous
+  // reference step — a planner replan or the avoidance decorator reshaping the
+  // line under the boat — would otherwise jump this error several metres in one
+  // cycle and slam the proportional controller into an over-correction (the
+  // hunting / 360-loop family). Ramp it in at cross_track_error_slew_rate_ (m/s)
+  // instead: real lateral drift changes far slower than a sane rate, so genuine
+  // tracking is untouched, while an instantaneous jump is absorbed. On a fresh
+  // start (slew_initialized_ false) snap to the current value rather than ramp.
+  // Rate 0 disables (slewToward returns the target). The raw cross_track_error
+  // is still logged below as the true tracking error.
+  double pid_cross_track_error = cross_track_error;
+  if (slew_initialized_ && cross_track_error_slew_rate_.load() > 0.0) {
+    const double max_step = cross_track_error_slew_rate_.load() * std::max(dt.seconds(), 0.0);
+    slewed_cross_track_error_ = slewToward(slewed_cross_track_error_, cross_track_error, max_step);
+    pid_cross_track_error = slewed_cross_track_error_;
+  } else {
+    slewed_cross_track_error_ = cross_track_error;
+    slew_initialized_ = true;
+  }
+  auto crab_angle = AngleDegrees(pid_->compute_command(pid_cross_track_error, dt));
   AngleRadians heading(tf2::getYaw(pose_in_plan.pose.orientation));
 
   RCLCPP_DEBUG_STREAM(logger_, "CrabbingPathFollower: progress: " << progress << " cross_track_error: " << cross_track_error << " crab_angle: " << crab_angle.value() << " heading: " << heading.value() << " segment_azimuth: " << segment_azimuth.value());

--- a/marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp
+++ b/marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp
@@ -516,22 +516,15 @@ geometry_msgs::msg::TwistStamped CrabbingPathFollower::computeVelocityCommands(
   // Slew-limit the cross-track error fed to the PID (#66). A discontinuous
   // reference step — a planner replan or the avoidance decorator reshaping the
   // line under the boat — would otherwise jump this error several metres in one
-  // cycle and slam the proportional controller into an over-correction (the
-  // hunting / 360-loop family). Ramp it in at cross_track_error_slew_rate_ (m/s)
-  // instead: real lateral drift changes far slower than a sane rate, so genuine
-  // tracking is untouched, while an instantaneous jump is absorbed. On a fresh
-  // start (slew_initialized_ false) snap to the current value rather than ramp.
-  // Rate 0 disables (slewToward returns the target). The raw cross_track_error
-  // is still logged below as the true tracking error.
-  double pid_cross_track_error = cross_track_error;
-  if (slew_initialized_ && cross_track_error_slew_rate_.load() > 0.0) {
-    const double max_step = cross_track_error_slew_rate_.load() * std::max(dt.seconds(), 0.0);
-    slewed_cross_track_error_ = slewToward(slewed_cross_track_error_, cross_track_error, max_step);
-    pid_cross_track_error = slewed_cross_track_error_;
-  } else {
-    slewed_cross_track_error_ = cross_track_error;
-    slew_initialized_ = true;
-  }
+  // cycle and slam the controller into an over-correction (the hunting /
+  // 360-loop family; #250 RCA). slewLimitError ramps it in at
+  // cross_track_error_slew_rate_ (m/s) instead: real lateral drift changes far
+  // slower than a sane rate, so genuine tracking is untouched, while an
+  // instantaneous jump is absorbed. Rate 0 disables (passes the raw error). The
+  // raw cross_track_error is still logged below as the true tracking error.
+  const double pid_cross_track_error = slewLimitError(
+    slewed_cross_track_error_, slew_initialized_, cross_track_error,
+    cross_track_error_slew_rate_.load(), dt.seconds());
   auto crab_angle = AngleDegrees(pid_->compute_command(pid_cross_track_error, dt));
   AngleRadians heading(tf2::getYaw(pose_in_plan.pose.orientation));
 

--- a/marine_nav_crabbing_path_follower/test/test_path_geometry.cpp
+++ b/marine_nav_crabbing_path_follower/test/test_path_geometry.cpp
@@ -125,6 +125,45 @@ TEST(AlongTrackProjection, ZeroLengthSegmentReturnsZero)
   EXPECT_EQ(alongTrackProjection(a, a, pt(9, 9)), 0.0);
 }
 
+using marine_nav_crabbing_path_follower::slewToward;
+
+// Far from target: advance by exactly max_step toward it (both directions).
+TEST(SlewToward, AdvancesByMaxStepWhenFar)
+{
+  EXPECT_DOUBLE_EQ(slewToward(0.0, 5.0, 1.0), 1.0);     // up
+  EXPECT_DOUBLE_EQ(slewToward(0.0, -5.0, 1.0), -1.0);   // down
+  EXPECT_DOUBLE_EQ(slewToward(2.0, 5.0, 0.5), 2.5);
+}
+
+// Within one step: snap to the target, never overshoot.
+TEST(SlewToward, SnapsToTargetWhenWithinStep)
+{
+  EXPECT_DOUBLE_EQ(slewToward(4.8, 5.0, 1.0), 5.0);
+  EXPECT_DOUBLE_EQ(slewToward(-4.8, -5.0, 1.0), -5.0);
+  EXPECT_DOUBLE_EQ(slewToward(5.0, 5.0, 1.0), 5.0);     // already there
+}
+
+// The point of #66: an instantaneous reference step is ramped in over many
+// cycles, not jumped in one — then converges exactly.
+TEST(SlewToward, RampsAReferenceStepInsteadOfJumping)
+{
+  const double target = 5.0;   // a 5 m instantaneous reference step
+  const double step = 0.3;     // slew_rate * dt
+  double v = slewToward(0.0, target, step);
+  EXPECT_DOUBLE_EQ(v, 0.3);    // first cycle moves one step, not 5 m
+  for (int i = 0; i < 100 && v < target; ++i) {
+    v = slewToward(v, target, step);
+  }
+  EXPECT_DOUBLE_EQ(v, target);  // eventually converges
+}
+
+// Non-positive max_step disables limiting: returns the target unchanged.
+TEST(SlewToward, NonPositiveStepDisablesLimiting)
+{
+  EXPECT_DOUBLE_EQ(slewToward(0.0, 5.0, 0.0), 5.0);
+  EXPECT_DOUBLE_EQ(slewToward(0.0, 5.0, -1.0), 5.0);
+}
+
 int main(int argc, char ** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/marine_nav_crabbing_path_follower/test/test_path_geometry.cpp
+++ b/marine_nav_crabbing_path_follower/test/test_path_geometry.cpp
@@ -164,6 +164,62 @@ TEST(SlewToward, NonPositiveStepDisablesLimiting)
   EXPECT_DOUBLE_EQ(slewToward(0.0, 5.0, -1.0), 5.0);
 }
 
+using marine_nav_crabbing_path_follower::slewLimitError;
+
+// First call (initialized==false) seeds to raw and passes through (snap, not
+// a ramp from a stale held value) and flips initialized true.
+TEST(SlewLimitError, FirstCallSeedsAndPassesThrough)
+{
+  double slewed = -999.0;  // stale
+  bool init = false;
+  EXPECT_DOUBLE_EQ(slewLimitError(slewed, init, 4.0, 3.0, 0.1), 4.0);
+  EXPECT_TRUE(init);
+  EXPECT_DOUBLE_EQ(slewed, 4.0);
+}
+
+// rate <= 0 disables limiting: raw passes through (the historical default).
+TEST(SlewLimitError, ZeroRateDisablesLimiting)
+{
+  double slewed = 0.0;
+  bool init = true;
+  EXPECT_DOUBLE_EQ(slewLimitError(slewed, init, 5.0, 0.0, 0.1), 5.0);
+  EXPECT_DOUBLE_EQ(slewLimitError(slewed, init, 5.0, -1.0, 0.1), 5.0);
+}
+
+// Normal cycle: ramp toward raw by rate*dt, not a jump.
+TEST(SlewLimitError, RampsTowardRawByRateTimesDt)
+{
+  double slewed = 0.0;
+  bool init = true;
+  EXPECT_DOUBLE_EQ(slewLimitError(slewed, init, 5.0, 3.0, 0.1), 0.3);
+  EXPECT_DOUBLE_EQ(slewed, 0.3);
+}
+
+// Zero / duplicate-stamp cycle (dt <= 0) HOLDS the previous slewed value — a
+// replan landing on a zero-dt cycle must not leak the raw jump through.
+TEST(SlewLimitError, ZeroOrNegativeDtHoldsAndDoesNotLeakJump)
+{
+  double slewed = 1.0;
+  bool init = true;
+  EXPECT_DOUBLE_EQ(slewLimitError(slewed, init, 9.0, 3.0, 0.0), 1.0);    // held, not 9.0
+  EXPECT_DOUBLE_EQ(slewed, 1.0);
+  EXPECT_DOUBLE_EQ(slewLimitError(slewed, init, 9.0, 3.0, -0.05), 1.0);  // negative dt too
+  EXPECT_DOUBLE_EQ(slewed, 1.0);
+}
+
+// A reset (caller clears initialized) re-seeds to the current raw — snaps to
+// the live error instead of ramping out from a stale held value.
+TEST(SlewLimitError, ResetReseedsToCurrentRaw)
+{
+  double slewed = 2.0;
+  bool init = true;
+  slewLimitError(slewed, init, 5.0, 3.0, 0.1);  // ramps a little
+  init = false;                                 // simulate the PID-reset re-seed
+  EXPECT_DOUBLE_EQ(slewLimitError(slewed, init, 8.0, 3.0, 0.1), 8.0);
+  EXPECT_TRUE(init);
+  EXPECT_DOUBLE_EQ(slewed, 8.0);
+}
+
 int main(int argc, char ** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Closes #66

# Plan: Cross-track controller over-corrects into 360° loops on planner paths (yaw-ceiling × path-jump synergy)

## Issue

https://github.com/rolker/unh_marine_navigation/issues/66

## Context

#72/#70 merged (progress-preserving localization in `setPlan`, bounded one-segment
backward re-localization, conditional-integration anti-windup, pure-pursuit look-ahead)
and **stopped the full 360° loops**. The 2026-06-10 deployment (#250) run-bag RCA showed
**residual hunting gated by planner REPLAN CHURN, not speed**: a *stable* reference tracks
sub-metre even at ~3 kn; mid-line re-sends / `override goto` / `replace_task` trigger replan
bursts that step the cross-track reference and saturate the (pure-proportional: Kp=1.0,
Ki=Kd=0) controller. Two churn sources remain: the `AvoidanceController` reshapes + re-issues
`setPlan` every cycle, and the global planner re-emits `/bizzy/plan` on replans.

This is delivered in **first-cut + follow-ups** so there's a testable artifact fast: the
first cut makes the controller robust to *any* reference step regardless of source; the
follow-ups reduce the churn at the source.

## Approach

### First cut (this PR) — controller robustness, B.3 only

**Cross-track-error slew limiter** in `CrabbingPathFollower::computeVelocityCommands`: a pure
`slewToward()` helper (in `path_geometry.hpp`) caps how fast the cross-track error *fed to
the PID* may change (`cross_track_error_slew_rate_`, m/s). A discontinuous reference step is
ramped in instead of slamming the controller; genuine lateral drift (far slower than a sane
rate) passes through untouched. Re-seeded on the same fresh-start gate as the PID reset so a
post-gap resume snaps to the current error rather than crawling from a stale value. **Default
0.0 = disabled (historical behaviour)**; the raw error is still logged as the true tracking
error. Live-tunable via the existing parameter callback (mirrors the look-ahead/heading param
plumbing + validation). Unit-tested via `slewToward` (`test_path_geometry.cpp`): ramps a
step, snaps within a step, never overshoots, disables on rate ≤ 0.

### Follow-ups (separate PRs/issues — NOT in this PR)

- **A.1 — AvoidanceController reshape suppression + hysteresis**: pass the nominal path
  through when peak `|offset|` < `kDeviationEpsilon`, only re-issue `primary_->setPlan` when
  the reshaped geometry materially changes. Removes clear-water churn at the source.
- **A.2 — BT replan hysteresis** (`run_tasks.xml`): don't re-emit a global plan while the
  current path is still valid (`IsPathValid`) and the goal is unchanged (gate
  `ComputePathToPose` / tune `RateController`). Specific BT mechanism TBD during A.2.
- **B.3b — derivative-on-measurement term**: add a small damping term computed on the boat's
  cross-track *position* (not the error, to avoid derivative kick on reference steps),
  param-gated, default 0 — land disabled, tune in the field.
- **#66 fix-direction (2) — survey yaw-rate magnitude cap**, decoupled from the smoother's
  1.0 rad/s capability ceiling. **Deferred:** the slew-limit removes the step *excitation* the
  data fingered, and #250 showed a stable reference tracks clean at 3 kn — so a magnitude cap
  is likely unnecessary; revisit only if hunting survives the first cut + A.1/A.2.

## Files to Change (this PR)

| File | Change |
|------|--------|
| `marine_nav_crabbing_path_follower/include/.../path_geometry.hpp` | `slewToward()` pure helper |
| `marine_nav_crabbing_path_follower/include/.../crabbing_path_follower.h` | Slew-rate atomic param + slew state members |
| `marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp` | Declare/validate/live-tune the param; slew the cross-track error before the PID; re-seed on reset |
| `marine_nav_crabbing_path_follower/test/test_path_geometry.cpp` | `SlewToward` unit tests |

## Principles Self-Check

| Principle | Consideration |
|---|---|
| Quality Standard (robustness + tests) | First cut ships with unit tests; default-off so it can't regress unvalidated behaviour |
| Validation / no silent failure | Param finite + `>= 0` checked, reusing the controller's `read_validated` / callback pattern |
| Safety (robot on open water) | Slew sits upstream of the velocity_smoother clamp + Collision Monitor reflex — the safety floor is unchanged; default-off means no behaviour change until a deployment opts in |

## ADR Compliance

| ADR | Triggered | How addressed |
|---|---|---|
| ADR-0008 (follow ROS 2 conventions) | Yes | `declare_parameter_if_not_declared` + validating param callback; nav2 controller plugin idiom |

## Consequences

| If we change... | Also update... | Included? |
|---|---|---|
| Add `cross_track_error_slew_rate` param | **Deployed value lives in `unh_echoboats_project11` (`bizzyboat_project11/config/nav2_overlay.yaml`), not this repo** — set it there (e.g. ~3.0) to enable on the boat; sim can `ros2 param set` live | No — cross-repo follow-up, flagged |
| Controller output dynamics | Re-verify interaction with velocity_smoother clamp + CA gate in sim | Yes (sim gate) |
| Slew the error | Confirm genuine cross-track recovery still tracks (rate ≥ ~2× lateral drift) — pick the deployed rate in sim | Yes |

## Open Questions (resolved)

- Slew the **error** (chosen — preserves PID semantics) vs the output yaw.
- Derivative term: **land disabled / defer to B.3b** (chosen).
- **Slew-limit first**, A.1/A.2/yaw-cap as follow-ups (chosen, over one big PR).

## Estimated Scope

First cut: single small PR (one package, ~80 lines + tests). Follow-ups A.1, A.2, B.3b, and
the yaw-rate cap are separate. Sim-verify a jumpy-reference scenario with the rate set; field
test on the next deployment.

## Implementation Notes

- **Descoped to slew-limit-first** (vs the original one-PR-both-fronts): the #250 data says
  reference-step excitation is the trigger and the slew-limit neutralizes it regardless of
  which churn source caused the step, so it's the fastest testable artifact and the
  highest-leverage single change. Source-side churn reduction (A.1/A.2) becomes additive
  follow-up rather than a prerequisite.
- **Default 0.0 (disabled)** matches the package convention (look-ahead/heading params all
  default to historical no-op) and avoids changing a shared controller's behaviour for sim +
  other platforms without per-platform validation; the deployed config opts in.
- **Re-acquisition is throttled too, by design** (review-code adversarial finding). The
  limiter caps the error *magnitude* rate, so a genuinely large offset — mission start far
  from the line, a big avoidance excursion, or re-acquisition after a gap shorter than
  `pid_reset_threshold_` — is also ramped in at `rate` m/s, not just replan steps. Choose the
  deployed rate with re-acquisition in mind (not only anti-hunt); a gap longer than the reset
  threshold re-seeds and snaps. The slew state lives in the testable `slewLimitError` helper.
- **`dt <= 0` holds, not passes through** (review-code adversarial finding): a zero /
  duplicate-stamp control cycle must not let `slewToward`'s "non-positive step = passthrough"
  leak the raw jump and defeat the limiter; `slewLimitError` holds the previous value there.


---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
