### PR TITLE
marine_nav_crabbing_path_follower: speed-normalize the cross-track gain (gain schedule)

### DIFF
--- a/.agent/work-plans/issue-76/plan.md
+++ b/.agent/work-plans/issue-76/plan.md
@@ -30,7 +30,14 @@ configure + a `SetParameters` branch (with the `as_number` integer-coercion guar
 
 ## Approach
 
-1. **Extract the scaling as a pure function** — add
+> **Implementation status (feature/issue-76):** all 8 steps below are DONE.
+> Param keys are sub-namespaced under `.pid.` per the Plan Review finding
+> (`progress.md` Plan Review): `plugin_name_ + ".pid.gain_ref_speed"` /
+> `".pid.gain_v_min"` in the declare (`read_validated` suffix), read, and
+> SetParameters branches — mirroring `".pid.reset_threshold_seconds"`, not the
+> bare-suffix `lookahead_*` keys. No other deviations.
+
+1. **Extract the scaling as a pure function** — [DONE] add
    `gainScheduleScale(crab_angle_deg, gain_ref_speed, v_min, target_speed)` to
    `path_geometry.hpp` (the established home for pure, unit-testable control math).
    Contract: `gain_ref_speed <= 0` returns `crab_angle_deg` unchanged (disabled,

--- a/.agent/work-plans/issue-76/plan.md
+++ b/.agent/work-plans/issue-76/plan.md
@@ -1,0 +1,143 @@
+# Plan: marine_nav_crabbing_path_follower — speed-normalize the cross-track gain (gain schedule)
+
+## Issue
+
+https://github.com/rolker/unh_marine_navigation/issues/76
+
+## Context
+
+`CrabbingPathFollower` (`marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp`)
+is a cascade controller: cross-track error → slew-limit (#66) → PID → `crab_angle`
+(heading offset). The outer (cross-track) loop has `ė ≈ v·sin(crab_angle) ≈ v·(p·e)`,
+so the outer-loop gain is **proportional to commanded speed `v`**. With fixed PID
+gains the stability margin shrinks as speed rises, producing a speed-dependent
+cross-track limit cycle (±1 m, ~10 s, non-decaying at 3.5 kt; stable at 3 kt;
+observed 2026-06-16 Lake Massabesic, rolker/unh_echoboats_project11#289). A flat
+field mitigation (`pid.p −20 → −13`) works but doesn't hold the response constant
+across speed.
+
+The proper fix is to **speed-normalize the PID output** by `gain_ref_speed / v`
+right after the PID compute (L528), cancelling the broadband plant gain `v`. This
+is opt-in: default `gain_ref_speed = 0.0` disables it, so there is **no behavior
+change** until a platform configures it — exactly mirroring the `lookahead_time = 0`
+default-off pattern already in this file.
+
+The package already follows a clean separation: pure control/geometry math lives in
+the header `path_geometry.hpp` and is unit-tested in `test/test_path_geometry.cpp`
+without spinning up a ROS node. The two live-tunable atomics follow the
+`lookahead_*` pattern: `std::atomic<double>` member + `read_validated()` at
+configure + a `SetParameters` branch (with the `as_number` integer-coercion guard).
+
+## Approach
+
+1. **Extract the scaling as a pure function** — add
+   `gainScheduleScale(crab_angle_deg, gain_ref_speed, v_min, target_speed)` to
+   `path_geometry.hpp` (the established home for pure, unit-testable control math).
+   Contract: `gain_ref_speed <= 0` returns `crab_angle_deg` unchanged (disabled,
+   default); otherwise returns `crab_angle_deg * gain_ref_speed / max(target_speed, v_min)`.
+   `v_min` floors the effective speed so creep/station-keep (`target_speed → 0`)
+   can't blow the gain up. Keeping it pure (not a method) is what lets the unit
+   test exercise it across speeds with no ROS scaffolding — the same reason
+   `slewLimitError` / `lookaheadPoint` live there.
+
+2. **Add the two atomic members** to `crabbing_path_follower.h` following the
+   `lookahead_*` block: `std::atomic<double> pid_gain_ref_speed_{0.0};` and
+   `std::atomic<double> pid_gain_v_min_{0.5};`, with a block comment explaining
+   the `v`-cancellation rationale, the default-off semantics, and the floor.
+
+3. **Declare + validate at configure** — add two `read_validated(...)` calls.
+   `gain_ref_speed` uses `lo=0.0, exclusive_lo=false` (`>= 0`, so 0 = disabled is
+   valid). `gain_v_min` uses `lo=0.0, exclusive_lo=true` (`> 0`, a floor of 0
+   would re-admit the divide-by-near-zero blow-up).
+
+4. **Add the two SetParameters branches** — mirror the `lookahead_*` branches
+   exactly: `as_number(...)` coercion then `update(target, v, lo, exclusive_lo, name)`,
+   same `>= 0` / `> 0` split as step 3, so both params are live-tunable.
+
+5. **Call the scaler in `computeVelocityCommands`** right after L528
+   (`crab_angle = AngleDegrees(pid_->compute_command(...))`), snapshotting both
+   atomics once (intra-cycle tear-free, matching the `lookahead_*` snapshot idiom):
+   ```cpp
+   crab_angle = AngleDegrees(gainScheduleScale(
+     crab_angle.value(), pid_gain_ref_speed_.load(), pid_gain_v_min_.load(),
+     target_speed));
+   ```
+   Placed **before** the L582 trajectory-speed reassignment, so it uses the
+   commanded `target_speed` (L410), not the per-pose trajectory speed.
+
+6. **In-source rationale comment** at the insertion point: why **commanded**
+   `target_speed` (keeps the gain term out of the measured-speed feedback path —
+   a feedback-coupled gain would itself be a dynamic element); why the `v_min`
+   floor (no blow-up at creep / station-keep); and the `gain_ref_speed / v`
+   = plant-gain-cancellation reasoning.
+
+7. **Unit test** — new `test/test_gain_schedule.cpp` (gtest, pure, no ROS), added
+   to `CMakeLists.txt` with a second `ament_add_gtest(...)` block mirroring
+   `test_path_geometry`. Cases:
+   - **disabled**: `gain_ref_speed = 0` returns the input crab angle unchanged
+     (and a negative `gain_ref_speed` too).
+   - **enabled, multiple speeds**: at `v = gain_ref_speed` the angle is unchanged
+     (unity); at `v < ref` it scales up; at `v > ref` it scales down; check the
+     exact `ref/v` ratio at 2–3 speeds.
+   - **gain_v_min floor**: with `target_speed` below `v_min`, the divisor is
+     `v_min` (not `target_speed`), so the result is bounded — assert it equals
+     the `v_min`-divided value and that `target_speed = 0` does not produce
+     inf/nan.
+   - **sign preservation**: a negative crab angle stays negative after scaling.
+
+8. **Parameter documentation** — the package has **no** README or param-reference
+   doc, and the repo-root `README.md` documents no controller params (the
+   existing `lookahead_*` / `cross_track_error_slew_rate` params are documented
+   only in-source). So the in-source block comments (steps 2 + 6) are the
+   parameter documentation; there is no separate doc to update. (Noted as a
+   consequence below; a package-doc task is out of scope for this fix.)
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `marine_nav_crabbing_path_follower/include/marine_nav_crabbing_path_follower/path_geometry.hpp` | Add pure `gainScheduleScale()` with doc comment |
+| `marine_nav_crabbing_path_follower/include/marine_nav_crabbing_path_follower/crabbing_path_follower.h` | Add `pid_gain_ref_speed_` / `pid_gain_v_min_` atomics + rationale comment |
+| `marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp` | `read_validated` ×2, SetParameters branch ×2, scaler call + rationale comment at L528 insertion point |
+| `marine_nav_crabbing_path_follower/test/test_gain_schedule.cpp` | New gtest: disabled, multi-speed scaling, `v_min` floor, sign |
+| `marine_nav_crabbing_path_follower/CMakeLists.txt` | Add `ament_add_gtest(test_gain_schedule ...)` block |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Robustness / completeness (Quality Standard) | Default-off (`gain_ref_speed = 0`) means zero behavior change until a platform opts in; `v_min` floor + validation (`> 0`) prevents divide-by-zero / NaN cmd_vel on an autonomous boat — handled, with a test asserting `target_speed = 0` stays finite. |
+| Fix it completely (add the test, handle the edge case) | The plan ships the unit test (multi-speed, disabled, floor, sign) and the creep/station-keep edge case in the same PR, not "good enough". |
+| Verify before documenting | In-source param docs only — verified there is no README/param-ref doc to drift; the issue's analysis (L-numbers, scope) was checked against the actual source before planning. |
+| Don't invent conventions; follow precedent | Implementation models the existing `lookahead_*` live-tunable pattern exactly (atomic + read_validated + SetParameters + snapshot), and the pure-math-in-header / gtest pattern of `path_geometry.hpp`. |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| ADR-0008 (Follow ROS 2 conventions) | Yes | Nav2 controller-plugin idiom preserved: params declared via `nav2_util::declare_parameter_if_not_declared`, live updates via the existing on-set-parameters callback, plugin-name-prefixed param names. No new conventions invented. |
+| ADR-0013 (`progress.md` vocabulary) | Yes | This phase appends a `## Plan Authored` entry; implementation/review phases append their own entry types. |
+| Others (0001–0012, 0014) | No | Workspace-infra / mode ADRs; not implicated by a controller code change. |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| Add `pid.gain_ref_speed` / `pid.gain_v_min` params | Platform nav2 overlay (`unh_echoboats_project11` `nav2_overlay.yaml`) to activate `gain_ref_speed: 1.8`, `gain_v_min: 0.5` | **No — deferred.** Out of scope per operator decision; the 1.8 anchor needs a sim + on-water re-test first (issue Caveat). A follow-on issue should be opened in `unh_echoboats_project11` to activate after re-test. |
+| Add new live-tunable params | Parameter reference doc | N/A — no README/param-ref doc exists for this package; in-source comments are the doc. A dedicated package-documentation task (separate issue) would be the place to add a README. |
+| Add a new test source | `CMakeLists.txt` `BUILD_TESTING` block | Yes — `ament_add_gtest(test_gain_schedule ...)`. |
+
+## Open Questions
+
+- None blocking. The `gain_v_min` default (~0.5 m/s) and the `gain_ref_speed`
+  anchor (1.8 m/s) come from the issue; only `gain_v_min`'s default ships in
+  this PR (`gain_ref_speed` ships as 0 = disabled), and the 1.8 activation is
+  the deferred follow-on. If the reviewer prefers `gain_v_min` as `>= 0`
+  (disabled-floor semantics) rather than `> 0`, flag at review — the plan
+  chooses `> 0` to guarantee the divisor can never reach zero.
+
+## Estimated Scope
+
+Single PR in `unh_marine_navigation` only. The `unh_echoboats_project11` overlay
+activation is **explicitly out of scope / deferred** to a separate follow-on issue
+(open it after the sim + on-water re-test of the 1.8 anchor).

--- a/.agent/work-plans/issue-76/plan.md
+++ b/.agent/work-plans/issue-76/plan.md
@@ -148,3 +148,10 @@ configure + a `SetParameters` branch (with the `as_number` integer-coercion guar
 Single PR in `unh_marine_navigation` only. The `unh_echoboats_project11` overlay
 activation is **explicitly out of scope / deferred** to a separate follow-on issue
 (open it after the sim + on-water re-test of the 1.8 anchor).
+
+## Review Hardening (Pre-Push)
+
+Applied 3 non-blocking hardening items from the Local Review (Pre-Push): `isfinite`
+guard on `target_speed` in `gainScheduleScale` (NaN/Inf falls back to `v_min`), plus
+two test lock-ins in `test_gain_schedule.cpp` (negative `target_speed` floored to
+`v_min`; non-finite `target_speed` yields a finite result).

--- a/.agent/work-plans/issue-76/progress.md
+++ b/.agent/work-plans/issue-76/progress.md
@@ -63,3 +63,19 @@ PR lands in `unh_marine_navigation` only.
 - [ ] (suggestion) `gain_v_min > 0` is the correct choice — divisor can never reach zero, confirmed. The plan's open-question flag (`>= 0` alternative) is resolved: keep `> 0`. — `plan.md:51`
 - [ ] (suggestion) SetParameters param name namespace: the plan names the params `pid.gain_ref_speed` / `pid.gain_v_min`. The existing `SetParameters` callback uses `base = plugin_name_` and branches on `base + ".lookahead_distance"` etc. The new branches will need to match `base + ".pid.gain_ref_speed"` (not `base + ".gain_ref_speed"`), consistent with `plugin_name_ + ".pid.reset_threshold_seconds"` at line 39. The plan's `read_validated` calls and `declare_parameter_if_not_declared` declarations must also use the `.pid.` sub-namespace. This is consistent with the plan's stated naming but worth making explicit so the implementer doesn't accidentally drop the `.pid.` prefix. — `plan.md:48,54`
 - [ ] (suggestion) All four review-issue action items are addressed by the plan: unit test (step 7), in-source rationale (steps 2+6), platform config deferred per operator decision (Consequences table), parameter doc noted as in-source-only (step 8). The platform-config action item from issue-review is legitimately deferred; no gap remains in this PR's scope.
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-16 22:33 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: approved
+
+**Branch**: feature/issue-76 at `91bb181`
+**Mode**: pre-push
+**Depth**: Standard (reason: ~133 LOC across 5 files in a core_ws Nav2 controller plugin; safety-relevant boat code; work plan present)
+**Must-fix**: 0 | **Suggestions**: 3
+
+### Findings
+- [ ] (suggestion) `gainScheduleScale` has no `isfinite` guard on `target_speed`; `std::max(NaN, v_min)` returns NaN, propagating to `crab_angle` when enabled. Cross-pass confirmed (Lens A + Lens B). Cannot occur in production — the only call site passes validator-guaranteed finite-positive `target_speed` — so it is pure-function-contract hardening, not a live defect. Optional: add `if (!std::isfinite(target_speed)) return crab_angle_deg;` + a test. — `path_geometry.hpp:130-138`
+- [ ] (suggestion) No integration-level test that the param callback rejects `pid.gain_v_min <= 0` / non-finite sets; the "atomic can never hold 0" invariant is proven by construction but not at the callback boundary. Consistent with the package's existing tunables (shared gap, not a regression). — `crabbing_path_follower.cpp:248-256`
+- [ ] (suggestion) Optional lock-in test: assert `gainScheduleScale(.., v_min, target_speed<0)` divides by `v_min` (negative-speed input is floored), documenting the contract edge. — `test_gain_schedule.cpp`

--- a/.agent/work-plans/issue-76/progress.md
+++ b/.agent/work-plans/issue-76/progress.md
@@ -49,3 +49,17 @@ PR lands in `unh_marine_navigation` only.
       (guarantees a non-zero divisor) rather than `>= 0` — confirm at review-plan.
 - [ ] Action-item carry-forward: the echoboats overlay activation + `pid.p −13`
       reconciliation is the deferred follow-on issue (not this PR).
+
+## Plan Review
+**Status**: complete
+**When**: 2026-06-16 20:30 +00:00
+**By**: Claude Code Agent (Claude Sonnet 4.6)
+
+**Plan**: `.agent/work-plans/issue-76/plan.md` at `d7b59fc`
+**PR**: PR-less (no draft PR at review time)
+**Verdict**: approve-with-suggestions
+
+### Findings
+- [ ] (suggestion) `gain_v_min > 0` is the correct choice — divisor can never reach zero, confirmed. The plan's open-question flag (`>= 0` alternative) is resolved: keep `> 0`. — `plan.md:51`
+- [ ] (suggestion) SetParameters param name namespace: the plan names the params `pid.gain_ref_speed` / `pid.gain_v_min`. The existing `SetParameters` callback uses `base = plugin_name_` and branches on `base + ".lookahead_distance"` etc. The new branches will need to match `base + ".pid.gain_ref_speed"` (not `base + ".gain_ref_speed"`), consistent with `plugin_name_ + ".pid.reset_threshold_seconds"` at line 39. The plan's `read_validated` calls and `declare_parameter_if_not_declared` declarations must also use the `.pid.` sub-namespace. This is consistent with the plan's stated naming but worth making explicit so the implementer doesn't accidentally drop the `.pid.` prefix. — `plan.md:48,54`
+- [ ] (suggestion) All four review-issue action items are addressed by the plan: unit test (step 7), in-source rationale (steps 2+6), platform config deferred per operator decision (Consequences table), parameter doc noted as in-source-only (step 8). The platform-config action item from issue-review is legitimately deferred; no gap remains in this PR's scope.

--- a/.agent/work-plans/issue-76/progress.md
+++ b/.agent/work-plans/issue-76/progress.md
@@ -79,3 +79,31 @@ PR lands in `unh_marine_navigation` only.
 - [ ] (suggestion) `gainScheduleScale` has no `isfinite` guard on `target_speed`; `std::max(NaN, v_min)` returns NaN, propagating to `crab_angle` when enabled. Cross-pass confirmed (Lens A + Lens B). Cannot occur in production — the only call site passes validator-guaranteed finite-positive `target_speed` — so it is pure-function-contract hardening, not a live defect. Optional: add `if (!std::isfinite(target_speed)) return crab_angle_deg;` + a test. — `path_geometry.hpp:130-138`
 - [ ] (suggestion) No integration-level test that the param callback rejects `pid.gain_v_min <= 0` / non-finite sets; the "atomic can never hold 0" invariant is proven by construction but not at the callback boundary. Consistent with the package's existing tunables (shared gap, not a regression). — `crabbing_path_follower.cpp:248-256`
 - [ ] (suggestion) Optional lock-in test: assert `gainScheduleScale(.., v_min, target_speed<0)` divides by `v_min` (negative-speed input is floored), documenting the contract edge. — `test_gain_schedule.cpp`
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-17 06:24 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: approved
+
+**Branch**: feature/issue-76 at `a2fd6af`
+**Mode**: pre-push
+**Depth**: Standard (reason: ~134 LOC across 5 changed source files in a core_ws Nav2 controller plugin; safety-relevant boat code; work plan present)
+**Must-fix**: 0 | **Suggestions**: 1
+
+Re-review after hardening commit `a2fd6af`, which applied the 3 non-blocking
+suggestions from the prior approved Local Review at `91bb181`: (1) `isfinite`
+guard on `target_speed` in the pure `gainScheduleScale` (non-finite falls back
+to `v_min`); (2) test lock-in for negative `target_speed` floored to `v_min`;
+(3) test lock-in for non-finite `target_speed` yielding a finite result. Both
+disjoint-lens Claude Adversarial passes (Lens A logic, Lens B systemic/safety)
+returned "sound, no regression vs 91bb181". gtest 9/9 PASS (verified by running
+the compiled `test_gain_schedule` binary). No lines exceed the 100-char ament
+limit in the new code. Hardening commit confirmed correct and complete; the
+isfinite guard is a strict superset — finite inputs traverse the identical path,
+so all pre-hardening behavior is preserved. The new params still default to
+disabled (`gain_ref_speed=0.0`); echoboats overlay activation is deliberately
+deferred (not a gap). Known local uncrustify 0.78.1 drift excluded per scope.
+
+### Findings
+- [ ] (suggestion) `NonFiniteTargetSpeedStaysFinite` exercises NaN and +Inf but not -Inf; `std::isfinite` handles -Inf identically so this is a coverage-completeness note, not a correctness gap (finite-negative flooring is already covered by `FloorsNegativeTargetSpeedAtVMin`). — `test_gain_schedule.cpp:82-93`

--- a/.agent/work-plans/issue-76/progress.md
+++ b/.agent/work-plans/issue-76/progress.md
@@ -18,3 +18,34 @@ issue: 76
 - [ ] Add in-source rationale comment at the scaling insertion point explaining why target_speed (commanded) is used rather than measured speed, and the gain_v_min floor purpose
 - [ ] Update platform config (`unh_echoboats_project11` nav2 overlay) with `pid.gain_ref_speed: 1.8` and `pid.gain_v_min: 0.5` — note whether this is part of the same PR or a companion commit
 - [ ] Update parameter documentation if a parameter reference doc exists for marine_nav_crabbing_path_follower
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-06-16 19:05 +00:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Plan**: `.agent/work-plans/issue-76/plan.md` at `d7b59fc`
+**Branch**: feature/issue-76 at `d7b59fc`
+**Phases**: single
+
+The plan speed-normalizes the cross-track gain by scaling the PID output
+`crab_angle` by `gain_ref_speed / max(target_speed, gain_v_min)` after the PID
+compute (L528). Two new live-tunable atomics (`pid.gain_ref_speed` default
+**0.0 = disabled**, `pid.gain_v_min` default **0.5**) follow the existing
+`lookahead_*` pattern (atomic + `read_validated` + SetParameters branch). The
+scaling math is extracted to a pure `gainScheduleScale()` in `path_geometry.hpp`
+and unit-tested in a new `test/test_gain_schedule.cpp` (disabled, multi-speed,
+`v_min` floor, sign). In-source rationale comment at the insertion point covers
+why commanded (not measured) speed and the floor purpose. No README/param-ref
+doc exists for this package — in-source comments are the doc.
+
+**Scope note**: `unh_echoboats_project11` nav2-overlay activation (`gain_ref_speed:
+1.8` / `gain_v_min: 0.5`) is **out of scope / deferred** to a separate follow-on
+issue — the 1.8 anchor needs a sim + on-water re-test first (issue Caveat). This
+PR lands in `unh_marine_navigation` only.
+
+### Open questions
+- [ ] No blocking open questions. Optional reviewer flag: `gain_v_min` uses `> 0`
+      (guarantees a non-zero divisor) rather than `>= 0` — confirm at review-plan.
+- [ ] Action-item carry-forward: the echoboats overlay activation + `pid.p −13`
+      reconciliation is the deferred follow-on issue (not this PR).

--- a/.agent/work-plans/issue-76/progress.md
+++ b/.agent/work-plans/issue-76/progress.md
@@ -1,0 +1,20 @@
+---
+issue: 76
+---
+
+# Issue #76 — marine_nav_crabbing_path_follower: speed-normalize the cross-track gain (gain schedule)
+
+## Issue Review
+**Status**: complete
+**When**: 2026-06-16 18:30 +00:00
+**By**: Claude Code Agent (Claude Sonnet 4.6)
+
+**Issue**: #76
+**Comment**: https://github.com/rolker/unh_marine_navigation/issues/76#issuecomment-4725111013
+**Scope verdict**: well-scoped
+
+### Actions
+- [ ] Add unit test for gain-schedule scaling (test that crab_angle scales correctly at multiple speeds, with gain_ref_speed disabled vs enabled, and with the gain_v_min floor) — test what breaks principle
+- [ ] Add in-source rationale comment at the scaling insertion point explaining why target_speed (commanded) is used rather than measured speed, and the gain_v_min floor purpose
+- [ ] Update platform config (`unh_echoboats_project11` nav2 overlay) with `pid.gain_ref_speed: 1.8` and `pid.gain_v_min: 0.5` — note whether this is part of the same PR or a companion commit
+- [ ] Update parameter documentation if a parameter reference doc exists for marine_nav_crabbing_path_follower

--- a/marine_nav_crabbing_path_follower/CMakeLists.txt
+++ b/marine_nav_crabbing_path_follower/CMakeLists.txt
@@ -72,6 +72,13 @@ if(BUILD_TESTING)
       "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>")
     ament_target_dependencies(test_path_geometry geometry_msgs)
   endif()
+
+  ament_add_gtest(test_gain_schedule test/test_gain_schedule.cpp)
+  if(TARGET test_gain_schedule)
+    target_include_directories(test_gain_schedule PRIVATE
+      "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>")
+    ament_target_dependencies(test_gain_schedule geometry_msgs)
+  endif()
 endif()
 
 ament_package()

--- a/marine_nav_crabbing_path_follower/include/marine_nav_crabbing_path_follower/crabbing_path_follower.h
+++ b/marine_nav_crabbing_path_follower/include/marine_nav_crabbing_path_follower/crabbing_path_follower.h
@@ -120,6 +120,21 @@ protected:
   double slewed_cross_track_error_{0.0};
   bool slew_initialized_{false};
 
+  // Cross-track gain schedule (speed-normalization, #76). The outer cross-track
+  // loop's effective gain is proportional to commanded speed v (ė ≈ v·sin(crab)),
+  // so fixed PID gains lose stability margin as speed rises — a speed-dependent
+  // cross-track limit cycle (Lake Massabesic, unh_echoboats_project11#289).
+  // Scaling the PID output crab_angle by gain_ref_speed / max(v, v_min) cancels
+  // that plant gain v, holding the closed-loop response constant across speed.
+  // pid_gain_ref_speed_ = 0.0 DISABLES it (the default; no behavior change until a
+  // platform opts in, mirroring lookahead_time_ = 0). pid_gain_v_min_ floors the
+  // divisor so creep / station-keep (v → 0) can't blow the gain up or divide by
+  // zero; its validator enforces > 0 (a floor of 0 would re-admit the blow-up).
+  // Both are live-tunable via the parameter callback, hence atomic (param-service
+  // thread writes while computeVelocityCommands reads on the controller thread).
+  std::atomic<double> pid_gain_ref_speed_{0.0};
+  std::atomic<double> pid_gain_v_min_{0.5};
+
   bool visualize_ = false;
   rclcpp_lifecycle::LifecyclePublisher<visualization_msgs::msg::MarkerArray>::SharedPtr visualization_publisher_;
 

--- a/marine_nav_crabbing_path_follower/include/marine_nav_crabbing_path_follower/path_geometry.hpp
+++ b/marine_nav_crabbing_path_follower/include/marine_nav_crabbing_path_follower/path_geometry.hpp
@@ -133,7 +133,11 @@ inline double gainScheduleScale(
   if (!(gain_ref_speed > 0.0)) {
     return crab_angle_deg;
   }
-  const double v = std::max(target_speed, v_min);
+  // A non-finite target_speed (NaN/Inf from a stale or wild estimate) would
+  // propagate through std::max into the divisor and command NaN crab; treat it
+  // as the floor so the result stays finite for finite crab_angle/gain_ref_speed/v_min.
+  const double safe_target_speed = std::isfinite(target_speed) ? target_speed : v_min;
+  const double v = std::max(safe_target_speed, v_min);
   return crab_angle_deg * gain_ref_speed / v;
 }
 

--- a/marine_nav_crabbing_path_follower/include/marine_nav_crabbing_path_follower/path_geometry.hpp
+++ b/marine_nav_crabbing_path_follower/include/marine_nav_crabbing_path_follower/path_geometry.hpp
@@ -104,6 +104,39 @@ inline geometry_msgs::msg::Point lookaheadPoint(
   return poses[last].pose.position;
 }
 
+/// Speed-normalize (gain-schedule) the cross-track PID output `crab_angle_deg`.
+///
+/// The outer cross-track loop has `ė ≈ v·sin(crab_angle) ≈ v·(p·e)`, so its
+/// effective gain is proportional to the commanded speed `v` (#76). With fixed
+/// PID gains the stability margin shrinks as speed rises, producing a
+/// speed-dependent cross-track limit cycle (observed at Lake Massabesic,
+/// unh_echoboats_project11#289). Scaling the PID output by
+/// `gain_ref_speed / v` cancels that broadband plant gain, holding the
+/// closed-loop response constant across speed: the controller behaves as if it
+/// were always running at `gain_ref_speed`.
+///
+/// Contract:
+///   - `gain_ref_speed <= 0`: disabled (the default) — returns `crab_angle_deg`
+///     unchanged, so there is no behavior change until a platform opts in
+///     (mirrors the `lookahead_time = 0` default-off idiom in this package).
+///   - otherwise: returns `crab_angle_deg * gain_ref_speed / max(target_speed, v_min)`.
+///     `v_min` floors the effective speed so creep / station-keep
+///     (`target_speed → 0`) can't blow the gain up (or divide by zero). The
+///     caller must pass a strictly-positive `v_min` (the parameter validator
+///     enforces `> 0`); `target_speed` may be any value, including 0.
+///
+/// Pure (not a method) so it can be unit-tested across speeds with no ROS
+/// scaffolding — the same reason `slewLimitError` / `lookaheadPoint` live here.
+inline double gainScheduleScale(
+  double crab_angle_deg, double gain_ref_speed, double v_min, double target_speed)
+{
+  if (!(gain_ref_speed > 0.0)) {
+    return crab_angle_deg;
+  }
+  const double v = std::max(target_speed, v_min);
+  return crab_angle_deg * gain_ref_speed / v;
+}
+
 /// Signed along-track distance of point `p` projected onto the segment a->b,
 /// measured from `a`. Negative means `p` is behind the segment start. A
 /// degenerate (zero-length) segment returns 0.

--- a/marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp
+++ b/marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp
@@ -237,6 +237,23 @@ void CrabbingPathFollower::configure(
           {
             return result;
           }
+        } else if (name == base + ".pid.gain_ref_speed") {
+          // >= 0: 0.0 disables the gain schedule (the default), so it is valid.
+          double v;
+          if (!as_number(p, v) ||
+            !update(pid_gain_ref_speed_, v, 0.0, false, "pid.gain_ref_speed"))
+          {
+            return result;
+          }
+        } else if (name == base + ".pid.gain_v_min") {
+          // > 0 (exclusive): the divisor floor must stay strictly positive so the
+          // gain schedule can never divide by zero / blow up at creep.
+          double v;
+          if (!as_number(p, v) ||
+            !update(pid_gain_v_min_, v, 0.0, true, "pid.gain_v_min"))
+          {
+            return result;
+          }
         }
       }
       return result;
@@ -293,6 +310,11 @@ void CrabbingPathFollower::configure(
   read_validated(".lookahead_min_distance", lookahead_min_distance_, 0.0, false);
   read_validated(".new_plan_goal_tolerance", new_plan_goal_tolerance_, 0.0, false);
   read_validated(".cross_track_error_slew_rate", cross_track_error_slew_rate_, 0.0, false);
+  // Cross-track gain schedule (#76). gain_ref_speed >= 0 (0 = disabled, the
+  // default); gain_v_min > 0 (the divisor floor must stay strictly positive).
+  // Sub-namespaced under .pid. to sit alongside .pid.reset_threshold_seconds.
+  read_validated(".pid.gain_ref_speed", pid_gain_ref_speed_, 0.0, false);
+  read_validated(".pid.gain_v_min", pid_gain_v_min_, 0.0, true);
 
   global_pub_ = node->create_publisher<nav_msgs::msg::Path>("received_global_plan", 1);
 }
@@ -526,6 +548,27 @@ geometry_msgs::msg::TwistStamped CrabbingPathFollower::computeVelocityCommands(
     slewed_cross_track_error_, slew_initialized_, cross_track_error,
     cross_track_error_slew_rate_.load(), dt.seconds());
   auto crab_angle = AngleDegrees(pid_->compute_command(pid_cross_track_error, dt));
+
+  // Speed-normalize the cross-track gain (#76). The outer loop's effective gain
+  // is proportional to commanded speed v (ė ≈ v·sin(crab)), so fixed PID gains
+  // lose stability margin as speed rises (a speed-dependent limit cycle; Lake
+  // Massabesic, unh_echoboats_project11#289). Scaling crab_angle by
+  // gain_ref_speed / max(v, v_min) cancels that plant gain v.
+  //
+  // We use the COMMANDED target_speed (the default_speed / speed-limit value from
+  // L410), NOT the measured speed and NOT the per-pose trajectory speed derived
+  // below. Using commanded speed keeps the gain term out of the measured-speed
+  // feedback path: a gain that varied with the boat's *measured* speed would
+  // itself be a dynamic element coupled into the loop (gain ↔ response feedback),
+  // which is exactly the kind of speed-dependent dynamics this fix removes. The
+  // gain_v_min floor keeps the divisor strictly positive so creep / station-keep
+  // (target_speed → 0) can't blow the gain up or divide by zero. Snapshot both
+  // atomics once (tear-free, matching the lookahead_* snapshot idiom). Default
+  // gain_ref_speed = 0 leaves crab_angle unchanged (disabled).
+  crab_angle = AngleDegrees(gainScheduleScale(
+    crab_angle.value(), pid_gain_ref_speed_.load(), pid_gain_v_min_.load(),
+    target_speed));
+
   AngleRadians heading(tf2::getYaw(pose_in_plan.pose.orientation));
 
   RCLCPP_DEBUG_STREAM(logger_, "CrabbingPathFollower: progress: " << progress << " cross_track_error: " << cross_track_error << " crab_angle: " << crab_angle.value() << " heading: " << heading.value() << " segment_azimuth: " << segment_azimuth.value());

--- a/marine_nav_crabbing_path_follower/test/test_gain_schedule.cpp
+++ b/marine_nav_crabbing_path_follower/test/test_gain_schedule.cpp
@@ -1,4 +1,5 @@
 #include <cmath>
+#include <limits>
 
 #include <gtest/gtest.h>
 
@@ -62,6 +63,33 @@ TEST(GainScheduleScale, ZeroTargetSpeedStaysFinite)
   const double r = gainScheduleScale(10.0, 2.0, 0.5, 0.0);
   EXPECT_TRUE(std::isfinite(r));
   EXPECT_DOUBLE_EQ(r, 10.0 * 2.0 / 0.5);  // divided by v_min, not 0
+}
+
+// A negative target_speed (a wild / backwards estimate) is floored to v_min by
+// the same std::max as the sub-floor creep case — the effective divisor is
+// v_min, never the negative value (which would flip the gain's sign).
+TEST(GainScheduleScale, FloorsNegativeTargetSpeedAtVMin)
+{
+  // v_min = 0.5, target_speed = -2.0 -> divides by 0.5, not -2.0.
+  EXPECT_DOUBLE_EQ(gainScheduleScale(10.0, 2.0, 0.5, -2.0), 10.0 * 2.0 / 0.5);
+  // Sign is preserved (not flipped by a negative divisor).
+  EXPECT_GT(gainScheduleScale(8.0, 1.8, 0.5, -1.0), 0.0);
+}
+
+// A non-finite target_speed (NaN/+Inf from a stale or wild speed estimate) must
+// not propagate into the crab command: the isfinite guard falls back to v_min
+// so the result stays finite for finite crab_angle/gain_ref_speed/v_min.
+TEST(GainScheduleScale, NonFiniteTargetSpeedStaysFinite)
+{
+  const double nan_v = std::numeric_limits<double>::quiet_NaN();
+  const double r_nan = gainScheduleScale(10.0, 2.0, 0.5, nan_v);
+  EXPECT_TRUE(std::isfinite(r_nan));
+  EXPECT_DOUBLE_EQ(r_nan, 10.0 * 2.0 / 0.5);  // fell back to v_min
+
+  const double inf_v = std::numeric_limits<double>::infinity();
+  const double r_inf = gainScheduleScale(10.0, 2.0, 0.5, inf_v);
+  EXPECT_TRUE(std::isfinite(r_inf));
+  EXPECT_DOUBLE_EQ(r_inf, 10.0 * 2.0 / 0.5);  // fell back to v_min
 }
 
 // Sign preservation: a negative crab angle stays negative after scaling (the

--- a/marine_nav_crabbing_path_follower/test/test_gain_schedule.cpp
+++ b/marine_nav_crabbing_path_follower/test/test_gain_schedule.cpp
@@ -1,0 +1,80 @@
+#include <cmath>
+
+#include <gtest/gtest.h>
+
+#include "marine_nav_crabbing_path_follower/path_geometry.hpp"
+
+using marine_nav_crabbing_path_follower::gainScheduleScale;
+
+// Disabled: gain_ref_speed <= 0 returns the crab angle unchanged (the default,
+// so there is no behavior change until a platform opts in).
+TEST(GainScheduleScale, DisabledReturnsInputUnchanged)
+{
+  // gain_ref_speed == 0 (the shipped default) is identity at any speed.
+  EXPECT_DOUBLE_EQ(gainScheduleScale(12.0, 0.0, 0.5, 1.0), 12.0);
+  EXPECT_DOUBLE_EQ(gainScheduleScale(12.0, 0.0, 0.5, 3.5), 12.0);
+  EXPECT_DOUBLE_EQ(gainScheduleScale(-7.5, 0.0, 0.5, 2.0), -7.5);
+  // A negative gain_ref_speed is also treated as disabled (identity), not a
+  // sign flip — the validator rejects it, but the pure function is defensive.
+  EXPECT_DOUBLE_EQ(gainScheduleScale(12.0, -1.0, 0.5, 1.0), 12.0);
+}
+
+// Enabled, at the reference speed: v == gain_ref_speed -> unity (unchanged).
+TEST(GainScheduleScale, UnityAtReferenceSpeed)
+{
+  EXPECT_DOUBLE_EQ(gainScheduleScale(10.0, 1.8, 0.5, 1.8), 10.0);
+  EXPECT_DOUBLE_EQ(gainScheduleScale(-4.0, 2.0, 0.5, 2.0), -4.0);
+}
+
+// Enabled, below the reference speed: scales the gain UP (ref/v > 1).
+TEST(GainScheduleScale, ScalesUpBelowReferenceSpeed)
+{
+  // ref = 2.0, v = 1.0 -> factor 2.0.
+  EXPECT_DOUBLE_EQ(gainScheduleScale(6.0, 2.0, 0.5, 1.0), 12.0);
+  // ref = 1.8, v = 1.2 -> factor 1.5.
+  EXPECT_DOUBLE_EQ(gainScheduleScale(4.0, 1.8, 0.5, 1.2), 4.0 * 1.8 / 1.2);
+}
+
+// Enabled, above the reference speed: scales the gain DOWN (ref/v < 1) — the
+// point of the fix (less aggressive cross-track gain as speed rises).
+TEST(GainScheduleScale, ScalesDownAboveReferenceSpeed)
+{
+  // ref = 2.0, v = 4.0 -> factor 0.5.
+  EXPECT_DOUBLE_EQ(gainScheduleScale(10.0, 2.0, 0.5, 4.0), 5.0);
+  // ref = 1.8, v = 3.5 -> factor 1.8/3.5.
+  EXPECT_DOUBLE_EQ(gainScheduleScale(7.0, 1.8, 0.5, 3.5), 7.0 * 1.8 / 3.5);
+}
+
+// gain_v_min floor: a target_speed below v_min divides by v_min (not the lower
+// target_speed), so the gain stays bounded at creep / station-keep.
+TEST(GainScheduleScale, FloorsDivisorAtVMin)
+{
+  // v_min = 0.5, target_speed = 0.1 (< v_min) -> divides by 0.5, not 0.1.
+  EXPECT_DOUBLE_EQ(gainScheduleScale(10.0, 2.0, 0.5, 0.1), 10.0 * 2.0 / 0.5);
+  // Exactly at the floor: divides by v_min.
+  EXPECT_DOUBLE_EQ(gainScheduleScale(10.0, 2.0, 0.5, 0.5), 10.0 * 2.0 / 0.5);
+}
+
+// target_speed == 0 (station-keep / start of motion) stays finite: the floor
+// prevents the divide-by-zero blow-up that would command NaN/Inf on the boat.
+TEST(GainScheduleScale, ZeroTargetSpeedStaysFinite)
+{
+  const double r = gainScheduleScale(10.0, 2.0, 0.5, 0.0);
+  EXPECT_TRUE(std::isfinite(r));
+  EXPECT_DOUBLE_EQ(r, 10.0 * 2.0 / 0.5);  // divided by v_min, not 0
+}
+
+// Sign preservation: a negative crab angle stays negative after scaling (the
+// scale factor is strictly positive).
+TEST(GainScheduleScale, PreservesSign)
+{
+  EXPECT_LT(gainScheduleScale(-8.0, 1.8, 0.5, 1.0), 0.0);   // up-scaled, still negative
+  EXPECT_GT(gainScheduleScale(8.0, 1.8, 0.5, 3.5), 0.0);    // down-scaled, still positive
+  EXPECT_LT(gainScheduleScale(-8.0, 1.8, 0.5, 3.5), 0.0);   // down-scaled negative
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary

Speed-normalizes the cross-track gain in `CrabbingPathFollower` to remove the **speed-dependent cross-track limit cycle** (±1 m, ~10 s, at 3.5 kt) observed during the 2026-06-16 Lake Massabesic survey (rolker/unh_echoboats_project11#289). The outer (cross-track) loop gain is `∝ v·p`, so fixed gains lose margin as speed rises. This scales the PID output (`crab_angle`) by `gain_ref_speed / max(target_speed, gain_v_min)` — a `1/v` law that cancels the broadband plant gain `v`.

Follow-on to the field mitigation `FollowPath.pid.p −20 → −13` already committed in the echoboats overlay.

## Changes
- **Pure `gainScheduleScale()`** in `path_geometry.hpp` (unit-testable, no ROS spin-up — mirrors `slewLimitError` / `lookaheadPoint`). `gain_ref_speed <= 0` → identity (disabled). Non-finite `target_speed` clamps the divisor to the `v_min` floor (contract-hardened, always finite).
- **Two live-tunable params** following the existing `lookahead_*` / `pid.reset_threshold_seconds` pattern (atomic + `declare_parameter_if_not_declared` + `read_validated` + on-SetParameters branch), correctly `.pid.`-sub-namespaced:
  - `pid.gain_ref_speed` — default **0.0 (disabled)** → no behavior change until a platform opts in.
  - `pid.gain_v_min` — default **0.5** m/s, exclusive `> 0` (divisor strictly positive; safe at creep / station-keep).
- Scaler applied right after the PID compute using **commanded** `target_speed` (keeps the gain out of the feedback path), before the trajectory-speed reassignment. In-source rationale comment at the insertion point.
- **`test/test_gain_schedule.cpp`** — 9 gtest cases: disabled/identity (incl. negative ref), unity at ref, scale-up below / scale-down above ref, `v_min` floor, negative `target_speed` floored, non-finite (NaN/+Inf) stays finite, sign preservation. All passing.

## Safety
Default-off → zero runtime behavior change until configured. `v_min > 0` makes divide-by-zero impossible; downstream `cos_crab = max(cos, 0.5)` and the `±max_yaw_rate` clamp bound any large scaled `crab_angle`. No unclamped NaN/Inf reaches `cmd_vel`.

## Out of scope (deferred)
The `unh_echoboats_project11` nav2-overlay activation (`pid.gain_ref_speed: 1.8`, `pid.gain_v_min: 0.5`) is **deferred to a separate follow-on issue** — the `1.8` anchor (3.5 kt) needs a sim + on-water re-test before it is trusted (per the issue's caveat). This PR lands only the default-disabled mechanism.

## Test plan
- `colcon test --packages-select marine_nav_crabbing_path_follower` → 9/9 gtest cases pass (build clean).
- On-water / sim validation of the `1.8` anchor tracked under the follow-on (above).

## Lifecycle
Reviewed locally through the full `run-issue` pipeline: review-issue → plan-task → review-plan → implement → review-code (pre-push, approved) → hardening → re-review (pre-push, approved). Progress timeline committed under `.agent/work-plans/issue-76/`.

Closes #76

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
