### PR TITLE
Wire collision-avoidance node (CaSafetyNode) into marine_control device control

### DIFF
--- a/.agent/work-plans/issue-80/progress.md
+++ b/.agent/work-plans/issue-80/progress.md
@@ -1,0 +1,29 @@
+---
+issue: 80
+---
+
+# Issue #80 — Wire collision-avoidance node (CaSafetyNode) into marine_control device control
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-27 17:27 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: approved
+
+**Branch**: feature/issue-80 at `42051a0`
+**Mode**: pre-push
+**Depth**: Standard (reason: safety-critical CA brake node + ~295 lines)
+**Must-fix**: 0 | **Suggestions**: 3
+**Round**: 1 | **Ship**: recommended — no must-fix; both adversarial lenses confirmed correct threading, validation routing, construction order, teardown.
+
+Two disjoint-lens Claude adversarial passes cross-confirmed: all 15 live params
+bound (no typos), the change channel routes through the existing onSetParameters
+validation (finite/>0 + slowdown_min<=max ordering) so no atomic is
+exposed-but-unvalidated, single-threaded executor makes the ControlServer
+callbacks non-concurrent with node callbacks, construction-last + teardown order
+satisfy the control_server.hpp contract, and the launch tests are non-vacuous.
+
+### Findings
+- [ ] (suggestion) 13 dynamic doubles have no FloatingPointRange → panel sees degenerate [0,0] bounds AND an operator can shrink stop_length/widths toward ~0 (valid but weakens the brake). Adding per-param sane ranges needs Roland's domain values — DEFERRED as a follow-up decision. — `ca_safety_node.h:declareDynamicDouble`
+- [ ] (suggestion) safety-critical adopter (ADR-0003 D8.3) uses bare fire-and-forget + audit log, no operator-confirmation handshake — by design; tracks with the marine_control confirmation follow-up. — `ca_safety_node.h:setupControlServer`
+- [ ] (deferred) package has pre-existing ament_lint debt on jazzy (cpplint header-guards/copyright, whole-file uncrustify config mismatch, no copyright headers) — out of scope; the new launch test is flake8/pep257 clean and matches the no-header convention.

--- a/marine_nav_ca_safety/CMakeLists.txt
+++ b/marine_nav_ca_safety/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_sensor_msgs REQUIRED)
+find_package(marine_control REQUIRED)
 
 # Header-only logic + node class; exported as an INTERFACE library.
 add_library(${PROJECT_NAME} INTERFACE)
@@ -42,6 +43,7 @@ set(ca_safety_deps
   tf2_ros
   tf2_geometry_msgs
   tf2_sensor_msgs
+  marine_control
 )
 
 add_executable(ca_safety_node src/ca_safety_node.cpp)
@@ -83,6 +85,12 @@ if(BUILD_TESTING)
   # TF transform of a real cloud, and the braking reaction + single output publisher.
   find_package(launch_testing_ament_cmake REQUIRED)
   add_launch_test(test/test_ca_safety_launch.py)
+
+  # marine_control device-control wiring (unh_marine_autonomy#140 / ADR-0003):
+  # asserts the node advertises all 15 live tunables on ~/control/state, that an
+  # in-range change applies, and that the existing parameter validation (> 0 and
+  # the slowdown min <= max ordering) still rejects bad operator input.
+  add_launch_test(test/test_ca_safety_control.py)
 endif()
 
 ament_package()

--- a/marine_nav_ca_safety/include/marine_nav_ca_safety/ca_safety_node.h
+++ b/marine_nav_ca_safety/include/marine_nav_ca_safety/ca_safety_node.h
@@ -11,6 +11,7 @@
 
 #include "geometry_msgs/msg/polygon_stamped.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"
+#include "marine_control/control_server.hpp"
 #include "marine_nav_ca_safety/ca_safety.h"
 #include "nav2_msgs/msg/collision_monitor_state.hpp"
 #include "nav_msgs/msg/odometry.hpp"
@@ -157,6 +158,11 @@ public:
     last_odom_time_ = t0;
     reverse_start_time_ = t0;
     last_stop_seen_ = t0;
+
+    // Expose the live tunables on the marine_control device panel. Done last so
+    // every parameter is declared and the validate/commit callbacks are
+    // registered before the control channel goes live.
+    setupControlServer();
   }
 
 private:
@@ -279,6 +285,43 @@ private:
         publish_visualization_ = p.as_bool();
       }
     }
+  }
+
+  // Expose the live CA-safety tunables on the marine_control device panel so the
+  // operator can retune slowdown/stop/reverse behavior live, bridgeable
+  // boat->operator (unh_marine_autonomy#140 / ADR-0003). Each control is backed
+  // by an already-declared dynamic parameter, so operator changes route through
+  // the existing onSetParameters validation (finite, > 0, ordered slowdown
+  // range) before onPostSetParameters commits them to the live atomics — the
+  // fire-and-forget change channel cannot bypass that validation (ADR-0003 D8.3).
+  // The descriptors (including cancel_yaw_during_reverse's unverified-false-path
+  // warning) carry through to the panel as the per-control help text.
+  void setupControlServer()
+  {
+    marine_control::ControlServerOptions opts;
+    opts.device_name = "Collision-Avoidance Safety";
+    control_server_ = std::make_shared<marine_control::ControlServer>(this, opts);
+
+    // Slowdown corridor.
+    control_server_->bind_parameter("ttc_time_constant", "s", "slowdown");
+    control_server_->bind_parameter("slowdown_min_length", "m", "slowdown");
+    control_server_->bind_parameter("slowdown_max_length", "m", "slowdown");
+    control_server_->bind_parameter("slowdown_speed_floor", "m/s", "slowdown");
+    control_server_->bind_parameter("slowdown_width", "m", "slowdown");
+    // Stop box.
+    control_server_->bind_parameter("stop_length", "m", "stop");
+    control_server_->bind_parameter("stop_width", "m", "stop");
+    control_server_->bind_parameter("stop_speed_eps", "m/s", "stop");
+    // Reverse brake.
+    control_server_->bind_parameter("reverse_speed", "m/s", "reverse");
+    control_server_->bind_parameter("reverse_distance", "m", "reverse");
+    control_server_->bind_parameter("reverse_duration", "s", "reverse");
+    control_server_->bind_parameter("reverse_clear_debounce", "s", "reverse");
+    control_server_->bind_parameter("cancel_yaw_during_reverse", "", "reverse");
+    // Source-loss handling.
+    control_server_->bind_parameter("source_timeout", "s", "source");
+    // Visualization.
+    control_server_->bind_parameter("publish_visualization", "", "visualization");
   }
 
   SafetyParams snapshotParams() const
@@ -556,6 +599,10 @@ private:
 
   OnSetParametersCallbackHandle::SharedPtr param_callback_handle_;
   PostSetParametersCallbackHandle::SharedPtr post_param_callback_handle_;
+  // Boat-side device-control server: publishes the live tunables as bridgeable
+  // marine_controls and applies operator changes via the validated parameter
+  // path. Constructed last in the constructor (setupControlServer).
+  std::shared_ptr<marine_control::ControlServer> control_server_;
   std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
   std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
   rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr cmd_vel_sub_;

--- a/marine_nav_ca_safety/package.xml
+++ b/marine_nav_ca_safety/package.xml
@@ -16,6 +16,7 @@
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <depend>geometry_msgs</depend>
+  <depend>marine_control</depend>
   <depend>nav_msgs</depend>
   <depend>nav2_msgs</depend>
   <depend>sensor_msgs</depend>
@@ -27,6 +28,7 @@
   <depend>tf2_sensor_msgs</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>marine_control_interfaces</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>

--- a/marine_nav_ca_safety/test/test_ca_safety_control.py
+++ b/marine_nav_ca_safety/test/test_ca_safety_control.py
@@ -1,0 +1,238 @@
+"""
+Exercise the CA-safety marine_control device-control channel (#140 / ADR-0003).
+
+`CaSafetyNode` is a plain rclcpp::Node, so the ControlServer is live as soon as
+the node starts — no lifecycle transition needed. This test asserts the wiring
+added when CA-safety became a marine_control adopter:
+
+  - The node advertises a ControlSet on `~/control/state` containing all 15 live
+    tunables, each in its declared UI group.
+  - An in-range change on `~/control/change` is applied to the bound parameter
+    and confirmed by the next state echo.
+  - The node's existing parameter validation still guards the channel: a
+    non-positive value is rejected, and a change that would violate the
+    slowdown_min <= slowdown_max ordering is rejected. In both cases the echoed
+    value is held — the fire-and-forget channel cannot push an invalid tuning
+    into the live safety brake (ADR-0003 D8.3).
+
+The numbered scenarios describe coverage, not execution order: unittest runs the
+methods alphabetically and each is self-contained.
+"""
+
+import time
+import unittest
+
+from launch import LaunchDescription
+from launch_ros.actions import Node
+import launch_testing
+import launch_testing.actions
+from marine_control_interfaces.msg import ControlItem, ControlSet, ControlValue
+import pytest
+import rclpy
+from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
+from std_msgs.msg import Header
+
+NAMESPACE = '/test_ca'
+NODE_NAME = 'ca_safety'
+STATE_TOPIC = f'{NAMESPACE}/{NODE_NAME}/control/state'
+CHANGE_TOPIC = f'{NAMESPACE}/{NODE_NAME}/control/change'
+
+EXPECTED_DEVICE_NAME = 'Collision-Avoidance Safety'
+
+# All 15 live tunables and the UI group each is bound under.
+EXPECTED_GROUPS = {
+    'ttc_time_constant': 'slowdown',
+    'slowdown_min_length': 'slowdown',
+    'slowdown_max_length': 'slowdown',
+    'slowdown_speed_floor': 'slowdown',
+    'slowdown_width': 'slowdown',
+    'stop_length': 'stop',
+    'stop_width': 'stop',
+    'stop_speed_eps': 'stop',
+    'reverse_speed': 'reverse',
+    'reverse_distance': 'reverse',
+    'reverse_duration': 'reverse',
+    'reverse_clear_debounce': 'reverse',
+    'cancel_yaw_during_reverse': 'reverse',
+    'source_timeout': 'source',
+    'publish_visualization': 'visualization',
+}
+
+# Heartbeat is 1 Hz; allow slack for discovery.
+TEST_TIMEOUT_SECONDS = 25.0
+
+# marine_control state QoS: RELIABLE + VOLATILE (ADR-0003 D5).
+_CONTROL_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.RELIABLE,
+    durability=DurabilityPolicy.VOLATILE,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=10,
+)
+
+
+@pytest.mark.launch_test
+def generate_test_description():
+    node = Node(
+        package='marine_nav_ca_safety',
+        executable='ca_safety_node',
+        name=NODE_NAME,
+        namespace=NAMESPACE,
+        output='screen',
+    )
+    return LaunchDescription([node, launch_testing.actions.ReadyToTest()])
+
+
+class TestCaSafetyControlChannel(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls.node = rclpy.create_node('ca_safety_control_test')
+        cls.latest = None
+
+        def on_state(msg: ControlSet):
+            cls.latest = msg
+
+        cls.sub = cls.node.create_subscription(
+            ControlSet, STATE_TOPIC, on_state, _CONTROL_QOS)
+        cls.change_pub = cls.node.create_publisher(
+            ControlValue, CHANGE_TOPIC, _CONTROL_QOS)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.node.destroy_node()
+        rclpy.shutdown()
+
+    def _spin_until(self, predicate, timeout=TEST_TIMEOUT_SECONDS):
+        start = time.monotonic()
+        while time.monotonic() - start < timeout:
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+            if predicate():
+                return True
+        return False
+
+    def _item(self, name):
+        if self.latest is None:
+            return None
+        for item in self.latest.items:
+            if item.name == name:
+                return item
+        return None
+
+    def _value(self, name):
+        item = self._item(name)
+        return None if item is None else float(item.value)
+
+    def _send_change(self, name, value):
+        msg = ControlValue()
+        msg.header = Header()
+        msg.name = name
+        msg.value = repr(float(value))
+        self.change_pub.publish(msg)
+
+    def _drive_to(self, name, value):
+        def predicate():
+            self._send_change(name, value)
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+            current = self._value(name)
+            return current is not None and abs(current - value) < 1e-6
+        return predicate
+
+    def test_state_advertises_all_live_tunables(self):
+        self.assertTrue(
+            self._spin_until(lambda: self.latest is not None),
+            f'no ControlSet received on {STATE_TOPIC} within '
+            f'{TEST_TIMEOUT_SECONDS}s; the ControlServer may not have been '
+            f'constructed in the node constructor.')
+
+        self.assertEqual(self.latest.device_name, EXPECTED_DEVICE_NAME)
+
+        advertised = {item.name: item for item in self.latest.items}
+        self.assertEqual(
+            set(advertised), set(EXPECTED_GROUPS),
+            'advertised controls do not match the 15 expected live tunables.')
+        for name, group in EXPECTED_GROUPS.items():
+            self.assertEqual(
+                advertised[name].group, group,
+                f'control {name!r} bound under group {advertised[name].group!r}, '
+                f'expected {group!r}.')
+        # The two bools should render as BOOL, the rest as FLOAT.
+        self.assertEqual(advertised['publish_visualization'].type, ControlItem.TYPE_BOOL)
+        self.assertEqual(advertised['cancel_yaw_during_reverse'].type, ControlItem.TYPE_BOOL)
+        self.assertEqual(advertised['stop_length'].type, ControlItem.TYPE_FLOAT)
+        self.assertEqual(advertised['stop_length'].units, 'm')
+
+    def test_in_range_change_is_applied(self):
+        # stop_length default is 5.0; drive it to 8.0.
+        self.assertTrue(
+            self._spin_until(self._drive_to('stop_length', 8.0)),
+            'in-range change to stop_length was not reflected in the state echo; '
+            'the change channel did not apply the bound parameter.')
+
+    def test_non_positive_change_is_rejected(self):
+        # Establish a known-good baseline (also proves the channel is live here).
+        self.assertTrue(self._spin_until(self._drive_to('stop_length', 6.0)))
+
+        # Request a non-positive value, then a valid sentinel. RELIABLE ordered
+        # delivery means a landed sentinel proves the bad request was delivered
+        # and processed (rejected), not dropped. Track the min echoed value: a
+        # rejected <= 0 request must never move stop_length to or below zero.
+        min_seen = 6.0
+        self._send_change('stop_length', -1.0)
+        self._send_change('stop_length', 7.0)
+
+        def sentinel_applied():
+            nonlocal min_seen
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+            current = self._value('stop_length')
+            if current is None:
+                return False
+            min_seen = min(min_seen, current)
+            return abs(current - 7.0) < 1e-6
+
+        self.assertTrue(
+            self._spin_until(sentinel_applied),
+            'sentinel change after the non-positive request never landed; cannot '
+            'confirm the bad request was delivered rather than dropped.')
+        self.assertGreater(
+            min_seen, 0.0,
+            'stop_length dropped to <= 0; a non-positive operator value reached '
+            'the live safety brake (the onSetParameters > 0 guard was bypassed).')
+
+    def test_slowdown_range_ordering_is_enforced(self):
+        # Defaults: slowdown_min_length=5, slowdown_max_length=25. Establish the
+        # baseline, then request a min above the max (must be rejected by the
+        # cross-field ordering check), then a valid sentinel min.
+        self.assertTrue(self._spin_until(self._drive_to('slowdown_min_length', 5.0)))
+
+        max_seen = 5.0
+        self._send_change('slowdown_min_length', 30.0)   # > slowdown_max_length (25)
+        self._send_change('slowdown_min_length', 6.0)    # valid sentinel
+
+        def sentinel_applied():
+            nonlocal max_seen
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+            current = self._value('slowdown_min_length')
+            if current is None:
+                return False
+            max_seen = max(max_seen, current)
+            return abs(current - 6.0) < 1e-6
+
+        self.assertTrue(
+            self._spin_until(sentinel_applied),
+            'sentinel change after the out-of-order request never landed; cannot '
+            'confirm the bad request was delivered rather than dropped.')
+        max_len = self._value('slowdown_max_length')
+        self.assertIsNotNone(max_len)
+        self.assertLessEqual(
+            max_seen, max_len,
+            f'slowdown_min_length rose to {max_seen} above slowdown_max_length '
+            f'{max_len}; the min <= max ordering guard was bypassed over the '
+            f'marine_control channel.')
+
+
+@launch_testing.post_shutdown_test()
+class TestProcessShutdown(unittest.TestCase):
+
+    def test_clean_exit(self, proc_info):
+        pass


### PR DESCRIPTION
## Summary

Wires the collision-avoidance safety node (`CaSafetyNode` in `marine_nav_ca_safety`)
into the **marine_control** device-control system so the operator can retune its
slowdown/stop/reverse geometry and timing live from the `rqt_marine_control`
panel, bridgeable boat→operator. This is the "CA tuning" adopter for the
marine_control rollout.

## What changed

- **`package.xml` / `CMakeLists.txt`** — depend on `marine_control` and link it
  into the node; `marine_control_interfaces` as a `test_depend` (the launch test
  imports it directly).
- **`ca_safety_node.h`** — construct a `marine_control::ControlServer` as the
  **last** step of the node constructor (plain `rclcpp::Node`, no lifecycle
  gating) and `bind_parameter()` all 15 already-declared live params (13 atomic
  doubles + 2 bools) with units and UI groups: **slowdown / stop / reverse /
  source / visualization**.
- **`test/test_ca_safety_control.py`** (new launch test) — asserts the node
  advertises all 15 controls in their groups, an in-range change applies, and
  **both** validation guards reject bad operator input over the channel with the
  value held: a non-positive value, and a `slowdown_min > slowdown_max` ordering
  violation. A sentinel-after-reject (RELIABLE ordered delivery) proves the bad
  request was delivered and rejected, not silently dropped.

## Safety (ADR-0003 D8.3)

Operator changes ride the base fire-and-forget channel but route through the
node's existing `onSetParameters` validation (finite, > 0, ordered slowdown
range) before `onPostSetParameters` commits to the live atomics — a bad value
cannot reach the safety brake. `cancel_yaw_during_reverse` keeps its descriptor
warning (its `false` path requires verified reverse-yaw handling), which surfaces
as the panel's help text.

## Review

Self-reviewed pre-push with two disjoint-lens adversarial passes (logic +
systemic/safety). Both cross-confirmed correct threading (single-threaded
executor → ControlServer callbacks never race the node's), validation routing,
construction-last + teardown order, and non-vacuous tests. **No must-fix
findings.** Open suggestions (see `progress.md`):

- **`FloatingPointRange` bounds (cross-confirmed, deferred for a decision):** the
  13 dynamic doubles declare no range, so the panel sees degenerate `[0,0]`
  bounds and an operator could shrink `stop_length`/widths toward ~0 — a "valid"
  value that weakens the brake. Adding per-param sane ranges would give the panel
  guardrails and reject absurd values before `onSetParameters`, but the bound
  *values* are safety-critical and deployment-sensitive — leaving them for a
  domain-informed follow-up rather than guessing.
- **Operator-confirmation handshake (D8.3):** safety-critical adopters arguably
  want a two-way ack beyond fire-and-forget + audit log; tracks with the
  marine_control confirmation follow-up.

## Pre-existing lint debt (out of scope)

This package already fails `ament_lint` on `jazzy` (cpplint header-guard style +
missing copyright headers, a whole-file uncrustify config mismatch). That is
untouched here. The new launch test is **flake8/pep257 clean** and matches the
package's no-copyright-header convention. A package-wide lint cleanup is a
separate effort.

## Out of scope

- Platform bridge routing of `~/control/state` / `~/control/change` (echoboats
  config) — follow-up.
- The Nav2 controller plugins (`marine_nav_avoidance_controller`,
  `marine_nav_crabbing_path_follower`) — no own node; separate effort.

Part of rolker/unh_marine_autonomy#140 (marine_control device control, ADR-0003).

Closes #80

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
