### PR TITLE
Wire survey obstacle-avoidance controller (AvoidanceController) into marine_control

### DIFF
--- a/.agent/work-plans/issue-82/progress.md
+++ b/.agent/work-plans/issue-82/progress.md
@@ -1,0 +1,28 @@
+---
+issue: 82
+---
+
+# Issue #82 — Wire survey obstacle-avoidance controller (AvoidanceController) into marine_control
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-27 18:46 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: approved (after addressing 1 must-fix)
+
+**Branch**: feature/issue-82 at `6154a05`
+**Mode**: pre-push
+**Depth**: Standard (reason: safety-relevant nav2 plugin, new param surface, ~420 lines)
+**Must-fix**: 1 (fixed) | **Suggestions**: 2
+**Round**: 1 | **Ship**: recommended — must-fix fixed + regression-locked; suggestions are by-design/documented.
+
+Two disjoint-lens adversarial passes. Both confirmed correct defaults parity,
+declared-vs-bound symmetry, range-rejection over the channel, lifecycle/teardown,
+topic/device uniqueness, and non-vacuous tests. Depends on marine_control PIC
+(rolker/marine_control#11) to link into the plugin .so.
+
+### Findings
+- [x] (must-fix) `_range` declared DOUBLE_ARRAY → integer-literal bounds (`[1, 10]`) threw at declare before fallback, failing bring-up. Fixed: dynamic_typing + coerce int array; regression test added. — `avoidance_controller.cpp:declareAvoidanceControlParams`
+- [ ] (suggestion, by-design) An operator can neutralize avoidance with in-range valid values (obstacle_avoidance_weight→0, max_deviation→min). The per-platform `_range` floors are the intended guard (a platform sets e.g. obstacle_avoidance_weight_range=[0.5,…] for a floor). Documented as operator authority; surfaced to Roland.
+- [ ] (suggestion, documented) bind/reset + refreshParams() coherence rely on the controller_server being single-threaded (nav2 default); a multi-threaded compose would break bind-before-spin and could interleave a one-tick mixed param set. The param-read-per-tick pattern is pre-existing; the invariant is documented in an activate() comment.
+- [ ] (deferred) package has pre-existing ament_lint debt on jazzy (cpplint header-guard/copyright, whole-file uncrustify mismatch, no copyright headers); untouched. New test is cpplint/uncrustify clean apart from the package's no-copyright-header convention.

--- a/marine_nav_avoidance_controller/CMakeLists.txt
+++ b/marine_nav_avoidance_controller/CMakeLists.txt
@@ -11,6 +11,7 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(geometry_msgs REQUIRED)
+find_package(marine_control REQUIRED)
 find_package(marine_nav_utilities REQUIRED)
 find_package(nav2_core REQUIRED)
 find_package(nav2_costmap_2d REQUIRED)
@@ -43,6 +44,7 @@ target_link_libraries(${PROJECT_NAME}
 
 ament_target_dependencies(${PROJECT_NAME}
   geometry_msgs
+  marine_control
   marine_nav_utilities
   nav2_core
   nav2_costmap_2d
@@ -81,6 +83,22 @@ if(BUILD_TESTING)
   # marine_nav_utilities (test_corridor_solver). The controller's remaining code
   # is ROS plumbing (configure/lifecycle/delegate) + costmap sampling, validated
   # in sim + on-water per the #59 acceptance criteria.
+
+  # marine_control device-control wiring (unh_marine_autonomy#140 / ADR-0003):
+  # exercises the real declareAvoidanceControlParams / bindAvoidanceControls
+  # helpers against a LifecycleNode + ControlServer (no nav2 bring-up). Verifies
+  # the 10 tunables are advertised with their ranges/groups, a platform _range
+  # override is honoured, an in-range change applies, and an out-of-range change
+  # is rejected by the FloatingPointRange over the marine_control channel.
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(test_avoidance_control test/test_avoidance_control.cpp)
+  target_link_libraries(test_avoidance_control ${PROJECT_NAME})
+  ament_target_dependencies(test_avoidance_control
+    marine_control
+    marine_control_interfaces
+    rclcpp
+    rclcpp_lifecycle
+  )
 endif()
 
 ament_package()

--- a/marine_nav_avoidance_controller/include/marine_nav_avoidance_controller/avoidance_controller.h
+++ b/marine_nav_avoidance_controller/include/marine_nav_avoidance_controller/avoidance_controller.h
@@ -18,10 +18,24 @@
 #include "tf2_ros/buffer.h"
 #include "visualization_msgs/msg/marker_array.hpp"
 
+#include "marine_control/control_server.hpp"
 #include "marine_nav_utilities/corridor_solver.h"
 
 namespace marine_nav_avoidance_controller
 {
+
+// Declare the live avoidance tunables on `node` under `<name>.*`, each with a
+// FloatingPointRange descriptor whose bounds come from a startup-only companion
+// parameter `<name>.<tunable>_range` ([min, max] double array) so platforms can
+// customise them. A malformed range falls back to a built-in default (warned).
+// Free function so the gtest can exercise the real declaration logic without a
+// full nav2 controller_server bring-up.
+void declareAvoidanceControlParams(
+  const rclcpp_lifecycle::LifecycleNode::SharedPtr & node, const std::string & name);
+
+// Bind the live avoidance tunables (declared by declareAvoidanceControlParams)
+// to `server` as marine_control controls, with their units and UI groups.
+void bindAvoidanceControls(marine_control::ControlServer & server, const std::string & name);
 
 // A decorator nav2_core::Controller that reshapes the followed path around
 // obstacles before delegating to an inner ("primary") controller. The inner
@@ -119,6 +133,13 @@ protected:
   // avoiding->clear transition that was_avoiding_ tracks.
   rclcpp_lifecycle::LifecyclePublisher<visualization_msgs::msg::MarkerArray>::SharedPtr viz_pub_;
   bool was_avoiding_{false};
+
+  // Boat-side marine_control server, attached to the parent controller_server
+  // node. Publishes the live tunables as bridgeable controls and applies
+  // operator changes via the validated parameter path (FloatingPointRange).
+  // Lives only while the controller is active (created in activate, reset in
+  // deactivate/cleanup); per-plugin topics avoid collisions on the shared node.
+  std::shared_ptr<marine_control::ControlServer> control_server_;
 };
 
 }  // namespace marine_nav_avoidance_controller

--- a/marine_nav_avoidance_controller/package.xml
+++ b/marine_nav_avoidance_controller/package.xml
@@ -15,6 +15,7 @@
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <depend>geometry_msgs</depend>
+  <depend>marine_control</depend>
   <depend>marine_nav_utilities</depend>
   <depend>nav2_core</depend>
   <depend>nav2_costmap_2d</depend>
@@ -29,6 +30,7 @@
   <depend>visualization_msgs</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>marine_control_interfaces</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/marine_nav_avoidance_controller/src/avoidance_controller.cpp
+++ b/marine_nav_avoidance_controller/src/avoidance_controller.cpp
@@ -17,6 +17,8 @@
 #include "nav2_costmap_2d/cost_values.hpp"
 #include "nav2_util/node_utils.hpp"
 #include "pluginlib/class_list_macros.hpp"
+#include "rcl_interfaces/msg/floating_point_range.hpp"
+#include "rcl_interfaces/msg/parameter_descriptor.hpp"
 
 namespace marine_nav_avoidance_controller
 {
@@ -113,7 +115,100 @@ visualization_msgs::msg::MarkerArray buildAvoidanceMarkers(
 
   return arr;
 }
+
+// Single source of truth for the live operator-tunable parameters: the value
+// default, the built-in fallback range [min, max], panel units, UI group, and
+// help text. Both declareAvoidanceControlParams (declares them with descriptors)
+// and bindAvoidanceControls (binds them to the marine_control server) iterate
+// this, so a parameter is never declared and bound out of sync.
+struct AvoidanceTunable
+{
+  const char * suffix;
+  double default_value;
+  double default_min;
+  double default_max;
+  const char * units;
+  const char * group;
+  const char * description;
+};
+
+constexpr AvoidanceTunable kTunables[] = {
+  {"max_deviation", 6.0, 0.1, 100.0, "m", "geometry",
+    "Corridor half-width and the give-up bound (m)."},
+  {"along_track_spacing", 2.0, 0.1, 50.0, "m", "geometry",
+    "Station spacing along the line (m)."},
+  {"lateral_resolution", 0.5, 0.05, 10.0, "m", "geometry",
+    "Cross-track search resolution (m)."},
+  {"max_lateral_change", 1.0, 0.01, 50.0, "m", "geometry",
+    "Max cross-track change between stations (m)."},
+  {"anchor_behind_distance", 4.0, 0.0, 100.0, "m", "geometry",
+    "Distance behind the boat to anchor the detour entry (m; 0 = at boat)."},
+  {"line_following_weight", 1.0, 0.0, 1000.0, "", "weights",
+    "Higher = hug the nominal line."},
+  {"obstacle_avoidance_weight", 1.0, 0.0, 1000.0, "", "weights",
+    "Higher = deviate more around obstacles."},
+  {"smoothness_weight", 2.0, 0.0, 1000.0, "", "weights",
+    "Higher = smoother detours."},
+  {"chatter_damping_weight", 0.0, 0.0, 1000.0, "", "weights",
+    "Higher = steadier tick-to-tick."},
+  {"avoid_speed", 0.0, 0.0, 20.0, "m/s", "speed",
+    "Inner speed limit while deviating (m/s; 0 = off)."},
+};
 }  // namespace
+
+void declareAvoidanceControlParams(
+  const rclcpp_lifecycle::LifecycleNode::SharedPtr & node, const std::string & name)
+{
+  for (const auto & t : kTunables) {
+    const std::string base = name + "." + t.suffix;
+
+    // Startup-only bound parameter: [min, max] for the FloatingPointRange.
+    // Platforms override it per deployment; a malformed value (wrong size,
+    // non-finite, or min >= max) is rejected with a warning and the built-in
+    // default range is used instead.
+    nav2_util::declare_parameter_if_not_declared(
+      node, base + "_range",
+      rclcpp::ParameterValue(std::vector<double>{t.default_min, t.default_max}));
+    const std::vector<double> range = node->get_parameter(base + "_range").as_double_array();
+
+    double rmin = t.default_min;
+    double rmax = t.default_max;
+    if (range.size() == 2 && std::isfinite(range[0]) && std::isfinite(range[1]) &&
+      range[0] < range[1])
+    {
+      rmin = range[0];
+      rmax = range[1];
+    } else {
+      RCLCPP_WARN(
+        node->get_logger(),
+        "%s: malformed '%s_range' (need [min, max] with min < max); using "
+        "default [%g, %g].", name.c_str(), t.suffix, t.default_min, t.default_max);
+    }
+
+    rcl_interfaces::msg::FloatingPointRange fp_range;
+    fp_range.from_value = rmin;
+    fp_range.to_value = rmax;
+    fp_range.step = 0.0;  // continuous
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.description = t.description;
+    descriptor.floating_point_range.push_back(fp_range);
+
+    // Clamp the built-in default into the (possibly platform-narrowed) range so
+    // declaring it never trips rclcpp's initial-value range validation. A
+    // platform that overrides the *value* out of its own range fails loudly at
+    // declare time, which is the correct signal for a self-contradictory config.
+    const double initial = std::clamp(t.default_value, rmin, rmax);
+    nav2_util::declare_parameter_if_not_declared(
+      node, base, rclcpp::ParameterValue(initial), descriptor);
+  }
+}
+
+void bindAvoidanceControls(marine_control::ControlServer & server, const std::string & name)
+{
+  for (const auto & t : kTunables) {
+    server.bind_parameter(name + "." + t.suffix, t.units, t.group);
+  }
+}
 
 void AvoidanceController::configure(
   const rclcpp_lifecycle::LifecycleNode::WeakPtr & parent,
@@ -133,16 +228,11 @@ void AvoidanceController::configure(
       nav2_util::declare_parameter_if_not_declared(node, name_ + "." + suffix, value);
     };
   declare("primary_controller", rclcpp::ParameterValue(std::string("")));
-  declare("max_deviation", rclcpp::ParameterValue(6.0));
-  declare("along_track_spacing", rclcpp::ParameterValue(2.0));
-  declare("lateral_resolution", rclcpp::ParameterValue(0.5));
-  declare("line_following_weight", rclcpp::ParameterValue(1.0));
-  declare("obstacle_avoidance_weight", rclcpp::ParameterValue(1.0));
-  declare("smoothness_weight", rclcpp::ParameterValue(2.0));
-  declare("chatter_damping_weight", rclcpp::ParameterValue(0.0));
-  declare("max_lateral_change", rclcpp::ParameterValue(1.0));
-  declare("anchor_behind_distance", rclcpp::ParameterValue(4.0));
-  declare("avoid_speed", rclcpp::ParameterValue(0.0));
+
+  // The live operator-tunable parameters are declared with FloatingPointRange
+  // descriptors whose bounds are platform-customisable via `<name>.<t>_range`
+  // startup params; this is also what the marine_control panel binds to.
+  declareAvoidanceControlParams(node, name_);
 
   const std::string primary_type =
     node->get_parameter(name_ + ".primary_controller").as_string();
@@ -180,6 +270,7 @@ void AvoidanceController::cleanup()
     primary_->cleanup();
   }
   viz_pub_.reset();
+  control_server_.reset();
 }
 
 void AvoidanceController::activate()
@@ -189,6 +280,24 @@ void AvoidanceController::activate()
   }
   if (viz_pub_) {
     viz_pub_->on_activate();
+  }
+
+  // Expose the live tunables on the marine_control panel while the controller is
+  // active (reset in deactivate/cleanup). The server attaches to the parent
+  // controller_server node; per-plugin topics keep multiple controllers from
+  // colliding on it. bind_parameter runs here, before any server callback can
+  // dispatch: the controller_server is single-threaded (nav2 default), so
+  // activate() owns the executor thread for the duration of this call, which
+  // satisfies the control_server.hpp bind-before-spin contract. Composing the
+  // controller_server into a multi-threaded executor would void that — don't,
+  // without revisiting the binding-table locking.
+  if (auto node = node_.lock()) {
+    marine_control::ControlServerOptions options;
+    options.device_name = "Survey Obstacle Avoidance (" + name_ + ")";
+    options.state_topic = "~/control/" + name_ + "/state";
+    options.change_topic = "~/control/" + name_ + "/change";
+    control_server_ = std::make_shared<marine_control::ControlServer>(node.get(), options);
+    bindAvoidanceControls(*control_server_, name_);
   }
 }
 
@@ -206,6 +315,9 @@ void AvoidanceController::deactivate()
   if (viz_pub_) {
     viz_pub_->on_deactivate();
   }
+  // Tear down the control channel so the panel stops advertising for an inactive
+  // controller (and the heartbeat/change sub are gone before re-activation).
+  control_server_.reset();
 }
 
 void AvoidanceController::setPlan(const nav_msgs::msg::Path & path)

--- a/marine_nav_avoidance_controller/src/avoidance_controller.cpp
+++ b/marine_nav_avoidance_controller/src/avoidance_controller.cpp
@@ -163,13 +163,25 @@ void declareAvoidanceControlParams(
     const std::string base = name + "." + t.suffix;
 
     // Startup-only bound parameter: [min, max] for the FloatingPointRange.
-    // Platforms override it per deployment; a malformed value (wrong size,
+    // Platforms override it per deployment; a malformed value (wrong size/type,
     // non-finite, or min >= max) is rejected with a warning and the built-in
-    // default range is used instead.
+    // default range is used instead. Declared dynamic_typing so a platform may
+    // write the bounds as an integer array (`[1, 10]`, the natural YAML form)
+    // without a type-mismatch throw at declare; integer arrays are coerced below.
+    rcl_interfaces::msg::ParameterDescriptor range_desc;
+    range_desc.dynamic_typing = true;
     nav2_util::declare_parameter_if_not_declared(
       node, base + "_range",
-      rclcpp::ParameterValue(std::vector<double>{t.default_min, t.default_max}));
-    const std::vector<double> range = node->get_parameter(base + "_range").as_double_array();
+      rclcpp::ParameterValue(std::vector<double>{t.default_min, t.default_max}), range_desc);
+
+    std::vector<double> range;
+    const auto range_value = node->get_parameter(base + "_range").get_parameter_value();
+    if (range_value.get_type() == rclcpp::ParameterType::PARAMETER_DOUBLE_ARRAY) {
+      range = range_value.get<std::vector<double>>();
+    } else if (range_value.get_type() == rclcpp::ParameterType::PARAMETER_INTEGER_ARRAY) {
+      const auto ints = range_value.get<std::vector<int64_t>>();
+      range.assign(ints.begin(), ints.end());
+    }  // any other type leaves `range` empty -> malformed fallback below
 
     double rmin = t.default_min;
     double rmax = t.default_max;

--- a/marine_nav_avoidance_controller/test/test_avoidance_control.cpp
+++ b/marine_nav_avoidance_controller/test/test_avoidance_control.cpp
@@ -1,0 +1,258 @@
+// Unit test for the marine_control device-control wiring of AvoidanceController
+// (unh_marine_autonomy#140 / ADR-0003).
+//
+// AvoidanceController is a Nav2 controller plugin, so its full configure() needs
+// a controller_server + costmap + inner controller. This test instead exercises
+// the extracted declareAvoidanceControlParams / bindAvoidanceControls helpers —
+// the actual code the plugin runs — against a bare LifecycleNode and a real
+// ControlServer, with no nav2 bring-up. It checks that:
+//   - all 10 tunables are advertised with their default FloatingPointRange,
+//     UI group, and units;
+//   - a platform `<name>.<t>_range` startup override is honoured;
+//   - an in-range change over the marine_control channel is applied; and
+//   - an out-of-range change is rejected by the range, with the value held
+//     (a sentinel sent after it confirms the bad change was delivered, not
+//     dropped).
+
+#include <chrono>
+#include <cmath>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+
+#include "marine_control/control_server.hpp"
+#include "marine_control_interfaces/msg/control_item.hpp"
+#include "marine_control_interfaces/msg/control_set.hpp"
+#include "marine_control_interfaces/msg/control_value.hpp"
+
+#include "marine_nav_avoidance_controller/avoidance_controller.h"
+
+using marine_control_interfaces::msg::ControlItem;
+using marine_control_interfaces::msg::ControlSet;
+using marine_control_interfaces::msg::ControlValue;
+using std::chrono::milliseconds;
+
+namespace
+{
+constexpr char kName[] = "FollowPath";
+constexpr char kStateTopic[] = "~/control/FollowPath/state";
+constexpr char kChangeTopic[] = "~/control/FollowPath/change";
+
+const ControlItem * findItem(const ControlSet & set, const std::string & name)
+{
+  for (const auto & item : set.items) {
+    if (item.name == name) {
+      return &item;
+    }
+  }
+  return nullptr;
+}
+
+rclcpp::QoS controlQos()
+{
+  rclcpp::QoS qos(rclcpp::KeepLast(10));
+  qos.reliable();
+  qos.durability_volatile();
+  return qos;
+}
+
+// Initialise rclcpp once for the whole program, before any fixture is
+// constructed — a fixture member executor would otherwise build its guard
+// condition against an invalid context if init ran per-test in SetUp().
+class RclcppEnvironment : public ::testing::Environment
+{
+public:
+  void SetUp() override {rclcpp::init(0, nullptr);}
+  void TearDown() override {rclcpp::shutdown();}
+};
+[[maybe_unused]] ::testing::Environment * const kRclcppEnv =
+  ::testing::AddGlobalTestEnvironment(new RclcppEnvironment);
+}  // namespace
+
+class AvoidanceControlTest : public ::testing::Test
+{
+protected:
+  // Make a controller_server stand-in node, optionally with parameter overrides
+  // (used to simulate a platform setting a custom <name>.<t>_range at startup).
+  rclcpp_lifecycle::LifecycleNode::SharedPtr makeNode(
+    const std::vector<rclcpp::Parameter> & overrides = {})
+  {
+    rclcpp::NodeOptions options;
+    if (!overrides.empty()) {
+      options.parameter_overrides(overrides);
+    }
+    return std::make_shared<rclcpp_lifecycle::LifecycleNode>("ctrl_srv", options);
+  }
+};
+
+TEST_F(AvoidanceControlTest, AdvertisesAllTunablesWithRangesAndGroups)
+{
+  auto node = makeNode();
+  marine_nav_avoidance_controller::declareAvoidanceControlParams(node, kName);
+
+  marine_control::ControlServerOptions opts;
+  opts.device_name = "Survey Obstacle Avoidance";
+  opts.state_topic = kStateTopic;
+  opts.change_topic = kChangeTopic;
+  marine_control::ControlServer server(node.get(), opts);
+  marine_nav_avoidance_controller::bindAvoidanceControls(server, kName);
+
+  const ControlSet set = server.build_control_set();
+  ASSERT_EQ(set.items.size(), 10u);
+
+  // Spot-check representative controls across all three groups.
+  const auto * max_dev = findItem(set, "FollowPath.max_deviation");
+  ASSERT_NE(max_dev, nullptr);
+  EXPECT_EQ(max_dev->type, ControlItem::TYPE_FLOAT);
+  EXPECT_EQ(max_dev->group, "geometry");
+  EXPECT_EQ(max_dev->units, "m");
+  EXPECT_DOUBLE_EQ(max_dev->min_value, 0.1);
+  EXPECT_DOUBLE_EQ(max_dev->max_value, 100.0);
+
+  const auto * weight = findItem(set, "FollowPath.obstacle_avoidance_weight");
+  ASSERT_NE(weight, nullptr);
+  EXPECT_EQ(weight->group, "weights");
+  EXPECT_DOUBLE_EQ(weight->min_value, 0.0);
+  EXPECT_DOUBLE_EQ(weight->max_value, 1000.0);
+
+  const auto * speed = findItem(set, "FollowPath.avoid_speed");
+  ASSERT_NE(speed, nullptr);
+  EXPECT_EQ(speed->group, "speed");
+  EXPECT_EQ(speed->units, "m/s");
+}
+
+TEST_F(AvoidanceControlTest, PlatformRangeOverrideIsHonoured)
+{
+  // Platform narrows max_deviation's bounds at startup.
+  auto node = makeNode(
+    {rclcpp::Parameter("FollowPath.max_deviation_range", std::vector<double>{1.0, 10.0})});
+  marine_nav_avoidance_controller::declareAvoidanceControlParams(node, kName);
+
+  marine_control::ControlServer server(node.get());  // default topics fine here
+  marine_nav_avoidance_controller::bindAvoidanceControls(server, kName);
+
+  const auto * max_dev = findItem(server.build_control_set(), "FollowPath.max_deviation");
+  ASSERT_NE(max_dev, nullptr);
+  EXPECT_DOUBLE_EQ(max_dev->min_value, 1.0);
+  EXPECT_DOUBLE_EQ(max_dev->max_value, 10.0);
+}
+
+TEST_F(AvoidanceControlTest, MalformedRangeFallsBackToDefault)
+{
+  // min >= max is malformed -> the built-in default range is used.
+  auto node = makeNode(
+    {rclcpp::Parameter("FollowPath.max_deviation_range", std::vector<double>{50.0, 5.0})});
+  marine_nav_avoidance_controller::declareAvoidanceControlParams(node, kName);
+
+  marine_control::ControlServer server(node.get());
+  marine_nav_avoidance_controller::bindAvoidanceControls(server, kName);
+
+  const auto * max_dev = findItem(server.build_control_set(), "FollowPath.max_deviation");
+  ASSERT_NE(max_dev, nullptr);
+  EXPECT_DOUBLE_EQ(max_dev->min_value, 0.1);
+  EXPECT_DOUBLE_EQ(max_dev->max_value, 100.0);
+}
+
+class AvoidanceControlChannelTest : public AvoidanceControlTest
+{
+protected:
+  void buildServerAndClient()
+  {
+    node_ = makeNode();
+    marine_nav_avoidance_controller::declareAvoidanceControlParams(node_, kName);
+    marine_control::ControlServerOptions opts;
+    opts.state_topic = kStateTopic;
+    opts.change_topic = kChangeTopic;
+    server_ = std::make_unique<marine_control::ControlServer>(node_.get(), opts);
+    marine_nav_avoidance_controller::bindAvoidanceControls(*server_, kName);
+
+    client_ = std::make_shared<rclcpp::Node>("test_client");
+    change_pub_ = client_->create_publisher<ControlValue>(
+      "/ctrl_srv/control/FollowPath/change", controlQos());
+
+    exec_.add_node(node_->get_node_base_interface());
+    exec_.add_node(client_);
+  }
+
+  void sendChange(const std::string & name, double value)
+  {
+    ControlValue msg;
+    msg.name = name;
+    msg.value = std::to_string(value);
+    change_pub_->publish(msg);
+  }
+
+  double paramValue(const std::string & suffix)
+  {
+    return node_->get_parameter(std::string(kName) + "." + suffix).as_double();
+  }
+
+  // Spin both nodes until `predicate()` holds or the timeout elapses.
+  bool spinUntil(std::function<bool()> predicate, milliseconds timeout = milliseconds(2000))
+  {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+      exec_.spin_some();
+      if (predicate()) {
+        return true;
+      }
+      rclcpp::sleep_for(milliseconds(10));
+    }
+    return predicate();
+  }
+
+  rclcpp_lifecycle::LifecycleNode::SharedPtr node_;
+  std::unique_ptr<marine_control::ControlServer> server_;
+  rclcpp::Node::SharedPtr client_;
+  rclcpp::Publisher<ControlValue>::SharedPtr change_pub_;
+  rclcpp::executors::SingleThreadedExecutor exec_;
+};
+
+TEST_F(AvoidanceControlChannelTest, InRangeChangeIsApplied)
+{
+  buildServerAndClient();
+  EXPECT_DOUBLE_EQ(paramValue("max_deviation"), 6.0);  // default
+
+  ASSERT_TRUE(
+    spinUntil(
+      [this] {
+        sendChange("FollowPath.max_deviation", 8.0);
+        return std::abs(paramValue("max_deviation") - 8.0) < 1e-9;
+      }))
+    << "in-range change to max_deviation was not applied over the channel";
+}
+
+TEST_F(AvoidanceControlChannelTest, OutOfRangeChangeIsRejected)
+{
+  buildServerAndClient();
+
+  // Drive to a known in-range baseline first.
+  ASSERT_TRUE(
+    spinUntil(
+      [this] {
+        sendChange("FollowPath.max_deviation", 8.0);
+        return std::abs(paramValue("max_deviation") - 8.0) < 1e-9;
+      }));
+
+  // Request an out-of-range value (default max is 100), then an in-range
+  // sentinel. RELIABLE ordered delivery means a landed sentinel proves the bad
+  // change was delivered and rejected, not dropped.
+  sendChange("FollowPath.max_deviation", 999.0);
+  ASSERT_TRUE(
+    spinUntil(
+      [this] {
+        sendChange("FollowPath.max_deviation", 50.0);
+        return std::abs(paramValue("max_deviation") - 50.0) < 1e-9;
+      }))
+    << "sentinel after the out-of-range change never landed";
+
+  // The out-of-range value must never have taken effect (cap held at 100).
+  EXPECT_LE(paramValue("max_deviation"), 100.0);
+  EXPECT_DOUBLE_EQ(paramValue("max_deviation"), 50.0);
+}

--- a/marine_nav_avoidance_controller/test/test_avoidance_control.cpp
+++ b/marine_nav_avoidance_controller/test/test_avoidance_control.cpp
@@ -16,6 +16,7 @@
 
 #include <chrono>
 #include <cmath>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <string>
@@ -135,6 +136,24 @@ TEST_F(AvoidanceControlTest, PlatformRangeOverrideIsHonoured)
   marine_nav_avoidance_controller::declareAvoidanceControlParams(node, kName);
 
   marine_control::ControlServer server(node.get());  // default topics fine here
+  marine_nav_avoidance_controller::bindAvoidanceControls(server, kName);
+
+  const auto * max_dev = findItem(server.build_control_set(), "FollowPath.max_deviation");
+  ASSERT_NE(max_dev, nullptr);
+  EXPECT_DOUBLE_EQ(max_dev->min_value, 1.0);
+  EXPECT_DOUBLE_EQ(max_dev->max_value, 10.0);
+}
+
+TEST_F(AvoidanceControlTest, IntegerRangeOverrideIsAcceptedAndCoerced)
+{
+  // A platform may write the bounds as integers (`[1, 10]`, the natural YAML
+  // form). They must be accepted and coerced to doubles, not rejected with a
+  // parameter-type-mismatch throw that would fail controller bring-up.
+  auto node = makeNode(
+    {rclcpp::Parameter("FollowPath.max_deviation_range", std::vector<int64_t>{1, 10})});
+  marine_nav_avoidance_controller::declareAvoidanceControlParams(node, kName);
+
+  marine_control::ControlServer server(node.get());
   marine_nav_avoidance_controller::bindAvoidanceControls(server, kName);
 
   const auto * max_dev = findItem(server.build_control_set(), "FollowPath.max_deviation");


### PR DESCRIPTION
## Summary

Wires the survey-path obstacle-avoidance controller
(`marine_nav_avoidance_controller::AvoidanceController`) into the **marine_control**
device-control system so the operator can retune the corridor-solve weights and
geometry live from the `rqt_marine_control` panel, bridgeable boat→operator. This
is the path-reshaping half of the CA tuning surface (the velocity brake
`CaSafetyNode` is #80 / PR #81).

> **Depends on rolker/marine_control#11** — the marine_control C++ library must be
> built PIC to link into this plugin `.so`. Merge that first.

## What changed

- **Plugin attachment.** `AvoidanceController` is a Nav2 controller *plugin*, not a
  node, so the `ControlServer` attaches to the parent `controller_server`
  lifecycle node, binds the params by their full `<name>.*` names, and uses
  **per-plugin topics** (`~/control/<name>/state|change`) to avoid collisions on
  that shared node. Created in `activate()`, reset in `deactivate()`/`cleanup()`
  so the panel is live only while the controller is active.
- **Validation via platform-customisable ranges.** The plugin had no parameter
  validation. The 10 live double tunables now get `FloatingPointRange`
  descriptors whose bounds come from **startup-only** companion params
  `<name>.<tunable>_range: [min, max]` so each platform customises them. This
  gives the panel real slider bounds and makes rclcpp reject out-of-range
  operator input before it reaches the corridor solver. Bounds may be written as
  integer or float arrays; a malformed range warns and falls back to a built-in
  default. Groups: **geometry / weights / speed** (`primary_controller`, a
  construction-time string, is not exposed).
- **Testable helpers.** Declaration + binding live in free helpers
  (`declareAvoidanceControlParams` / `bindAvoidanceControls`) so a gtest
  exercises the real logic against a `LifecycleNode` + `ControlServer` without a
  nav2 bring-up. **6 tests, 0 failures:** advertise-with-ranges/groups, platform
  `_range` override honoured, integer-array bounds coerced, malformed range
  falls back, in-range change applied, out-of-range change rejected (value held).

## Threading

The `ControlServer` bind-before-spin / destroy-when-not-spinning contract holds
because `activate()`/`deactivate()` run on the `controller_server`'s
single-threaded executor (nav2 default), documented in an `activate()` comment. A
multi-threaded compose would void it — flagged in-code.

## Review

Self-reviewed pre-push, two disjoint-lens adversarial passes. **1 must-fix, fixed
+ regression-locked:** integer-literal `_range` bounds (`[1, 10]`) threw at
declare before the fallback could run — now declared `dynamic_typing` and
coerced. Open suggestions (see `progress.md`):

- **Operator can neutralize avoidance with in-range valid values**
  (`obstacle_avoidance_weight → 0`, `max_deviation → min`). By design the
  per-platform `_range` floors are the guard (a platform sets
  `obstacle_avoidance_weight_range = [0.5, …]` if it wants a floor). **Your
  call** whether the avoidance-critical knobs should ship with a non-zero default
  floor — happy to follow up.
- The single-threaded-executor invariant is enforced by documentation, not code.

## Pre-existing lint debt (out of scope)

`marine_nav_avoidance_controller` already fails `ament_lint` on `jazzy` (cpplint
header-guard/copyright, a whole-file uncrustify config mismatch, no copyright
headers). Untouched. The new test is cpplint/uncrustify clean apart from matching
the package's no-copyright-header convention.

## Out of scope

- Platform bridge routing of the control topics (echoboats config) — follow-up.
- The inner `CrabbingPathFollower` controller's own params — separate effort.

Part of rolker/unh_marine_autonomy#140 (marine_control device control, ADR-0003).

Closes #82

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
