### PR TITLE
CrabbingPathFollower: anticipatory turn slowdown from path curvature (#89)

### DIFF
--- a/.agent/work-plans/issue-89/plan.md
+++ b/.agent/work-plans/issue-89/plan.md
@@ -140,9 +140,27 @@ follows the same pattern as `turnSpeedFactor` (#87):
 | `path_geometry.hpp` (new functions) | `test_curvature_speed_factor.cpp` unit tests; CMakeLists.txt | Yes |
 | Control count doc comments ("twelve controls") | Update to "thirteen" in `test_crabbing_control.cpp` header | Yes |
 
+## Implementation Deviations (from Plan Review, both mandatory)
+
+- **First circumfit point (Plan Review sug 1).** Step 7 originally used
+  `pose_in_plan.pose.position` (the boat's raw actual position). Implemented
+  instead with the **along-track on-path projection** as the first fit point:
+  `lookaheadPoint(poses, current_segment_, progress, 0.0)` — walking 0 m forward
+  yields the projected foot on the current segment (the point the controller
+  tracks from). The half- and full-lookahead points are the other two. All three
+  are path-referenced, so curvature is a pure property of the path and
+  cross-track error (wind/current) cannot inflate it and double-count with the
+  crab-angle regulator. A code comment at the regulation site states this.
+- **Coincident-point test (Plan Review sug 2).** Added
+  `CircumscribedRadius.CoincidentPointsAreInfinite`, covering both all-three
+  coincident and the near-goal half==full==goal (two-coincident) case → R = ∞ →
+  factor 1.0. The curvature test file has 9 cases (was planned as 8).
+- **DEBUG log.** The turn-speed regulation log line now prints `turn_factor`,
+  `curvature_factor`, and `combined_factor` (not just the single factor).
+
 ## Open Questions
 
-- [ ] No open questions — plan is review-plan-ready.
+- [x] No open questions — plan is review-plan-ready.
 
 ## Estimated Scope
 

--- a/.agent/work-plans/issue-89/plan.md
+++ b/.agent/work-plans/issue-89/plan.md
@@ -1,0 +1,149 @@
+# Plan: Anticipatory speed regulation via path curvature
+
+## Issue
+
+https://github.com/rolker/unh_marine_navigation/issues/89
+
+## Context
+
+Issue #87 (PR #88, merged) added **reactive** turn-speed regulation: the boat
+slows in proportion to the crab angle it is holding. This is inherently a beat
+late — by the time the PID commands a large crab angle, the boat is already
+committed into the turn at speed.
+
+This issue adds the **anticipatory** half: a curvature-based speed cap that slows
+the boat *before* the turn apex by looking ahead on the path geometry. The two
+compose via `min()` so both regimes apply simultaneously.
+
+The implementation lives entirely in `marine_nav_crabbing_path_follower` and
+follows the same pattern as `turnSpeedFactor` (#87):
+
+- **Algorithm**: 3-point circumscribed-circle fit using the boat's current plan
+  position, a half-lookahead point, and the full-lookahead point (reuses the
+  existing `lookaheadPoint()` machinery). Chosen over heading-change-per-arc-length
+  because the circumfit degeneracy case (collinear → R = ∞ → factor 1.0) is direct
+  and requires no arc-length measure on a piecewise-linear path.
+- **Param**: `turn_speed_curvature_min_radius` (not `turn_curvature_min_radius`),
+  units m, default 0.0 (disabled), group `speed` — naming follows the existing
+  `turn_speed_*` namespace (review-issue recommendation).
+- **Floor**: reuses `turn_speed_min_factor_` (no new floor param) — since the
+  two regulators already share a `min()` composition, a single floor is simpler
+  and avoids an operator tuning two separate minimums for what is effectively
+  one "slowest I'm willing to go in a turn" knob.
+- **Disabled** when `turn_speed_curvature_min_radius = 0.0` OR when lookahead
+  is disabled (`lookahead_distance = 0`, `lookahead_time = 0`) — factor returns
+  1.0 in both cases, a clean no-op that changes no existing behavior.
+
+## Approach
+
+1. **Add `circumscribedRadius()` to `path_geometry.hpp`** — pure inline function
+   taking 3 `geometry_msgs::msg::Point` args. Returns `std::numeric_limits<double>::infinity()`
+   for degenerate inputs (collinear, zero-area, fewer than 3 distinct points, NaN
+   coordinates). Formula: R = |AB|·|BC|·|CA| / (4·|area|) where area is the
+   signed area of the triangle.
+
+2. **Add `curvatureSpeedFactor()` to `path_geometry.hpp`** — pure inline function
+   `(double radius, double min_radius, double min_factor) → double`. Contract:
+   - `min_radius <= 0` → returns 1.0 (disabled).
+   - `radius` non-finite or ≥ `min_radius` → returns 1.0 (straight/gentle).
+   - Otherwise: `clamp(radius / min_radius, min_factor, 1.0)`.
+   A tight turn (R < R_min) yields a factor < 1 that slows the boat; R ≥ R_min
+   (a gentle bend) yields 1.0, leaving speed untouched.
+
+3. **Add `turn_speed_curvature_min_radius_` atomic to `crabbing_path_follower.h`**
+   — `std::atomic<double>`, default 0.0, with the same doc-comment style as
+   `turn_speed_max_crab_deg_`.
+
+4. **Add one `kTunables[]` entry in `crabbing_path_follower.cpp`** —
+   `{"turn_speed_curvature_min_radius", 0.0, 0.0, 200.0, "m", "speed", "..."}`.
+   Picked up automatically by `declareCrabbingControlParams` / `bindCrabbingControls`,
+   growing the control count from 12 to 13.
+
+5. **Add `read_validated` call in `configure()`** — same pattern as
+   `turn_speed_max_crab_deg_`, `lo=0.0, exclusive_lo=false`.
+
+6. **Add callback branch in the on-set-parameters callback** — `>= 0.0` lower
+   bound (0.0 = disabled is valid), no upper bound (wide open, operator-settable).
+
+7. **Apply curvature factor in `computeVelocityCommands()`**:
+   - Hoist `la_point` out of the existing `if (lookahead > 0.0)` block so it is
+     in scope at the regulation site.
+   - At the turn-speed regulation site (immediately before the `cos_crab`
+     division, after the trajectory-speed rederivation block), compute:
+     ```
+     curvature_factor = 1.0
+     if lookahead > 0 and curvature_min_radius > 0:
+       half_la = lookaheadPoint(..., lookahead / 2)
+       R = circumscribedRadius(pose_in_plan.pose.position, half_la, la_point)
+       curvature_factor = curvatureSpeedFactor(R, curvature_min_radius, turn_min_factor)
+     combined_factor = min(turn_factor, curvature_factor)
+     regulated_target_speed = target_speed * combined_factor
+     ```
+   - Snapshot `turn_speed_curvature_min_radius_` atomic once (same tear-free
+     pattern as lookahead_* and gain-schedule atomics).
+   - Extend the existing DEBUG log to also print `curvature_factor` and `combined_factor`.
+
+8. **Add `test/test_curvature_speed_factor.cpp`** — unit tests using
+   `circumscribedRadius` and `curvatureSpeedFactor` directly:
+   - Straight path (collinear 3 pts) → R = ∞ → factor 1.0.
+   - Constant-radius arc (equilateral triangle inscribed in a known circle) →
+     expected factor.
+   - Degenerate: NaN coordinate in a point → R = ∞ → factor 1.0.
+   - Degenerate: `min_radius = 0` → factor 1.0.
+   - `R >= min_radius` (gentle bend) → factor 1.0.
+   - `R < min_radius` (tight turn) → factor R/min_radius, floored at min_factor.
+   - Floor respected: tiny R → min_factor not underrun.
+   - Symmetric: no dependence on point ordering that would break (regression guard).
+
+9. **Update `CMakeLists.txt`** — add `ament_add_gtest(test_curvature_speed_factor ...)` target wired like the sibling `test_turn_speed_factor` target.
+
+10. **Update `test/test_crabbing_control.cpp`** — bump size assertions 12u → 13u
+    (both the advertise test and the wrapped-namespace test), update the "twelve
+    controls" doc comment, and add group/units/range assertions for the new
+    curvature control (`speed` group, `m` units, range `[0, 200]`).
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `include/marine_nav_crabbing_path_follower/path_geometry.hpp` | Add `circumscribedRadius()` and `curvatureSpeedFactor()` |
+| `include/marine_nav_crabbing_path_follower/crabbing_path_follower.h` | Add `turn_speed_curvature_min_radius_` atomic member + doc comment |
+| `src/crabbing_path_follower.cpp` | Add `kTunables[]` entry; `read_validated`; callback branch; apply curvature factor in `computeVelocityCommands` |
+| `test/test_curvature_speed_factor.cpp` | New unit test file (8 test cases) |
+| `CMakeLists.txt` | Add `test_curvature_speed_factor` gtest target |
+| `test/test_crabbing_control.cpp` | 12u → 13u in two size assertions; update doc comment; add curvature control assertions |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Human control and transparency | Default `turn_speed_curvature_min_radius = 0.0` is a clean no-op; live-settable via marine_control; all three opt-in conditions (default-off, live-tunable, finiteness-guarded) satisfied |
+| A change includes its consequences | All six files in scope; `declareCrabbingControlParams`/`bindCrabbingControls` pick up the new entry automatically via the `kTunables` loop; `test_crabbing_control.cpp` size + group/units/range assertions updated |
+| Only what's needed | Reuses `lookaheadPoint()` (no second horizon); reuses `turn_speed_min_factor_` (no second floor param); degenerate guard in pure function only |
+| Improve incrementally | Single PR; default-off; builds directly on the #87 pattern |
+| Test what breaks | 8 curvature unit tests + `test_crabbing_control` count/group checks cover the acceptance criteria |
+| Safety First | Degenerate inputs (collinear, <3 pts, NaN, R=0, min_radius=0) all return factor 1.0 (no slowdown is the safe side for degenerate geometry); combined_factor ≤ 1.0 so the boat can only slow, never speed up |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0002 — Worktree isolation | Yes | Already in worktree `issue-unh_marine_navigation-89` ✓ |
+| 0008 — ROS 2 conventions | Yes | `kTunables` entry, `FloatingPointRange` descriptor, `_range` companion, `read_validated`, callback branch all follow the established pattern exactly |
+| 0013 — progress.md vocabulary | Yes | This plan and the `## Plan Authored` entry follow ADR-0013 ✓ |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| `kTunables[]` (new entry) | `test_crabbing_control.cpp` size assertions (12u → 13u) + group/units assertions | Yes |
+| `path_geometry.hpp` (new functions) | `test_curvature_speed_factor.cpp` unit tests; CMakeLists.txt | Yes |
+| Control count doc comments ("twelve controls") | Update to "thirteen" in `test_crabbing_control.cpp` header | Yes |
+
+## Open Questions
+
+- [ ] No open questions — plan is review-plan-ready.
+
+## Estimated Scope
+
+Single PR.

--- a/.agent/work-plans/issue-89/progress.md
+++ b/.agent/work-plans/issue-89/progress.md
@@ -208,3 +208,25 @@ group/units/range assertions, and updated the CMake and header count comments.
 - Static analysis: cppcheck clean on new code; ament_cpplint findings (copyright, include-order, line-length) are pre-existing repo convention, mirrored from the merged sibling `test_turn_speed_factor.cpp` (#87), not a gating check. Silence-filtered.
 - Dropped one Lens B false positive: the `circumscribedRadius` doc comment (path_geometry.hpp:189 vs 216) is internally consistent (`|cross| = 2·Area`), not contradictory.
 - Two disjoint-lens Claude Adversarial passes (A: logic/correctness; B: systemic/safety) both returned zero must-fix.
+
+## Implementation
+**Status**: complete
+**When**: 2026-07-01 04:32 +00:00
+**By**: Claude Code Agent (Claude Opus)
+
+**Branch**: feature/issue-89 at `a61857d`
+**Addressed**: Local Review (Pre-Push) — When 2026-07-01 04:22 +00:00, branch `9ebcf68` (0 must-fix, 2 suggestions)
+**Commits**: `5e975d8` (test), `a61857d` (help text)
+
+### Actions
+- [x] (suggestion) End-to-end test of the curvature wiring over a multi-segment `global_plan_` — `marine_nav_crabbing_path_follower/test/test_curvature_speed_factor.cpp`. Added a `CurvatureWiring` suite (6 cases) that mirrors the composition at `crabbing_path_follower.cpp:991-1006`: a `regulate()` helper selects the along-track foot / half-lookahead / full-lookahead points off a real multi-segment `PoseStamped` plan via `lookaheadPoint()`, feeds them to `circumscribedRadius`/`curvatureSpeedFactor`, and composes with the reactive `turnSpeedFactor` via `min()`. Covers: straight plan → no curvature slowdown; L-shaped corner → radius exactly 12.5 m → factor 0.5 (pins fit-point selection + geometry); `progress`>0 shifts the foot mid-segment; `min()` composition with either regulator governing; and the disabled (`curvature_min_radius`=0) no-op on a curved plan. Kept at the pure-function composition level (not a full ROS-lifecycle `calculate()` harness — none exists in this package and one would be disproportionate for a suggestion); the helper carries a comment requiring it be kept in lockstep with the call site.
+- [x] (suggestion) Noted the shared `turn_speed_min_factor` floor in the param help text — `marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp:65-68`. The `kTunables` description now states the floor applies to BOTH turn-speed regulators (the reactive `turn_speed_max_crab_deg` one and the anticipatory `turn_speed_curvature_min_radius` one), matching the internal doc-comment note at `path_geometry.hpp:243-244`.
+
+### Build & test (ACTUAL)
+- `colcon build --packages-select marine_nav_crabbing_path_follower --symlink-install` → 1 package finished (only pre-existing `-Wunused-parameter`/`-Wsign-compare` warnings in untouched code).
+- `colcon test --packages-select marine_nav_crabbing_path_follower`: functional gtest suites ALL PASS — `test_curvature_speed_factor` now 15/15 (9 unit + 6 new wiring), `test_crabbing_control` 10/10, others unchanged. Pre-existing package-wide lint (cpplint copyright/include-order/line-length + uncrustify) remains, unchanged from the reviewed diff — documented as non-gating repo convention mirrored from sibling test files (#87), NOT introduced here.
+
+### Next step
+Lifecycle: Implementation → review-code (re-review the fixes). Hand off to a fresh-context sub-agent:
+
+    .agent/scripts/dispatch_subagent.sh --mode in-process --issue 89 --skill review-code

--- a/.agent/work-plans/issue-89/progress.md
+++ b/.agent/work-plans/issue-89/progress.md
@@ -74,3 +74,15 @@ unit tests. This is the same shape and size as #87 — a single focused PR in
 - [ ] Resolve curvature algorithm (3-point circumfit recommended) in the work plan.
 - [ ] Confirm param naming: prefer `turn_speed_curvature_min_radius` for namespace consistency.
 - [ ] Clarify whether curvature regulation shares `turn_speed_min_factor_` or introduces its own floor param.
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-07-01 00:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Plan**: `.agent/work-plans/issue-89/plan.md` at `256e2f2`
+**Branch**: feature/issue-89 at `256e2f2`
+**Phases**: single
+
+### Open questions
+- [ ] No open questions — plan is review-plan-ready.

--- a/.agent/work-plans/issue-89/progress.md
+++ b/.agent/work-plans/issue-89/progress.md
@@ -230,3 +230,29 @@ group/units/range assertions, and updated the CMake and header count comments.
 Lifecycle: Implementation → review-code (re-review the fixes). Hand off to a fresh-context sub-agent:
 
     .agent/scripts/dispatch_subagent.sh --mode in-process --issue 89 --skill review-code
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-07-01 04:41 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: approved
+
+**Branch**: feature/issue-89 at `88edf1d`
+**Mode**: pre-push
+**Depth**: Deep (reason: real-time vessel motion-control law; 200+ changed code+test lines)
+**Must-fix**: 0 | **Suggestions**: 1
+**Round**: 2 | **Ship**: recommended — round-1's 2 suggestions addressed (wiring suite + shared-floor help text); no must-fix this round; both Deep adversarial lenses returned zero.
+
+### Findings
+- [ ] (suggestion) Test comment cites call-site range `crabbing_path_follower.cpp:991-1006`; the `min()` composition it mirrors now lands at `1007-1008` — nudge the range to keep the lockstep pointer exact — `test/test_curvature_speed_factor.cpp:37,209`
+
+### Notes
+- Round-2 delta since round 1 (`9ebcf68`) is exactly the two addressed pre-push suggestions: the `CurvatureWiring` end-to-end suite (6 cases) and the shared-floor help text. Core algorithm unchanged since round-1 approval.
+- Two disjoint-lens Claude Adversarial passes (A: logic/correctness; B: systemic/safety) both returned zero must-fix. Verified: circumradius formula correct ((0,0),(15,0),(20,10)→R=12.5); no non-finite surge path (degenerate → `+inf` → factor 1.0); `combined_factor = min(...) ≤ 1.0` (boat can only slow); atomics `.load()`-snapshotted tear-free.
+- Dropped Lens B false positive (callback already uses `if (!as_number(p, v) || !update(...))`) and a defensive-only isfinite-guard (provably unreachable — target_speed finite, factor in [min,1.0]).
+- Static analysis: cppcheck findings (`cos_error_azimuth`:779, `dt` shadow:952) are on pre-existing untouched lines — silence-filtered. cpplint copyright/include-order on the new test file is repo-wide convention mirrored from the merged #87 sibling tests, non-gating.
+
+### Next step
+Lifecycle: **Local Review (approved)** → push / open PR → **triage-reviews**. Hand off to a fresh-context sub-agent:
+
+    .agent/scripts/dispatch_subagent.sh --mode in-process --issue 89 --skill triage-reviews

--- a/.agent/work-plans/issue-89/progress.md
+++ b/.agent/work-plans/issue-89/progress.md
@@ -202,7 +202,7 @@ group/units/range assertions, and updated the CMake and header count comments.
 
 ### Findings
 - [x] (suggestion) No end-to-end test exercises the curvature wiring (foot/half/full point selection + `min()` composition) through a multi-segment `global_plan_` — `src/crabbing_path_follower.cpp:991-1006`
-- [ ] (suggestion) Shared `turn_speed_min_factor` floor couples both regulators; note it in the param help text — `include/marine_nav_crabbing_path_follower/path_geometry.hpp:243-244`
+- [x] (suggestion) Shared `turn_speed_min_factor` floor couples both regulators; note it in the param help text — `include/marine_nav_crabbing_path_follower/path_geometry.hpp:243-244`
 
 ### Notes
 - Static analysis: cppcheck clean on new code; ament_cpplint findings (copyright, include-order, line-length) are pre-existing repo convention, mirrored from the merged sibling `test_turn_speed_factor.cpp` (#87), not a gating check. Silence-filtered.

--- a/.agent/work-plans/issue-89/progress.md
+++ b/.agent/work-plans/issue-89/progress.md
@@ -108,3 +108,82 @@ integration site matches the `turnSpeedFactor` pattern, count assertions at
 ### Findings
 - [ ] (suggestion) Circumfit uses the boat's actual position (`pose_in_plan.pose.position`), which carries cross-track error, as the first fit point while the other two are on-path; consider the along-track projection or document the choice — `plan.md:76-80`
 - [ ] (suggestion) Add a coincident-point test case (near-goal: half_la == full_la == goal → R = ∞ → factor 1.0) — the planned 8 cases omit it — `plan.md:88-96`
+
+## Implementation
+**Status**: complete
+**When**: 2026-07-01 04:10 +00:00
+**By**: Claude Opus
+
+**Plan**: `.agent/work-plans/issue-89/plan.md`
+**Branch**: feature/issue-89
+**Verdict**: implemented per plan; both Plan Review suggestions applied (mandatory)
+
+### What was implemented
+- `path_geometry.hpp`: added `circumscribedRadius(a, b, c)` (3-point
+  circumscribed-circle radius; returns `+inf` for collinear / coincident /
+  non-finite inputs via a single `!isfinite` guard on the result) and
+  `curvatureSpeedFactor(radius, min_radius, min_factor)` (disabled when
+  `min_radius <= 0`; 1.0 for non-finite/gentle radius; else
+  `clamp(radius/min_radius, min_factor, 1.0)`). Added `#include <limits>`.
+- `crabbing_path_follower.h`: added `turn_speed_curvature_min_radius_`
+  `std::atomic<double>{0.0}` with doc comment.
+- `crabbing_path_follower.cpp`: added the `kTunables[]` entry
+  (`turn_speed_curvature_min_radius`, default 0.0, range `[0, 200]`, units `m`,
+  group `speed`) — control count 12→13; added `read_validated` call
+  (`lo=0.0, exclusive_lo=false`); added the on-set-parameters callback branch
+  (`>= 0.0`, no upper bound); applied the factor at the turn-speed regulation
+  site as `combined_factor = min(turn_factor, curvature_factor)` before the
+  `cos_crab` division; reuses `turn_speed_min_factor_` as the shared floor.
+  Updated "eleven"→"twelve" tunable-count comments.
+- New `test/test_curvature_speed_factor.cpp` (9 gtest cases) wired into
+  `CMakeLists.txt` like `test_turn_speed_factor`.
+- `test/test_crabbing_control.cpp`: bumped both size assertions 12u→13u,
+  updated "twelve"→"thirteen" / "nine"→"twelve" doc comments, added
+  group/units/range assertions (`speed`, `m`, `[0, 200]`) for the new control.
+  Also updated the CMake comment and header "eleven"→"twelve".
+
+### Along-track fit-point decision + Plan Review suggestions (both applied)
+- **Sug 1 (along-track fit point):** the first circumfit point is the along-track
+  on-path projection — `lookaheadPoint(poses, current_segment_, progress, 0.0)`
+  (the projected foot on the current segment), NOT `pose_in_plan.pose.position`.
+  The other two points are the half-lookahead and full-lookahead points (the
+  full-lookahead `la_point` was hoisted out of the `if (lookahead > 0.0)` block
+  and reused). All three fit points are path-referenced; a code comment at the
+  site states this, so curvature stays a pure path property and cross-track error
+  does not double-count with the crab-angle regulator.
+- **Sug 2 (coincident-point test):** added
+  `CircumscribedRadius.CoincidentPointsAreInfinite` covering all-three-coincident
+  and near-goal half==full==goal → R = ∞ → factor 1.0.
+
+### Control-count bump (#87 lesson)
+Advertised control set grew 12→13. Updated `test_crabbing_control.cpp` size
+assertions (`:119`, `:284`) and doc comments, added the new control's
+group/units/range assertions, and updated the CMake and header count comments.
+
+### Build & test (ACTUAL)
+- Build: `colcon build --packages-up-to marine_nav_crabbing_path_follower
+  --symlink-install` → **4 packages finished**, `marine_nav_crabbing_path_follower`
+  compiled (only pre-existing `-Wunused-parameter` / `-Wsign-compare` warnings in
+  untouched code).
+- Tests: `colcon test --packages-select marine_nav_crabbing_path_follower`.
+  Functional gtest suites ALL PASS:
+  - `test_curvature_speed_factor`: 9/9
+  - `test_crabbing_control`: 10/10
+  - `test_turn_speed_factor`: 7/7
+  - `test_gain_schedule`: 9/9
+  - `test_path_geometry`: 18/18
+  (53 functional tests, 0 failures, 0 errors.)
+- Pre-existing package-wide lint remains (NOT fixed here, per instructions):
+  cpplint `legal/copyright` + `build/include_order` and uncrustify style diffs.
+  Confirmed pre-existing — `ament_uncrustify src/crabbing_path_follower.cpp`
+  fails on the pristine (pre-change) file, and the copyright/include-order
+  findings hit every sibling test file (`test_turn_speed_factor.cpp`,
+  `test_gain_schedule.cpp`, `test_path_geometry.cpp`).
+
+### Deviations from plan.md
+- First circumfit point is the along-track projection, not
+  `pose_in_plan.pose.position` (Plan Review sug 1, operator-mandated).
+- Curvature test file has 9 cases (planned 8) — the added coincident-point case
+  (Plan Review sug 2).
+- DEBUG log prints `turn_factor` / `curvature_factor` / `combined_factor`.
+- No other deviations.

--- a/.agent/work-plans/issue-89/progress.md
+++ b/.agent/work-plans/issue-89/progress.md
@@ -1,0 +1,76 @@
+---
+issue: 89
+---
+
+# Issue #89 — Anticipatory speed regulation via path curvature
+
+## Issue Review
+**Status**: complete
+**When**: 2026-07-01 00:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Issue**: #89
+**Comment**: (best-effort post follows this entry; not recorded inline)
+**Scope verdict**: well-scoped
+
+### Scope Assessment
+
+Adds a `curvatureSpeedFactor()` pure function to `path_geometry.hpp`, new
+`turn_curvature_min_radius` param (and companion `_range`), integration into
+`computeVelocityCommands()` via `min()` with the existing crab-angle factor,
+binding in `bindCrabbingControls()` / `declareCrabbingControlParams()`, and
+unit tests. This is the same shape and size as #87 — a single focused PR in
+`marine_nav_crabbing_path_follower`. No cross-repo or interface changes needed.
+
+**Right repo?** `unh_marine_navigation` (`marine_nav_crabbing_path_follower` package) — correct.
+
+**Dependencies**: Depends on #87/#88 (already shipped). Compose-with-#32
+(speed precedence) is covered in the issue description.
+
+### Principle Alignment
+
+| Principle | Status | Notes |
+|---|---|---|
+| Human control and transparency | OK | Default `turn_curvature_min_radius = 0.0` is a clean no-op; live-settable via marine_control; same opt-in idiom as existing params |
+| A change includes its consequences | Watch | `declareCrabbingControlParams()` and `bindCrabbingControls()` must both be updated; issue implies this but does not call it out explicitly |
+| Test what breaks | OK | Issue lists concrete unit-test cases: straight path → 1.0; constant-radius arc; degenerate inputs (<3 pts, collinear, NaN); floor respected — mirrors the `turnSpeedFactor` test structure |
+| Only what's needed | OK | Reuses existing lookahead machinery; no new lookahead horizon introduced |
+| Improve incrementally | OK | Directly follows #87; default-off maintains backward compatibility |
+| Safety First (project) | OK | Degenerate-input contract (collinear → radius infinity → factor 1.0; <3 pts → 1.0; NaN → 1.0; non-finite `linear.x` never emitted) is explicitly stated and comprehensive |
+| Hardware agnosticism (project) | OK | Pure path-geometry computation; no platform-specific APIs |
+
+### ADR Applicability
+
+| ADR | Triggered | Notes |
+|---|---|---|
+| 0002 — Worktree isolation | Yes | Already in worktree `issue-unh_marine_navigation-89` ✓ |
+| 0008 — ROS 2 conventions | Yes | New param with FloatingPointRange descriptor + `_range` companion follows established pattern ✓ |
+| 0013 — progress.md vocabulary | Yes | This entry ✓ |
+
+### Consequences
+
+- `declareCrabbingControlParams()` must declare the new param(s).
+- `bindCrabbingControls()` must bind them to the marine_control panel (speed group).
+- Unit test file for `curvatureSpeedFactor` should be added alongside `test_turn_speed_factor.cpp`.
+
+### Recommendations
+
+1. **Curvature algorithm choice**: The issue offers two options (3-point circumscribed-circle fit
+   vs. heading-change-per-arc-length). On piecewise-linear paths both are valid but the
+   circumfit is more direct and already has a clean degenerate case (collinear → inf radius → factor
+   1.0). Recommend settling this in the plan rather than leaving it open for implementation.
+
+2. **Param naming consistency**: Existing params are `turn_speed_max_crab_deg` /
+   `turn_speed_min_factor`. The new param should be `turn_speed_curvature_min_radius` (not
+   `turn_curvature_min_radius`) to stay within the existing `turn_speed_*` namespace group.
+
+3. **Shared or separate min-factor floor**: It is unspecified whether the curvature factor
+   reuses `turn_speed_min_factor_` (the crab-angle floor) or gets its own
+   `turn_speed_curvature_min_factor_`. Since the two regulators now compose via `min()`, sharing
+   the floor is simpler and avoids the operator having to set two separate floors; a separate
+   param is only warranted if the desired floors differ. Clarify in the plan.
+
+### Actions
+- [ ] Resolve curvature algorithm (3-point circumfit recommended) in the work plan.
+- [ ] Confirm param naming: prefer `turn_speed_curvature_min_radius` for namespace consistency.
+- [ ] Clarify whether curvature regulation shares `turn_speed_min_factor_` or introduces its own floor param.

--- a/.agent/work-plans/issue-89/progress.md
+++ b/.agent/work-plans/issue-89/progress.md
@@ -187,3 +187,24 @@ group/units/range assertions, and updated the CMake and header count comments.
   (Plan Review sug 2).
 - DEBUG log prints `turn_factor` / `curvature_factor` / `combined_factor`.
 - No other deviations.
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-07-01 04:22 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: approved
+
+**Branch**: feature/issue-89 at `9ebcf68`
+**Mode**: pre-push
+**Depth**: Deep (reason: 200+ changed lines; real-time vessel motion-control)
+**Must-fix**: 0 | **Suggestions**: 2
+**Round**: 1 | **Ship**: recommended — no must-fix; math/degenerate-handling verified safe, follows the merged #87 pattern, no-op until a platform opts in.
+
+### Findings
+- [ ] (suggestion) No end-to-end test exercises the curvature wiring (foot/half/full point selection + `min()` composition) through a multi-segment `global_plan_` — `src/crabbing_path_follower.cpp:991-1006`
+- [ ] (suggestion) Shared `turn_speed_min_factor` floor couples both regulators; note it in the param help text — `include/marine_nav_crabbing_path_follower/path_geometry.hpp:243-244`
+
+### Notes
+- Static analysis: cppcheck clean on new code; ament_cpplint findings (copyright, include-order, line-length) are pre-existing repo convention, mirrored from the merged sibling `test_turn_speed_factor.cpp` (#87), not a gating check. Silence-filtered.
+- Dropped one Lens B false positive: the `circumscribedRadius` doc comment (path_geometry.hpp:189 vs 216) is internally consistent (`|cross| = 2·Area`), not contradictory.
+- Two disjoint-lens Claude Adversarial passes (A: logic/correctness; B: systemic/safety) both returned zero must-fix.

--- a/.agent/work-plans/issue-89/progress.md
+++ b/.agent/work-plans/issue-89/progress.md
@@ -86,3 +86,25 @@ unit tests. This is the same shape and size as #87 — a single focused PR in
 
 ### Open questions
 - [ ] No open questions — plan is review-plan-ready.
+
+## Plan Review
+**Status**: complete
+**When**: 2026-07-01 03:53 +00:00
+**By**: Claude Code Agent (Claude Opus)
+
+**Plan**: `.agent/work-plans/issue-89/plan.md` at `256e2f2`
+**PR**: PR-less (--issue mode)
+**Verdict**: approve-with-suggestions
+
+Independent review (fresh-context sub-agent, distinct model from the Sonnet
+plan author). All three `review-issue` findings verified as addressed:
+curvature algorithm settled (3-point circumfit), param renamed to
+`turn_speed_curvature_min_radius`, floor reuses shared `turn_speed_min_factor_`.
+All structural claims cross-checked against source: `kTunables` loop drives both
+`declareCrabbingControlParams`/`bindCrabbingControls` (auto-pickup confirmed),
+integration site matches the `turnSpeedFactor` pattern, count assertions at
+`test_crabbing_control.cpp:119,284` (12u→13u), ADRs 0002/0008/0013 present.
+
+### Findings
+- [ ] (suggestion) Circumfit uses the boat's actual position (`pose_in_plan.pose.position`), which carries cross-track error, as the first fit point while the other two are on-path; consider the along-track projection or document the choice — `plan.md:76-80`
+- [ ] (suggestion) Add a coincident-point test case (near-goal: half_la == full_la == goal → R = ∞ → factor 1.0) — the planned 8 cases omit it — `plan.md:88-96`

--- a/.agent/work-plans/issue-89/progress.md
+++ b/.agent/work-plans/issue-89/progress.md
@@ -201,7 +201,7 @@ group/units/range assertions, and updated the CMake and header count comments.
 **Round**: 1 | **Ship**: recommended — no must-fix; math/degenerate-handling verified safe, follows the merged #87 pattern, no-op until a platform opts in.
 
 ### Findings
-- [ ] (suggestion) No end-to-end test exercises the curvature wiring (foot/half/full point selection + `min()` composition) through a multi-segment `global_plan_` — `src/crabbing_path_follower.cpp:991-1006`
+- [x] (suggestion) No end-to-end test exercises the curvature wiring (foot/half/full point selection + `min()` composition) through a multi-segment `global_plan_` — `src/crabbing_path_follower.cpp:991-1006`
 - [ ] (suggestion) Shared `turn_speed_min_factor` floor couples both regulators; note it in the param help text — `include/marine_nav_crabbing_path_follower/path_geometry.hpp:243-244`
 
 ### Notes

--- a/marine_nav_crabbing_path_follower/CMakeLists.txt
+++ b/marine_nav_crabbing_path_follower/CMakeLists.txt
@@ -89,11 +89,18 @@ if(BUILD_TESTING)
     ament_target_dependencies(test_turn_speed_factor geometry_msgs)
   endif()
 
+  ament_add_gtest(test_curvature_speed_factor test/test_curvature_speed_factor.cpp)
+  if(TARGET test_curvature_speed_factor)
+    target_include_directories(test_curvature_speed_factor PRIVATE
+      "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>")
+    ament_target_dependencies(test_curvature_speed_factor geometry_msgs)
+  endif()
+
   # marine_control device-control wiring (unh_marine_autonomy#140 / ADR-0003 —
   # the external marine_control device-control ADR, not this workspace's ADR-0003):
   # exercises the real declareCrabbingDefaultSpeed / declareCrabbingControlParams /
   # bindCrabbingControls helpers against a LifecycleNode + ControlServer (no nav2
-  # bring-up). Verifies the twelve controls are advertised with their ranges/groups, a
+  # bring-up). Verifies the thirteen controls are advertised with their ranges/groups, a
   # platform _range override is honoured, an in-range change applies, and an
   # out-of-range change is rejected by the FloatingPointRange over the channel.
   ament_add_gtest(test_crabbing_control test/test_crabbing_control.cpp)

--- a/marine_nav_crabbing_path_follower/include/marine_nav_crabbing_path_follower/crabbing_path_follower.h
+++ b/marine_nav_crabbing_path_follower/include/marine_nav_crabbing_path_follower/crabbing_path_follower.h
@@ -48,7 +48,7 @@ void declareCrabbingControlParams(
 
 // Bind the live crabbing tunables (declared by declareCrabbingDefaultSpeed +
 // declareCrabbingControlParams) to `server` as marine_control controls, with
-// their units and UI groups. Binds default_speed plus the eleven tunables.
+// their units and UI groups. Binds default_speed plus the twelve tunables.
 void bindCrabbingControls(marine_control::ControlServer & server, const std::string & name);
 
 class CrabbingPathFollower : public nav2_core::Controller
@@ -185,6 +185,23 @@ protected:
   // writes while computeVelocityCommands reads on the controller thread).
   std::atomic<double> turn_speed_max_crab_deg_{0.0};
   std::atomic<double> turn_speed_min_factor_{0.3};
+
+  // Anticipatory curvature regulation (#89). The crab-angle factor above is
+  // reactive — it slows the boat only once the PID is already holding a large
+  // crab into a turn. This factor is the anticipatory half: it fits the
+  // circumscribed-circle radius through three PATH-REFERENCED points ahead of the
+  // boat (the along-track projection onto the current segment, a half-lookahead
+  // point, and the full-lookahead point — all from lookaheadPoint()), then slows
+  // the boat *before* the apex of a tight bend. The two regulators compose via
+  // min(), so both regimes apply simultaneously. Using on-path points (not the
+  // boat's raw position) keeps curvature a pure property of the path, so
+  // cross-track error can't inflate it and double-count with the crab regulator.
+  // turn_speed_curvature_min_radius_ is the radius (m) below which regulation
+  // engages; 0.0 DISABLES it (the default; no behavior change until a platform
+  // opts in, mirroring turn_speed_max_crab_deg_ = 0). It reuses
+  // turn_speed_min_factor_ as its floor (one shared "slowest I'll go in a turn"
+  // knob). Live-tunable via the parameter callback, hence atomic.
+  std::atomic<double> turn_speed_curvature_min_radius_{0.0};
 
   bool visualize_ = false;
   rclcpp_lifecycle::LifecyclePublisher<visualization_msgs::msg::MarkerArray>::SharedPtr visualization_publisher_;

--- a/marine_nav_crabbing_path_follower/include/marine_nav_crabbing_path_follower/path_geometry.hpp
+++ b/marine_nav_crabbing_path_follower/include/marine_nav_crabbing_path_follower/path_geometry.hpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 #include <vector>
 
 #include "geometry_msgs/msg/point.hpp"
@@ -178,6 +179,83 @@ inline double turnSpeedFactor(
   }
   const double frac = std::abs(crab_angle_deg) / max_crab_deg;
   return std::clamp(1.0 - frac, min_factor, 1.0);
+}
+
+/// Radius of the circle circumscribing the triangle a-b-c — the local radius of
+/// curvature of the path passing through those three points (#89).
+///
+/// Formula: R = |AB|·|BC|·|CA| / (4·Area), where Area is the (unsigned) area of
+/// triangle abc and |AB| etc. are the side lengths. The twice-signed-area is the
+/// 2D cross product of AB and BC, so 4·Area = 2·|AB × BC|.
+///
+/// Returns `+infinity` for every degenerate input — collinear points (zero
+/// area → a straight line, curvature 0), coincident points (fewer than three
+/// distinct points, so no circle is defined), or any non-finite coordinate. A
+/// single `!isfinite` guard on the result covers all three: collinear/coincident
+/// drive the divisor to 0 (→ inf or 0/0 → NaN), and a NaN coordinate propagates
+/// to a NaN result; both map to infinity. Infinity is the "straight, no
+/// curvature" sentinel that `curvatureSpeedFactor` turns into no slowdown — the
+/// safe default for geometry we can't interpret.
+///
+/// Pure (not a method) so it can be unit-tested with no ROS scaffolding — the
+/// same reason `turnSpeedFactor` / `lookaheadPoint` live here.
+inline double circumscribedRadius(
+  const geometry_msgs::msg::Point & a,
+  const geometry_msgs::msg::Point & b,
+  const geometry_msgs::msg::Point & c)
+{
+  const double abx = b.x - a.x;
+  const double aby = b.y - a.y;
+  const double bcx = c.x - b.x;
+  const double bcy = c.y - b.y;
+  const double cax = a.x - c.x;
+  const double cay = a.y - c.y;
+  const double ab = std::hypot(abx, aby);
+  const double bc = std::hypot(bcx, bcy);
+  const double ca = std::hypot(cax, cay);
+  // Twice the signed triangle area (the 2D cross product of AB and BC); its
+  // magnitude is 2·Area, so 4·Area == 2·|cross|.
+  const double cross = abx * bcy - aby * bcx;
+  const double radius = (ab * bc * ca) / (2.0 * std::abs(cross));
+  if (!std::isfinite(radius)) {
+    return std::numeric_limits<double>::infinity();
+  }
+  return radius;
+}
+
+/// Anticipatory turn-speed factor from the local path radius of curvature (#89).
+///
+/// The reactive `turnSpeedFactor` slows the boat in proportion to the crab angle
+/// it is *already* holding — a beat late into a turn. This factor is the
+/// anticipatory half: given the circumscribed radius of the path geometry ahead
+/// (see `circumscribedRadius`), it slows the boat *before* the apex of a tight
+/// bend. The caller composes the two via `min()`.
+///
+/// Contract:
+///   - `min_radius <= 0`: disabled (the default) — returns 1.0 always, so there
+///     is no behavior change until a platform opts in (mirrors the
+///     `turn_speed_max_crab_deg = 0` default-off idiom in `turnSpeedFactor`).
+///   - `radius` non-finite (a straight/degenerate fit) or `radius >= min_radius`
+///     (a gentle bend): returns 1.0 (no slowdown).
+///   - otherwise (a tight turn, `radius < min_radius`): returns
+///     `clamp(radius / min_radius, min_factor, 1.0)` — the tighter the turn the
+///     lower the factor, floored at `min_factor` so the boat never stalls
+///     mid-turn. `min_factor` is the SAME floor `turnSpeedFactor` uses (the two
+///     regulators share one "slowest I'll go in a turn" knob).
+///
+/// Pure (not a method) so it can be unit-tested across radii with no ROS
+/// scaffolding — the same reason `circumscribedRadius` / `turnSpeedFactor` live
+/// here.
+inline double curvatureSpeedFactor(
+  double radius, double min_radius, double min_factor)
+{
+  if (!(min_radius > 0.0)) {
+    return 1.0;
+  }
+  if (!std::isfinite(radius) || radius >= min_radius) {
+    return 1.0;
+  }
+  return std::clamp(radius / min_radius, min_factor, 1.0);
 }
 
 /// Signed along-track distance of point `p` projected onto the segment a->b,

--- a/marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp
+++ b/marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp
@@ -20,7 +20,7 @@ namespace marine_nav_crabbing_path_follower
 
 namespace
 {
-// Single source of truth for the eleven live operator-tunable parameters exposed
+// Single source of truth for the twelve live operator-tunable parameters exposed
 // through marine_control (default_speed is handled separately — see
 // declareCrabbingDefaultSpeed). For each: the value default, the built-in
 // fallback range [min, max], panel units, UI group, and help text. Both
@@ -64,6 +64,8 @@ constexpr CrabbingTunable kTunables[] = {
     "Crab angle at which turn-speed regulation reaches its floor (deg; 0 = disabled)."},
   {"turn_speed_min_factor", 0.3, 0.0, 1.0, "", "speed",
     "Minimum surge fraction when crabbing hardest (dimensionless; floors the regulation)."},
+  {"turn_speed_curvature_min_radius", 0.0, 0.0, 200.0, "m", "speed",
+    "Path radius of curvature below which the boat slows anticipating a turn (m; 0 = disabled)."},
 };
 
 // default_speed's panel range. Permissive enough that every physically
@@ -457,6 +459,18 @@ void CrabbingPathFollower::configure(
           if (!update(turn_speed_min_factor_, v, 0.0, false, "turn_speed_min_factor")) {
             return result;
           }
+        } else if (name == base + ".turn_speed_curvature_min_radius") {
+          // >= 0: 0.0 disables anticipatory curvature regulation (the default),
+          // so it is valid. No upper bound in the callback — a platform tunes the
+          // engagement radius freely (the panel range caps it at 200 m).
+          double v;
+          if (!as_number(p, v) ||
+            !update(
+              turn_speed_curvature_min_radius_, v, 0.0, false,
+              "turn_speed_curvature_min_radius"))
+          {
+            return result;
+          }
         }
       }
       return result;
@@ -473,7 +487,7 @@ void CrabbingPathFollower::configure(
   nav2_util::declare_parameter_if_not_declared(node, plugin_name_ + ".transform_tolerance", rclcpp::ParameterValue(transform_tolerance_));
   node->get_parameter(plugin_name_ + ".transform_tolerance", transform_tolerance_);
 
-  // Declare the eleven live operator-tunables with FloatingPointRange descriptors
+  // Declare the twelve live operator-tunables with FloatingPointRange descriptors
   // (and their `<name>.<tunable>_range` startup overrides) BEFORE the
   // read_validated block below, so the descriptor attaches at first declaration;
   // read_validated's declare_parameter_if_not_declared then no-ops the
@@ -533,6 +547,11 @@ void CrabbingPathFollower::configure(
   // loudly at declare) and by the on-set-parameters callback for live updates.
   read_validated(".turn_speed_max_crab_deg", turn_speed_max_crab_deg_, 0.0, false);
   read_validated(".turn_speed_min_factor", turn_speed_min_factor_, 0.0, false);
+  // Anticipatory curvature regulation (#89). min_radius >= 0 (0 = disabled, the
+  // default). No upper bound here — a platform tunes the engagement radius
+  // freely; the FloatingPointRange descriptor advertises a [0, 200] m panel band.
+  read_validated(
+    ".turn_speed_curvature_min_radius", turn_speed_curvature_min_radius_, 0.0, false);
 
   // marine_control panel namespace for the control topics created in activate().
   // Defaults to plugin_name_, so a standalone controller's topics are
@@ -895,15 +914,20 @@ geometry_msgs::msg::TwistStamped CrabbingPathFollower::computeVelocityCommands(
     // speed, not the trajectory-derived one.
     lookahead = std::max(lookahead_min_distance, target_speed * lookahead_time);
   }
+  // Hoisted out of the `if` so the full-lookahead point is in scope at the
+  // curvature-regulation site below (which reuses it as the third circumfit
+  // point). Zero-initialised; only read there when lookahead > 0.0, the same
+  // guard that fills it here.
+  geometry_msgs::msg::Point la_point;
   if (lookahead > 0.0) {
     // progress is the boat's signed projection along the current segment; it is
     // clamped to [0, seg_len] inside lookaheadPoint, so a boat sitting behind
     // the segment start measures the horizon from the segment start.
-    const auto la = lookaheadPoint(
+    la_point = lookaheadPoint(
       global_plan_.poses, current_segment_, progress, lookahead);
     base_heading = AngleRadians(atan2(
-      la.y - pose_in_plan.pose.position.y,
-      la.x - pose_in_plan.pose.position.x));
+      la_point.y - pose_in_plan.pose.position.y,
+      la_point.x - pose_in_plan.pose.position.x));
   }
 
   AngleRadians target_heading = base_heading + crab_angle;
@@ -945,9 +969,43 @@ geometry_msgs::msg::TwistStamped CrabbingPathFollower::computeVelocityCommands(
   const double turn_min_factor = turn_speed_min_factor_.load();
   const double turn_factor =
     turnSpeedFactor(crab_angle.value(), turn_max_crab, turn_min_factor);
-  const double regulated_target_speed = target_speed * turn_factor;
 
-  RCLCPP_DEBUG_STREAM(logger_, "CrabbingPathFollower: turn_speed regulation factor: " << turn_factor << " target_speed " << target_speed << " -> regulated: " << regulated_target_speed);
+  // Anticipatory curvature regulation (#89). The turn_factor above is reactive
+  // (it responds to the crab angle already commanded); this composes in the
+  // anticipatory half by slowing the boat for the path curvature *ahead*, before
+  // the turn apex. The circumscribed-circle radius is fit through three
+  // PATH-REFERENCED points, all from lookaheadPoint():
+  //   1. the along-track projection of the boat onto the current segment (walk 0 m
+  //      forward -> the foot the controller tracks from),
+  //   2. the half-lookahead point, and
+  //   3. the full-lookahead point (la_point, reused from the base-heading calc).
+  // Using the on-path projection as the first point — NOT pose_in_plan.pose.position
+  // (the boat's raw actual position) — keeps curvature a pure property of the path:
+  // cross-track error (wind/current pushing the boat off the line) would otherwise
+  // inflate the apparent curvature and double-count with the crab-angle regulator.
+  // Snapshot the atomic once (tear-free, matching the turn_speed_* idiom). Disabled
+  // (factor 1.0) when the min-radius is 0 (the default) or look-ahead is off; the
+  // shared turn_min_factor floors the slowdown (one knob for both regulators).
+  const double curvature_min_radius = turn_speed_curvature_min_radius_.load();
+  double curvature_factor = 1.0;
+  if (lookahead > 0.0 && curvature_min_radius > 0.0) {
+    const auto foot_point =
+      lookaheadPoint(global_plan_.poses, current_segment_, progress, 0.0);
+    const auto half_point =
+      lookaheadPoint(global_plan_.poses, current_segment_, progress, lookahead / 2.0);
+    const double curvature_radius =
+      circumscribedRadius(foot_point, half_point, la_point);
+    curvature_factor =
+      curvatureSpeedFactor(curvature_radius, curvature_min_radius, turn_min_factor);
+  }
+
+  // Compose the reactive and anticipatory factors via min(): whichever regime
+  // demands the greater slowdown wins, and each is <= 1.0 so the boat can only
+  // slow, never speed up.
+  const double combined_factor = std::min(turn_factor, curvature_factor);
+  const double regulated_target_speed = target_speed * combined_factor;
+
+  RCLCPP_DEBUG_STREAM(logger_, "CrabbingPathFollower: turn_speed regulation turn_factor: " << turn_factor << " curvature_factor: " << curvature_factor << " combined_factor: " << combined_factor << " target_speed " << target_speed << " -> regulated: " << regulated_target_speed);
 
   double cos_crab = std::max(cos(crab_angle), 0.5);
   cmd_vel.twist.linear.x = regulated_target_speed/cos_crab;

--- a/marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp
+++ b/marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp
@@ -63,7 +63,9 @@ constexpr CrabbingTunable kTunables[] = {
   {"turn_speed_max_crab_deg", 0.0, 0.0, 90.0, "deg", "speed",
     "Crab angle at which turn-speed regulation reaches its floor (deg; 0 = disabled)."},
   {"turn_speed_min_factor", 0.3, 0.0, 1.0, "", "speed",
-    "Minimum surge fraction when crabbing hardest (dimensionless; floors the regulation)."},
+    "Minimum surge fraction when crabbing hardest (dimensionless; the shared floor for "
+    "BOTH turn-speed regulators — the reactive crab-angle one (turn_speed_max_crab_deg) "
+    "and the anticipatory curvature one (turn_speed_curvature_min_radius))."},
   {"turn_speed_curvature_min_radius", 0.0, 0.0, 200.0, "m", "speed",
     "Path radius of curvature below which the boat slows anticipating a turn (m; 0 = disabled)."},
 };

--- a/marine_nav_crabbing_path_follower/test/test_crabbing_control.cpp
+++ b/marine_nav_crabbing_path_follower/test/test_crabbing_control.cpp
@@ -7,7 +7,7 @@
 // declareCrabbingDefaultSpeed / declareCrabbingControlParams / bindCrabbingControls
 // helpers — the actual code the plugin runs — against a bare LifecycleNode and a
 // real ControlServer, with no nav2 bring-up. It checks that:
-//   - all twelve controls (default_speed + eleven tunables) are advertised with
+//   - all thirteen controls (default_speed + twelve tunables) are advertised with
 //     their default FloatingPointRange, UI group, and units;
 //   - a platform `<name>.<t>_range` startup override is honoured (and integer
 //     bounds are coerced; a malformed range falls back to the default);
@@ -47,7 +47,7 @@ constexpr char kName[] = "FollowPath";
 constexpr char kStateTopic[] = "~/control/FollowPath/state";
 constexpr char kChangeTopic[] = "~/control/FollowPath/change";
 
-// Declare every control the plugin exposes (default_speed + the nine tunables),
+// Declare every control the plugin exposes (default_speed + the twelve tunables),
 // matching what configure() does, so the bound ControlSet is complete.
 void declareAll(
   const rclcpp_lifecycle::LifecycleNode::SharedPtr & node, const std::string & name)
@@ -116,7 +116,7 @@ TEST_F(CrabbingControlTest, AdvertisesAllControlsWithRangesAndGroups)
   marine_nav_crabbing_path_follower::bindCrabbingControls(server, kName);
 
   const ControlSet set = server.build_control_set();
-  ASSERT_EQ(set.items.size(), 12u);
+  ASSERT_EQ(set.items.size(), 13u);
 
   // default_speed: handled separately from the generic helper, with its own
   // permissive panel range so the configure-time fallback is preserved.
@@ -162,6 +162,16 @@ TEST_F(CrabbingControlTest, AdvertisesAllControlsWithRangesAndGroups)
   EXPECT_EQ(min_factor->units, "");
   EXPECT_DOUBLE_EQ(min_factor->min_value, 0.0);
   EXPECT_DOUBLE_EQ(min_factor->max_value, 1.0);
+
+  // Anticipatory curvature regulation (#89): another "speed" group control,
+  // a radius in metres over [0, 200].
+  const auto * curvature = findItem(set, "FollowPath.turn_speed_curvature_min_radius");
+  ASSERT_NE(curvature, nullptr);
+  EXPECT_EQ(curvature->type, ControlItem::TYPE_FLOAT);
+  EXPECT_EQ(curvature->group, "speed");
+  EXPECT_EQ(curvature->units, "m");
+  EXPECT_DOUBLE_EQ(curvature->min_value, 0.0);
+  EXPECT_DOUBLE_EQ(curvature->max_value, 200.0);
 }
 
 TEST_F(CrabbingControlTest, PlatformRangeOverrideIsHonoured)
@@ -281,7 +291,7 @@ TEST_F(CrabbingControlTest, NamespaceParamDifferentiatesTopicsWhenWrapped)
   // Both bind the same parameter set; only the channel differs.
   marine_control::ControlServer s1(node.get(), standalone);
   marine_nav_crabbing_path_follower::bindCrabbingControls(s1, kName);
-  ASSERT_EQ(s1.build_control_set().items.size(), 12u);
+  ASSERT_EQ(s1.build_control_set().items.size(), 13u);
 }
 
 class CrabbingControlChannelTest : public CrabbingControlTest

--- a/marine_nav_crabbing_path_follower/test/test_curvature_speed_factor.cpp
+++ b/marine_nav_crabbing_path_follower/test/test_curvature_speed_factor.cpp
@@ -1,14 +1,19 @@
 #include <cmath>
 #include <limits>
+#include <vector>
 
 #include <gtest/gtest.h>
 
 #include "geometry_msgs/msg/point.hpp"
+#include "geometry_msgs/msg/pose_stamped.hpp"
 #include "marine_nav_crabbing_path_follower/path_geometry.hpp"
 
 using geometry_msgs::msg::Point;
+using geometry_msgs::msg::PoseStamped;
 using marine_nav_crabbing_path_follower::circumscribedRadius;
 using marine_nav_crabbing_path_follower::curvatureSpeedFactor;
+using marine_nav_crabbing_path_follower::lookaheadPoint;
+using marine_nav_crabbing_path_follower::turnSpeedFactor;
 
 namespace
 {
@@ -19,6 +24,59 @@ Point makePoint(double x, double y)
   p.y = y;
   p.z = 0.0;
   return p;
+}
+
+PoseStamped makePose(double x, double y)
+{
+  PoseStamped ps;
+  ps.pose.position = makePoint(x, y);
+  return ps;
+}
+
+// Mirrors the anticipatory-curvature composition at
+// crabbing_path_follower.cpp:991-1006 as a pure function so the *wiring* (the
+// along-track foot / half-lookahead / full-lookahead point selection and the
+// min() with the reactive turn factor) can be exercised end-to-end over a real
+// multi-segment global_plan_ without ROS lifecycle scaffolding. Any change to
+// the fit-point selection or the min() direction at the call site must be kept
+// in lockstep with this helper.
+struct SpeedRegulation
+{
+  double turn_factor;
+  double curvature_factor;
+  double combined;
+};
+
+SpeedRegulation regulate(
+  const std::vector<PoseStamped> & poses, int current_segment, double progress,
+  double lookahead, double crab_angle_deg, double max_crab_deg, double min_factor,
+  double curvature_min_radius)
+{
+  // The three PATH-REFERENCED fit points, exactly as the call site derives them.
+  const Point foot = lookaheadPoint(poses, current_segment, progress, 0.0);
+  const Point half = lookaheadPoint(poses, current_segment, progress, lookahead / 2.0);
+  const Point full = lookaheadPoint(poses, current_segment, progress, lookahead);
+
+  double curvature_factor = 1.0;
+  if (lookahead > 0.0 && curvature_min_radius > 0.0) {
+    const double radius = circumscribedRadius(foot, half, full);
+    curvature_factor = curvatureSpeedFactor(radius, curvature_min_radius, min_factor);
+  }
+  const double turn_factor = turnSpeedFactor(crab_angle_deg, max_crab_deg, min_factor);
+  return {turn_factor, curvature_factor, std::min(turn_factor, curvature_factor)};
+}
+
+// An L-shaped plan: a 20 m run east, a right-angle corner, then a run north.
+// current_segment_ = 0, progress = 0 puts the boat at the very start.
+std::vector<PoseStamped> lShapedPlan()
+{
+  return {makePose(0.0, 0.0), makePose(20.0, 0.0), makePose(20.0, 20.0), makePose(40.0, 20.0)};
+}
+
+// A straight three-vertex plan: no curvature anywhere along it.
+std::vector<PoseStamped> straightPlan()
+{
+  return {makePose(0.0, 0.0), makePose(20.0, 0.0), makePose(40.0, 0.0)};
 }
 }  // namespace
 
@@ -144,6 +202,107 @@ TEST(CurvatureSpeedFactor, MinFactorFloorRespected)
     EXPECT_LE(f, 1.0);
     EXPECT_TRUE(std::isfinite(f));
   }
+}
+
+// --- End-to-end wiring over a multi-segment plan -------------------------
+// These exercise the full anticipatory-curvature path the calculate() site
+// walks (crabbing_path_follower.cpp:991-1006): the along-track foot, the
+// half-lookahead, and the full-lookahead points are selected off a real
+// multi-segment global_plan_ via lookaheadPoint(), fed to circumscribedRadius /
+// curvatureSpeedFactor, and composed with the reactive turnSpeedFactor via min().
+
+// A straight multi-segment plan curves nowhere: the three fit points are
+// collinear, so the curvature factor is a clean 1.0 (no slowdown) and the
+// combined factor is governed entirely by the reactive turn factor.
+TEST(CurvatureWiring, StraightPlanNeverSlowsForCurvature)
+{
+  const auto plan = straightPlan();
+  const auto r = regulate(
+    plan, /*current_segment=*/0, /*progress=*/0.0, /*lookahead=*/30.0,
+    /*crab_angle_deg=*/0.0, /*max_crab_deg=*/30.0, /*min_factor=*/0.3,
+    /*curvature_min_radius=*/25.0);
+  EXPECT_DOUBLE_EQ(r.curvature_factor, 1.0);
+  EXPECT_DOUBLE_EQ(r.combined, r.turn_factor);  // reactive governs
+}
+
+// The L-shaped plan with lookahead 30 m selects foot (0,0), half (15,0), and
+// full (20,10) — the full-lookahead point runs 10 m past the corner into the
+// second segment. Those three points circumscribe a circle of radius exactly
+// 12.5 m; with a 25 m engagement radius the curvature factor is 12.5/25 = 0.5.
+// This pins the foot/half/full selection *and* the geometry in one shot.
+TEST(CurvatureWiring, CorneredPlanSlowsAnticipatingTheTurn)
+{
+  const auto plan = lShapedPlan();
+  const auto r = regulate(
+    plan, /*current_segment=*/0, /*progress=*/0.0, /*lookahead=*/30.0,
+    /*crab_angle_deg=*/0.0, /*max_crab_deg=*/0.0, /*min_factor=*/0.3,
+    /*curvature_min_radius=*/25.0);
+  EXPECT_DOUBLE_EQ(r.curvature_factor, 0.5);
+  // Reactive regulator disabled (max_crab_deg = 0 -> turn_factor 1.0), so the
+  // anticipatory curvature factor is what reaches the surge.
+  EXPECT_DOUBLE_EQ(r.turn_factor, 1.0);
+  EXPECT_DOUBLE_EQ(r.combined, 0.5);
+}
+
+// The along-track foot is picked at `progress` metres into the current segment,
+// not the segment start: starting 5 m along segment 0 shifts all three fit
+// points forward, but the plan still curves, so the boat still slows. Exercises
+// the start_offset path through lookaheadPoint that the call site relies on.
+TEST(CurvatureWiring, AlongTrackFootHonoursProgress)
+{
+  const auto plan = lShapedPlan();
+  const auto r = regulate(
+    plan, /*current_segment=*/0, /*progress=*/5.0, /*lookahead=*/30.0,
+    /*crab_angle_deg=*/0.0, /*max_crab_deg=*/0.0, /*min_factor=*/0.3,
+    /*curvature_min_radius=*/1000.0);
+  EXPECT_LT(r.curvature_factor, 1.0);
+  EXPECT_GE(r.curvature_factor, 0.3);
+}
+
+// min() composition: whichever regulator demands the greater slowdown wins.
+// Reactive harder — a hard crab on a straight plan: turn_factor floors while the
+// curvature factor stays 1.0, so the reactive factor governs the combined result.
+TEST(CurvatureWiring, MinCompositionReactiveGoverns)
+{
+  const auto plan = straightPlan();
+  const auto r = regulate(
+    plan, /*current_segment=*/0, /*progress=*/0.0, /*lookahead=*/30.0,
+    /*crab_angle_deg=*/30.0, /*max_crab_deg=*/30.0, /*min_factor=*/0.3,
+    /*curvature_min_radius=*/25.0);
+  EXPECT_DOUBLE_EQ(r.turn_factor, 0.3);       // |crab| == max_crab -> floor
+  EXPECT_DOUBLE_EQ(r.curvature_factor, 1.0);  // straight -> no curvature slowdown
+  EXPECT_DOUBLE_EQ(r.combined, 0.3);          // reactive governs
+}
+
+// Anticipatory harder — a gentle crab into the L-shaped corner: the curvature
+// factor (0.5) is below the reactive factor, so the curvature factor governs.
+TEST(CurvatureWiring, MinCompositionCurvatureGoverns)
+{
+  const auto plan = lShapedPlan();
+  // max_crab 60, |crab| 30 -> turn_factor clamp(1 - 30/60, .3, 1) = 0.5... make
+  // the reactive factor clearly milder than the 0.5 curvature factor: |crab| 12
+  // of 60 -> 0.8.
+  const auto r = regulate(
+    plan, /*current_segment=*/0, /*progress=*/0.0, /*lookahead=*/30.0,
+    /*crab_angle_deg=*/12.0, /*max_crab_deg=*/60.0, /*min_factor=*/0.3,
+    /*curvature_min_radius=*/25.0);
+  EXPECT_DOUBLE_EQ(r.turn_factor, 0.8);
+  EXPECT_DOUBLE_EQ(r.curvature_factor, 0.5);
+  EXPECT_DOUBLE_EQ(r.combined, 0.5);  // anticipatory governs
+}
+
+// The whole anticipatory path is gated off when the feature is disabled
+// (curvature_min_radius <= 0, the shipped default) even on a sharply curved
+// plan: the curvature factor is 1.0 and only the reactive factor can slow the boat.
+TEST(CurvatureWiring, DisabledCurvatureRadiusIsNoOpOnCurvedPlan)
+{
+  const auto plan = lShapedPlan();
+  const auto r = regulate(
+    plan, /*current_segment=*/0, /*progress=*/0.0, /*lookahead=*/30.0,
+    /*crab_angle_deg=*/0.0, /*max_crab_deg=*/0.0, /*min_factor=*/0.3,
+    /*curvature_min_radius=*/0.0);
+  EXPECT_DOUBLE_EQ(r.curvature_factor, 1.0);
+  EXPECT_DOUBLE_EQ(r.combined, 1.0);
 }
 
 int main(int argc, char ** argv)

--- a/marine_nav_crabbing_path_follower/test/test_curvature_speed_factor.cpp
+++ b/marine_nav_crabbing_path_follower/test/test_curvature_speed_factor.cpp
@@ -34,7 +34,7 @@ PoseStamped makePose(double x, double y)
 }
 
 // Mirrors the anticipatory-curvature composition at
-// crabbing_path_follower.cpp:991-1006 as a pure function so the *wiring* (the
+// crabbing_path_follower.cpp:991-1008 as a pure function so the *wiring* (the
 // along-track foot / half-lookahead / full-lookahead point selection and the
 // min() with the reactive turn factor) can be exercised end-to-end over a real
 // multi-segment global_plan_ without ROS lifecycle scaffolding. Any change to
@@ -206,7 +206,7 @@ TEST(CurvatureSpeedFactor, MinFactorFloorRespected)
 
 // --- End-to-end wiring over a multi-segment plan -------------------------
 // These exercise the full anticipatory-curvature path the calculate() site
-// walks (crabbing_path_follower.cpp:991-1006): the along-track foot, the
+// walks (crabbing_path_follower.cpp:991-1008): the along-track foot, the
 // half-lookahead, and the full-lookahead points are selected off a real
 // multi-segment global_plan_ via lookaheadPoint(), fed to circumscribedRadius /
 // curvatureSpeedFactor, and composed with the reactive turnSpeedFactor via min().

--- a/marine_nav_crabbing_path_follower/test/test_curvature_speed_factor.cpp
+++ b/marine_nav_crabbing_path_follower/test/test_curvature_speed_factor.cpp
@@ -1,0 +1,153 @@
+#include <cmath>
+#include <limits>
+
+#include <gtest/gtest.h>
+
+#include "geometry_msgs/msg/point.hpp"
+#include "marine_nav_crabbing_path_follower/path_geometry.hpp"
+
+using geometry_msgs::msg::Point;
+using marine_nav_crabbing_path_follower::circumscribedRadius;
+using marine_nav_crabbing_path_follower::curvatureSpeedFactor;
+
+namespace
+{
+Point makePoint(double x, double y)
+{
+  Point p;
+  p.x = x;
+  p.y = y;
+  p.z = 0.0;
+  return p;
+}
+}  // namespace
+
+// A straight run (three collinear points) has no curvature: the circumscribed
+// radius is infinite, which maps to no slowdown (factor 1.0).
+TEST(CircumscribedRadius, CollinearIsInfinite)
+{
+  const double r = circumscribedRadius(
+    makePoint(0.0, 0.0), makePoint(1.0, 0.0), makePoint(2.0, 0.0));
+  EXPECT_TRUE(std::isinf(r));
+  EXPECT_DOUBLE_EQ(curvatureSpeedFactor(r, 50.0, 0.3), 1.0);
+}
+
+// A right triangle circumscribes a circle whose diameter is the hypotenuse, so
+// its radius is exact and hand-checkable: legs 6 and 8, hypotenuse 10, R = 5.
+// (R = |AB|·|BC|·|CA| / (4·Area) = 6·10·8 / (4·24) = 5.)
+TEST(CircumscribedRadius, RightTriangleHasExactRadius)
+{
+  const double r = circumscribedRadius(
+    makePoint(0.0, 0.0), makePoint(6.0, 0.0), makePoint(0.0, 8.0));
+  EXPECT_DOUBLE_EQ(r, 5.0);
+}
+
+// The circumscribed radius is a property of the point set, not their order:
+// permuting the three arguments must give the same radius.
+TEST(CircumscribedRadius, InvariantToPointOrder)
+{
+  const Point a = makePoint(0.0, 0.0);
+  const Point b = makePoint(6.0, 0.0);
+  const Point c = makePoint(0.0, 8.0);
+  const double r_abc = circumscribedRadius(a, b, c);
+  EXPECT_DOUBLE_EQ(circumscribedRadius(b, c, a), r_abc);
+  EXPECT_DOUBLE_EQ(circumscribedRadius(c, a, b), r_abc);
+  EXPECT_DOUBLE_EQ(circumscribedRadius(a, c, b), r_abc);
+}
+
+// A non-finite coordinate (NaN/Inf from a wild pose or transform) must not
+// propagate: the radius collapses to infinity -> factor 1.0 (no slowdown), never
+// a non-finite factor into the commanded surge.
+TEST(CircumscribedRadius, NonFiniteCoordinateIsInfinite)
+{
+  const double nan_c = std::numeric_limits<double>::quiet_NaN();
+  const double r_nan = circumscribedRadius(
+    makePoint(nan_c, 0.0), makePoint(6.0, 0.0), makePoint(0.0, 8.0));
+  EXPECT_TRUE(std::isinf(r_nan));
+  EXPECT_DOUBLE_EQ(curvatureSpeedFactor(r_nan, 50.0, 0.3), 1.0);
+
+  const double inf_c = std::numeric_limits<double>::infinity();
+  const double r_inf = circumscribedRadius(
+    makePoint(0.0, 0.0), makePoint(inf_c, 0.0), makePoint(0.0, 8.0));
+  EXPECT_TRUE(std::isinf(r_inf));
+  EXPECT_DOUBLE_EQ(curvatureSpeedFactor(r_inf, 50.0, 0.3), 1.0);
+}
+
+// Fewer than three distinct points -> no circle is defined -> infinite radius.
+// The near-goal case the operator flagged: as the look-ahead runs onto the goal,
+// lookaheadPoint clamps the half- and full-lookahead points onto the same final
+// vertex, so all three fit points coincide (or two of them do). Must be a clean
+// no-op (factor 1.0), not a division-by-zero NaN into the surge.
+TEST(CircumscribedRadius, CoincidentPointsAreInfinite)
+{
+  // All three coincident (boat parked on the goal).
+  const double r_all = circumscribedRadius(
+    makePoint(5.0, 5.0), makePoint(5.0, 5.0), makePoint(5.0, 5.0));
+  EXPECT_TRUE(std::isinf(r_all));
+  EXPECT_DOUBLE_EQ(curvatureSpeedFactor(r_all, 50.0, 0.3), 1.0);
+
+  // Near-goal: half_lookahead == full_lookahead == goal (two points coincide).
+  const double r_two = circumscribedRadius(
+    makePoint(0.0, 0.0), makePoint(10.0, 10.0), makePoint(10.0, 10.0));
+  EXPECT_TRUE(std::isinf(r_two));
+  EXPECT_DOUBLE_EQ(curvatureSpeedFactor(r_two, 50.0, 0.3), 1.0);
+}
+
+// Disabled: min_radius <= 0 returns 1.0 for any radius (the shipped default, so
+// there is no behavior change until a platform opts in).
+TEST(CurvatureSpeedFactor, DisabledReturnsOne)
+{
+  EXPECT_DOUBLE_EQ(curvatureSpeedFactor(5.0, 0.0, 0.3), 1.0);
+  EXPECT_DOUBLE_EQ(curvatureSpeedFactor(1.0, 0.0, 0.3), 1.0);
+  // A negative min_radius is also treated as disabled, not a sign flip.
+  EXPECT_DOUBLE_EQ(curvatureSpeedFactor(5.0, -10.0, 0.3), 1.0);
+}
+
+// A gentle bend (radius >= min_radius) leaves the speed untouched.
+TEST(CurvatureSpeedFactor, GentleBendReturnsOne)
+{
+  EXPECT_DOUBLE_EQ(curvatureSpeedFactor(50.0, 40.0, 0.3), 1.0);   // radius > min
+  EXPECT_DOUBLE_EQ(curvatureSpeedFactor(40.0, 40.0, 0.3), 1.0);   // exactly at min
+  // An infinite radius (a straight line) is the ultimate gentle bend.
+  EXPECT_DOUBLE_EQ(
+    curvatureSpeedFactor(std::numeric_limits<double>::infinity(), 40.0, 0.3), 1.0);
+}
+
+// A tight turn (radius < min_radius) ramps linearly as radius / min_radius.
+TEST(CurvatureSpeedFactor, TightTurnRampsLinearly)
+{
+  // R = 5, min = 10 -> 0.5 (above the 0.3 floor).
+  EXPECT_DOUBLE_EQ(curvatureSpeedFactor(5.0, 10.0, 0.3), 0.5);
+  // R = 30, min = 40 -> 0.75.
+  EXPECT_DOUBLE_EQ(curvatureSpeedFactor(30.0, 40.0, 0.0), 0.75);
+  // The right-triangle radius (R = 5) with a 10 m engagement radius -> 0.5,
+  // exercising circumscribedRadius and curvatureSpeedFactor together.
+  const double r = circumscribedRadius(
+    makePoint(0.0, 0.0), makePoint(6.0, 0.0), makePoint(0.0, 8.0));
+  EXPECT_DOUBLE_EQ(curvatureSpeedFactor(r, 10.0, 0.3), 0.5);
+}
+
+// The floor holds: a very tight turn never drops below min_factor, and the
+// returned factor is always in [min_factor, 1.0].
+TEST(CurvatureSpeedFactor, MinFactorFloorRespected)
+{
+  // R tiny relative to min -> would be far below the floor; the clamp holds it.
+  EXPECT_DOUBLE_EQ(curvatureSpeedFactor(1.0, 100.0, 0.3), 0.3);
+  EXPECT_DOUBLE_EQ(curvatureSpeedFactor(0.001, 50.0, 0.25), 0.25);
+
+  // Sweep radius across the range: result stays within [min_factor, 1.0].
+  const double min_factor = 0.4;
+  const double min_radius = 40.0;
+  for (double radius = 0.0; radius <= 80.0; radius += 2.0) {
+    const double f = curvatureSpeedFactor(radius, min_radius, min_factor);
+    EXPECT_GE(f, min_factor);
+    EXPECT_LE(f, 1.0);
+    EXPECT_TRUE(std::isfinite(f));
+  }
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary

Adds the **anticipatory** half of turn-speed regulation to `CrabbingPathFollower`, following the reactive crab-angle regulation merged in #88 (issue #87). The boat now slows on the *approach* to a sharp turn based on upcoming path curvature, instead of only reacting once it's already crabbing hard mid-corner.

## Approach

- `circumscribedRadius(A,B,C)` and `curvatureSpeedFactor(radius, min_radius, min_factor)` added to `path_geometry.hpp` — pure, unit-tested. Degenerate inputs (collinear / coincident / <3 distinct points / NaN) → radius `+inf` → factor `1.0` (no slowdown, no non-finite surge).
- New param **`turn_speed_curvature_min_radius`** (units m, default `0.0` = disabled, group `speed`), live-tunable and marine_control-bound via the `kTunables` loop (control count 12→13). Below `min_radius` the boat slows toward the floor; at/above it (gentle bend) speed is untouched.
- The three circumfit points are **all path-referenced** — the first is the along-track on-path projection (`lookaheadPoint(..., progress, 0.0)`), not the boat's cross-track-displaced actual position — so curvature is a pure property of the path geometry and does not double-count with the crab-angle regulator when wind/current pushes the boat off-line. *(Operator-chosen at the plan-review checkpoint.)*
- Composed with the reactive factor as `target_speed *= min(turnSpeedFactor, curvatureSpeedFactor)`, so whichever regime demands the bigger slowdown governs. Both share the existing `turn_speed_min_factor` floor (one "slowest I'll go in a turn" knob).
- Default-off → backward-compatible; no-op until a platform sets `turn_speed_curvature_min_radius > 0`.

## Tests

New `test_curvature_speed_factor` — **15 cases**: 9 pure-function (straight/collinear→∞, coincident points, constant-radius arc with pinned geometry, gentle vs tight, disabled, NaN/duplicate, floor) + a 6-case `CurvatureWiring` end-to-end suite over a real multi-segment plan (foot/half/full point selection via `lookaheadPoint()`, L-corner pinned to R=12.5 m → factor 0.5, `progress`-shifted foot, `min()` composition either regime governing, disabled no-op). Full package: `test_curvature_speed_factor` 15/15, `test_crabbing_control` 10/10, `test_turn_speed_factor` 7/7, `test_gain_schedule` 9/9, `test_path_geometry` 18/18 — 0 failures. Build clean.

## Review

Local pre-push review, 2 rounds (deep tier). Round 1 approved with 2 suggestions → applied (the end-to-end wiring suite + a param-help note that the floor is shared by both regulators). Round 2 approved, 0 must-fix. Both disjoint adversarial lenses (correctness + systemic/safety) returned zero must-fix across both rounds; verified the combined factor is always ≤ 1.0 (can only slow the boat) and no path yields a non-finite surge.

Follow-on to #87 (PR #88). Field RCA: rolker/unh_echoboats_project11#361.

Closes #89

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
