### PR TITLE
CrabbingPathFollower: use path tangent for look-ahead base_heading (fix off-course oscillation) (#91)

### DIFF
--- a/.agent/work-plans/issue-91/plan.md
+++ b/.agent/work-plans/issue-91/plan.md
@@ -1,0 +1,92 @@
+# Plan: Fix look-ahead double-correction in CrabbingPathFollower
+
+## Issue
+
+https://github.com/rolker/unh_marine_navigation/issues/91
+
+## Context
+
+With look-ahead enabled (`lookahead_distance > 0` or `lookahead_time > 0`),
+`CrabbingPathFollower` sets `base_heading` to the bearing from the boat's current
+position to the look-ahead point (pure-pursuit steering). The crab-angle PID then
+adds a cross-track correction on top, resulting in double correction: the
+pure-pursuit bearing *already* steers back toward the line, and the crab PID drives
+the same error a second time. This causes oscillation that is worst at short horizons
+(≈1–2 s at survey speed, where the bearing swings ≈50° per metre of cross-track
+error).
+
+The fix: when look-ahead is on, set `base_heading` to the **path tangent at the
+look-ahead point** (the azimuth of the segment the look-ahead point falls on), not
+the boat-to-point bearing. This anticipates upcoming bends while leaving cross-track
+correction solely to the crab PID — no double-counting.
+
+## Approach
+
+1. **Add `lookaheadSegmentAzimuth` to `path_geometry.hpp`** — a pure inline function
+   that walks the path with the same logic as `lookaheadPoint` but returns the
+   azimuth (radians) of the segment containing the look-ahead point. Degenerate
+   inputs (empty path, single point, zero-length segment) return `0.0`. Sits
+   alongside `lookaheadPoint` and follows the same "pure, no ROS scaffolding"
+   contract so it is unit-testable without a node.
+
+2. **Replace the `atan2` call in `crabbing_path_follower.cpp` (lines 930–932)** —
+   swap `base_heading = AngleRadians(atan2(la_point.y − boat.y, la_point.x − boat.x))`
+   for `base_heading = AngleRadians(lookaheadSegmentAzimuth(...))`. `la_point` is
+   still computed by the preceding `lookaheadPoint` call (the curvature block at
+   lines 979–1007 reuses it as the third circumfit point — do not remove it).
+
+3. **Update the comment block at lines 899–905** — correct "pure-pursuit bearing to a
+   point" to "path tangent at the look-ahead point" to match the fixed semantics.
+
+4. **Add unit tests in `test_path_geometry.cpp`** — four tests for
+   `lookaheadSegmentAzimuth`:
+   - Straight line: returns the segment azimuth regardless of cross-track offset
+     (the acceptance-criteria unit test — boat-position-independence).
+   - Bend anticipation: look-ahead past a turn returns the next segment's azimuth,
+     not the current one.
+   - Past-end clamp: returns the final segment's azimuth when the horizon overshoots.
+   - Degenerate inputs: empty path and single-point path do not crash.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `include/marine_nav_crabbing_path_follower/path_geometry.hpp` | Add `lookaheadSegmentAzimuth(poses, start_seg, start_offset, lookahead) → double` |
+| `src/crabbing_path_follower.cpp` | Replace lines 930–932 (`atan2` bearing) with `lookaheadSegmentAzimuth` call; update comment at 899–905 |
+| `test/test_path_geometry.cpp` | Add four `LookaheadSegmentAzimuth` tests using the existing `makePath` helper |
+
+No CMakeLists changes needed — `test_path_geometry.cpp` is already registered as
+`test_path_geometry` in the package's `CMakeLists.txt` (line 71).
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| A change includes its consequences | Unit tests for new function; comment update; `la_point` computation preserved for curvature block |
+| Test what breaks | Four targeted unit tests; acceptance criteria include a sim/log check (cross-track decays monotonically with look-ahead on) |
+| Only what's needed | One new function (~20 lines), one changed call site, four tests; no interface changes, no param changes |
+| Human control and transparency | Existing DEBUG log at line 897 logs `segment_azimuth` (current segment, unchanged); label remains accurate |
+| Improve incrementally | Narrow fix; does not touch crab PID, speed regulation, or curvature logic |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| ADR-0008 — ROS 2 conventions | Yes | Fix stays within the Nav2 controller plugin interface; no convention deviation |
+| ADR-0013 — progress.md vocabulary | Yes | Progress file uses `## Plan Authored` entry per ADR-0013 |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| `path_geometry.hpp` (new function) | `test_path_geometry.cpp` (unit tests) | Yes |
+| `base_heading` computation | Comment at lines 899–905 | Yes |
+| `base_heading` semantics | DEBUG log label (line 897 logs `segment_azimuth`, not `base_heading` — label stays correct) | Yes — verified, no change needed |
+
+## Open Questions
+
+- None — approach, affected files, and acceptance criteria are fully specified by the issue.
+
+## Estimated Scope
+
+Single PR.

--- a/.agent/work-plans/issue-91/progress.md
+++ b/.agent/work-plans/issue-91/progress.md
@@ -130,3 +130,26 @@ Per Plan Review sug 3, the simulator was NOT run in this container. At **review-
 
 ### Deviations from plan.md
 None. Approach and all four planned tests implemented as specified, with the 3 Plan Review suggestions folded in.
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-07-01 13:53 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: approved
+
+**Branch**: feature/issue-91 at `acf8bea`
+**Mode**: pre-push
+**Depth**: Deep (reason: 344 total changed lines >200 + safety-relevant control-law change; code portion alone is Standard-sized)
+**Must-fix**: 0 | **Suggestions**: 4
+**Round**: 1 | **Ship**: recommended — no must-fix findings; clean, well-scoped control-law fix, 22/22 gtests re-verified locally, static analysis clean on changed lines.
+
+### Findings
+- [ ] (suggestion) Comment at `:905-907` credits the `max_yaw_rate` clamp as the discrete-step bound, but at default params it is a no-op — the external `velocity_smoother` is the real bound (see `crabbing_path_follower.h:108-109`) — `src/crabbing_path_follower.cpp:905`
+- [ ] (suggestion) Segment-tangent `base_heading` can toggle across a vertex cycle-to-cycle on dense/short-segment plans (chatter); no hysteresis and no worst-case (hairpin) test — `include/marine_nav_crabbing_path_follower/path_geometry.hpp:143`
+- [ ] (suggestion) Mixed-reference bend regime: `base_heading` (ahead segment) + `crab_angle` (current segment) superposed; convergence provable only in the straight regime; transition untested — `src/crabbing_path_follower.cpp:936`
+- [ ] (suggestion/owed) Sim/log monotonic cross-track decay acceptance check still unverified — could not run in offline container (no simulator); owed before merge — `n/a`
+
+### Notes
+- Lens A (logic/correctness): no findings — traced `lookaheadSegmentAzimuth` against `lookaheadPoint` line-by-line (byte-identical traversal → same segment landing), independently verified all 4 test assertions, no boundary/OOB defects.
+- Static analysis: cpplint + cppcheck clean on all changed lines; new function has zero findings. Pre-existing package-wide lint (legal/copyright, line-length) exists on untouched lines — not attributable to this PR.
+- Plan drift: none. Governance: all consequences addressed; ADR-0008/0013 compliant.

--- a/.agent/work-plans/issue-91/progress.md
+++ b/.agent/work-plans/issue-91/progress.md
@@ -1,0 +1,69 @@
+---
+issue: 91
+---
+
+# Issue #91 — Fix look-ahead double-correction in CrabbingPathFollower
+
+## Issue Review
+**Status**: complete
+**When**: 2026-07-01 00:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Issue**: #91
+**Comment**: (best-effort post follows this entry; not recorded inline)
+**Scope verdict**: well-scoped
+
+### Scope
+Single bug fix in `marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp`
+(lines 930–932): replace the boat-to-look-ahead-point bearing with the segment
+azimuth at the look-ahead point. The fix is confined to one controller and one
+logical change. Acceptance criteria include a unit test and a sim/log check — both
+are clearly bounded. Single PR.
+
+**Right repo?** Yes — `unh_marine_navigation` project repo, `marine_nav_crabbing_path_follower` package.
+
+**Dependencies**: #90 (merged) is a logical predecessor (curvature anticipation is
+gated on stable look-ahead). No blocking dependency on open issues.
+
+### Principle Alignment
+
+| Principle | Status | Notes |
+|---|---|---|
+| Human control and transparency | OK | Fix is clearly motivated; existing DEBUG log at line 897 continues to expose `base_heading` and `crab_angle`. Note: that log fires *before* the look-ahead block so after the fix `base_heading` in the log will reflect the updated look-ahead azimuth — confirm it still makes sense. |
+| A change includes its consequences | Watch | Issue specifies a unit test for `base_heading` derivation and a sim/log check. The implementation will need a new pure function in `path_geometry.hpp` (e.g. `lookaheadSegmentAzimuth`) to retrieve the azimuth of the segment the look-ahead point lands on — `lookaheadPoint()` returns only a `Point`, not the segment index. The new function must be unit-tested alongside it. |
+| Test what breaks | OK | Acceptance criteria explicitly require a unit test for the `base_heading` derivation and a monotonic cross-track error sim check. Existing test patterns in `test_path_geometry.cpp` are directly reusable. |
+| Improve incrementally | OK | Narrow, targeted fix. Does not touch the crab PID, speed regulation, or curvature logic. |
+| Only what's needed | OK | Fix is minimal. One new helper function in `path_geometry.hpp`, one changed call site in `crabbing_path_follower.cpp`. |
+| Capture decisions, not just implementations | OK | The issue body itself is the decision record (root cause, rejected alternative, rationale). No ADR needed for a bug fix. |
+
+### ADR Applicability
+
+| ADR | Triggered | Notes |
+|---|---|---|
+| ADR-0008 — ROS 2 conventions | Yes | Fix touches a Nav2 controller plugin; follow ROS 2 Jazzy/Rolling conventions. No deviation expected. |
+| ADR-0013 — progress.md vocabulary | Yes | This entry uses `## Issue Review` per ADR-0013. |
+| Others | No | No workspace infra, Python packaging, build system, or agent-instruction changes. |
+
+### Consequences
+
+- `path_geometry.hpp` will likely gain a new function (`lookaheadSegmentAzimuth` or
+  a combined `lookaheadPointAndSegment`). Corresponding tests should be added to
+  `test_path_geometry.cpp`.
+- The DEBUG log at line 897 logs `segment_azimuth` before the look-ahead block.
+  After the fix the logged value will be the look-ahead segment azimuth (correct),
+  but the label in the log message should be verified to still be accurate.
+- No message-type or interface changes → no downstream package updates needed.
+
+### Recommendations
+
+- Define a pure `lookaheadSegmentAzimuth(poses, start_seg, start_offset, lookahead)`
+  (or equivalent) in `path_geometry.hpp` rather than inlining the segment-walk
+  logic a second time in `crabbing_path_follower.cpp`. Keeps the geometry layer
+  testable in isolation, consistent with the existing `lookaheadPoint` pattern.
+- Update the DEBUG log string at line 897 if needed so the label matches the
+  semantics of the value being logged (look-ahead segment azimuth vs. current
+  segment azimuth).
+
+### Actions
+- [ ] Add `lookaheadSegmentAzimuth` (or combined `lookaheadPointAndSegment`) to `path_geometry.hpp` and unit-test it in `test_path_geometry.cpp`.
+- [ ] Verify/update DEBUG log string at line 897 after changing the `base_heading` computation.

--- a/.agent/work-plans/issue-91/progress.md
+++ b/.agent/work-plans/issue-91/progress.md
@@ -145,7 +145,7 @@ None. Approach and all four planned tests implemented as specified, with the 3 P
 
 ### Findings
 - [x] (suggestion) Comment at `:905-907` credits the `max_yaw_rate` clamp as the discrete-step bound, but at default params it is a no-op — the external `velocity_smoother` is the real bound (see `crabbing_path_follower.h:108-109`) — `src/crabbing_path_follower.cpp:905`
-- [ ] (suggestion) Segment-tangent `base_heading` can toggle across a vertex cycle-to-cycle on dense/short-segment plans (chatter); no hysteresis and no worst-case (hairpin) test — `include/marine_nav_crabbing_path_follower/path_geometry.hpp:143`
+- [x] (suggestion) Segment-tangent `base_heading` can toggle across a vertex cycle-to-cycle on dense/short-segment plans (chatter); no hysteresis and no worst-case (hairpin) test — `include/marine_nav_crabbing_path_follower/path_geometry.hpp:143`
 - [ ] (suggestion) Mixed-reference bend regime: `base_heading` (ahead segment) + `crab_angle` (current segment) superposed; convergence provable only in the straight regime; transition untested — `src/crabbing_path_follower.cpp:936`
 - [ ] (suggestion/owed) Sim/log monotonic cross-track decay acceptance check still unverified — could not run in offline container (no simulator); owed before merge — `n/a`
 

--- a/.agent/work-plans/issue-91/progress.md
+++ b/.agent/work-plans/issue-91/progress.md
@@ -175,3 +175,27 @@ new hairpin), `test_crabbing_control` 10/10, `test_curvature_speed_factor` 15/15
 - [x] Add worst-case (hairpin) test `HairpinReversalStepsByNearlyPi` characterizing the near-π single-cycle `base_heading` step at a ~180° reversal, and documenting that this pure geometry helper deliberately has no hysteresis (smoothing is the downstream `velocity_smoother`'s job) — `test/test_path_geometry.cpp` (`de0182c`). Hysteresis itself is a separate design change with its own state/tuning, out of scope for the #91 bug fix (deferred to a follow-up).
 - [x] Document the mixed-reference bend-regime limitation at the `target_heading = base_heading + crab_angle` superposition: proven-convergent only in the straight (same-segment) regime; the bend transition is a bounded, self-correcting heuristic verified by the owed sim check, not a unit test — `src/crabbing_path_follower.cpp:936` (`fc424d1`)
 - [x] Sim/log monotonic cross-track decay acceptance check — `n/a` (deferred: no simulator in this offline container; a manual review-code/merge deliverable, not a code change — still owed before merge, as the review itself flagged)
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-07-01 14:31 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: approved
+
+**Branch**: feature/issue-91 at `f8bbbb7`
+**Mode**: pre-push
+**Depth**: Deep (reason: safety-relevant motion-control law change on a real vehicle)
+**Must-fix**: 0 | **Suggestions**: 4
+**Round**: 2 | **Ship**: recommended — 0 must-fix; round-1 suggestions all addressed, remaining items are polish + the owed manual sim check (not resolvable offline).
+
+### Findings
+- [ ] (suggestion, follow-up) Physical yaw-rate bound lives entirely in the downstream `velocity_smoother`, which this package neither ships nor declares (no README/launch/yaml). Pre-existing — the default `segment_azimuth` base_heading steps identically and the smoother reliance predates #91 (see `crabbing_path_follower.h:109`), so not a #91 blocker; worth declaring the smoother as a documented hard plugin dependency — `src/crabbing_path_follower.cpp:907`
+- [ ] (suggestion) Comment "base_heading steps by at most one segment's turn" is imprecise: on dense/short segments the look-ahead point can cross multiple vertices per cycle — `src/crabbing_path_follower.cpp:951`
+- [ ] (suggestion, owed merge-gate) Sim/log monotonic cross-track-decay check for the mixed-reference bend regime still owed — no offline simulator; a manual review-code/merge deliverable — `src/crabbing_path_follower.cpp:944`
+- [ ] (suggestion, low) Trailing degenerate/zero-length final segment yields base_heading=0 (due-east) for the terminal cycle; mirrors `lookaheadPoint`'s accepted behavior, benign at goal. Lens B's interior-vertex variant does not actually trigger (traversal returns on the preceding real segment) — `include/marine_nav_crabbing_path_follower/path_geometry.hpp:153`
+
+### Notes
+- Static analysis: ament_cpplint + ament_cppcheck clean on all changed lines; the new function has zero findings. Pre-existing package-wide lint (legal/copyright, line-length, include-order) exists only on untouched lines — not attributable to this PR.
+- Lens A (logic/correctness): no defects. Traced `lookaheadSegmentAzimuth` against `lookaheadPoint` line-by-line (identical guards + traversal → same segment landing, so the returned azimuth is exactly the tangent at the look-ahead point); independently verified all 5 test assertions and the disabled-look-ahead path (bit-for-bit prior behavior).
+- Lens B (systemic/safety): one "must-fix" raised (discrete base_heading step → yaw command, external-smoother reliance) — triaged DOWN to suggestion: the default `segment_azimuth` control law already steps discretely at every vertex with the same magnitude, and the smoother reliance predates #91; the concern was already triaged in round 1 (hairpin test + docs; hysteresis deferred as out-of-scope).
+- Governance: compliant with ADR-0008 and ADR-0013; only workspace governance applies (no project-level governance in repo). Plan drift: clean — all three planned files changed and only those; round-1 suggestions folded in.

--- a/.agent/work-plans/issue-91/progress.md
+++ b/.agent/work-plans/issue-91/progress.md
@@ -94,3 +94,39 @@ gated on stable look-ahead). No blocking dependency on open issues.
 - [ ] (suggestion) Note in the updated comment block that the segment-tangent `base_heading` steps discretely at vertex crossings (bounded by the `max_yaw_rate` clamp) — `plan.md:38`
 - [ ] (suggestion) Confirm the sim/log monotonic cross-track decay acceptance check is run manually at review-code (it's not an automated deliverable). — `plan.md:66`
 - [ ] (info) Plan correctly determined the DEBUG log at `crabbing_path_follower.cpp:897` needs no change — it logs `segment_azimuth` (current segment, line 815), not `base_heading`; the review-issue log action item is discharged.
+
+## Implementation
+**Status**: complete
+**When**: 2026-07-01 13:00 +00:00
+**By**: Claude Opus
+
+**Branch**: feature/issue-91
+**Plan**: `.agent/work-plans/issue-91/plan.md`
+
+### What changed
+- **`path_geometry.hpp`** — added pure inline `lookaheadSegmentAzimuth(poses, start_seg, start_offset, lookahead) → double`. Walks the path with the SAME forward-only traversal as `lookaheadPoint` and returns the azimuth (`atan2(dy, dx)`, radians) of the segment CONTAINING the look-ahead point.
+- **`src/crabbing_path_follower.cpp`** — replaced the boat-to-look-ahead-point `atan2` bearing (`~:930-932`) with `base_heading = AngleRadians(lookaheadSegmentAzimuth(global_plan_.poses, current_segment_, progress, lookahead));`. The preceding `lookaheadPoint(...)` call and `la_point` are KEPT — the #90 curvature block reuses `la_point` as its third circumfit point. Updated the comment block (`~:899`) from "pure-pursuit bearing to a point" to "path tangent at the look-ahead point", explaining the no-double-count rationale.
+- **`test/test_path_geometry.cpp`** — 4 new `LookaheadSegmentAzimuth` tests.
+
+### Plan Review suggestions applied (all 3 mandatory)
+1. **Past-end / out-of-range clamp → FINAL segment azimuth** (not `0.0`): implemented via a `start_seg > last - 1` early return AND the loop's `i == last - 1` fallthrough, mirroring `lookaheadPoint`'s goal-clamp. Only empty path, single point, and all-coincident/zero-length inputs return `0.0` (`atan2(0,0)` is naturally 0). Covered by `ClampsToFinalSegmentPastEnd` (both horizon-overshoot and past-end `start_seg`).
+2. **Comment note on discrete vertex-crossing steps**: the updated comment states `base_heading` steps discretely as the look-ahead point crosses a vertex, bounded downstream by the `max_yaw_rate` clamp.
+3. **Manual sim check owed at review-code** — see below.
+
+### Tests (`LookaheadSegmentAzimuth`)
+- `StraightLineIsBoatPositionIndependent` (the AC test — function takes no boat position, returns segment azimuth).
+- `AnticipatesNextSegmentPastBend` (past a vertex → next segment azimuth; short horizon → current).
+- `ClampsToFinalSegmentPastEnd` (overshoot and past-end start both → final segment azimuth).
+- `HandlesDegeneratePaths` (empty + single-point → 0.0, no crash).
+
+### ⚠ Manual verification owed at review-code
+Per Plan Review sug 3, the simulator was NOT run in this container. At **review-code**, run the sim with `lookahead_time` = 0 vs 1–2 s and confirm cross-track error decays **monotonically** (no growing oscillation) with look-ahead enabled. This is a manual review-code deliverable, not an automated test.
+
+### Build / test result (ACTUAL)
+- Build: `colcon build --packages-up-to marine_nav_crabbing_path_follower --symlink-install` → **succeeded** (used the fallback; `build.sh` alone failed because underlay deps weren't yet built in this worktree). Only pre-existing unused-parameter / sign-compare warnings.
+- Test: `colcon test --packages-select marine_nav_crabbing_path_follower` + `colcon test-result --verbose`.
+  - **All functional gtest suites PASS**: `test_path_geometry` **22/22** (18 prior + 4 new), `test_crabbing_control` 10/10, `test_curvature_speed_factor` 15/15, `test_gain_schedule` 9/9, `test_turn_speed_factor` 7/7 — **0 failures, 0 errors** across all gtests.
+  - The 51 `colcon test-result` failures are **pre-existing package-wide lint only** (cpplint `legal/copyright`, `build/include_order`; uncrustify on `crabbing_path_follower.{h,cpp}`) — noted, not fixed per instructions.
+
+### Deviations from plan.md
+None. Approach and all four planned tests implemented as specified, with the 3 Plan Review suggestions folded in.

--- a/.agent/work-plans/issue-91/progress.md
+++ b/.agent/work-plans/issue-91/progress.md
@@ -79,3 +79,18 @@ gated on stable look-ahead). No blocking dependency on open issues.
 
 ### Open questions
 - [ ] No open questions — plan is review-plan-ready.
+
+## Plan Review
+**Status**: complete
+**When**: 2026-07-01 11:53 +00:00
+**By**: Claude Code Agent (Claude Opus)
+
+**Plan**: `.agent/work-plans/issue-91/plan.md` at `3c60486`
+**PR**: PR-less
+**Verdict**: approve-with-suggestions
+
+### Findings
+- [ ] (suggestion) `lookaheadSegmentAzimuth` should return the final segment's azimuth when `start_seg` is past the last segment (mirror `lookaheadPoint`'s goal-clamp, `path_geometry.hpp:82-84`), not fold it into the `0.0`-degenerate bucket — add a parallel out-of-range test. — `plan.md:47`
+- [ ] (suggestion) Note in the updated comment block that the segment-tangent `base_heading` steps discretely at vertex crossings (bounded by the `max_yaw_rate` clamp) — `plan.md:38`
+- [ ] (suggestion) Confirm the sim/log monotonic cross-track decay acceptance check is run manually at review-code (it's not an automated deliverable). — `plan.md:66`
+- [ ] (info) Plan correctly determined the DEBUG log at `crabbing_path_follower.cpp:897` needs no change — it logs `segment_azimuth` (current segment, line 815), not `base_heading`; the review-issue log action item is discharged.

--- a/.agent/work-plans/issue-91/progress.md
+++ b/.agent/work-plans/issue-91/progress.md
@@ -146,7 +146,7 @@ None. Approach and all four planned tests implemented as specified, with the 3 P
 ### Findings
 - [x] (suggestion) Comment at `:905-907` credits the `max_yaw_rate` clamp as the discrete-step bound, but at default params it is a no-op — the external `velocity_smoother` is the real bound (see `crabbing_path_follower.h:108-109`) — `src/crabbing_path_follower.cpp:905`
 - [x] (suggestion) Segment-tangent `base_heading` can toggle across a vertex cycle-to-cycle on dense/short-segment plans (chatter); no hysteresis and no worst-case (hairpin) test — `include/marine_nav_crabbing_path_follower/path_geometry.hpp:143`
-- [ ] (suggestion) Mixed-reference bend regime: `base_heading` (ahead segment) + `crab_angle` (current segment) superposed; convergence provable only in the straight regime; transition untested — `src/crabbing_path_follower.cpp:936`
+- [x] (suggestion) Mixed-reference bend regime: `base_heading` (ahead segment) + `crab_angle` (current segment) superposed; convergence provable only in the straight regime; transition untested — `src/crabbing_path_follower.cpp:936`
 - [ ] (suggestion/owed) Sim/log monotonic cross-track decay acceptance check still unverified — could not run in offline container (no simulator); owed before merge — `n/a`
 
 ### Notes

--- a/.agent/work-plans/issue-91/progress.md
+++ b/.agent/work-plans/issue-91/progress.md
@@ -147,9 +147,31 @@ None. Approach and all four planned tests implemented as specified, with the 3 P
 - [x] (suggestion) Comment at `:905-907` credits the `max_yaw_rate` clamp as the discrete-step bound, but at default params it is a no-op — the external `velocity_smoother` is the real bound (see `crabbing_path_follower.h:108-109`) — `src/crabbing_path_follower.cpp:905`
 - [x] (suggestion) Segment-tangent `base_heading` can toggle across a vertex cycle-to-cycle on dense/short-segment plans (chatter); no hysteresis and no worst-case (hairpin) test — `include/marine_nav_crabbing_path_follower/path_geometry.hpp:143`
 - [x] (suggestion) Mixed-reference bend regime: `base_heading` (ahead segment) + `crab_angle` (current segment) superposed; convergence provable only in the straight regime; transition untested — `src/crabbing_path_follower.cpp:936`
-- [ ] (suggestion/owed) Sim/log monotonic cross-track decay acceptance check still unverified — could not run in offline container (no simulator); owed before merge — `n/a`
+- [x] (suggestion/owed) Sim/log monotonic cross-track decay acceptance check still unverified — could not run in offline container (no simulator); owed before merge — `n/a` (deferred: no simulator in this offline container — a manual review-code/merge deliverable, not addressable via code change; still owed before merge)
 
 ### Notes
 - Lens A (logic/correctness): no findings — traced `lookaheadSegmentAzimuth` against `lookaheadPoint` line-by-line (byte-identical traversal → same segment landing), independently verified all 4 test assertions, no boundary/OOB defects.
 - Static analysis: cpplint + cppcheck clean on all changed lines; new function has zero findings. Pre-existing package-wide lint (legal/copyright, line-length) exists on untouched lines — not attributable to this PR.
 - Plan drift: none. Governance: all consequences addressed; ADR-0008/0013 compliant.
+
+## Implementation
+**Status**: complete
+**When**: 2026-07-01 14:09 +00:00
+**By**: Claude Code Agent (Claude Opus)
+
+**Branch**: feature/issue-91 at `fc424d1`
+**Addressed**: `## Local Review (Pre-Push)` (When 2026-07-01 13:53 +00:00, at `acf8bea`)
+**Commits**: `178d069`, `de0182c`, `fc424d1`
+
+Consumed the four unchecked suggestions from the pre-push review. Three fixed via
+code/doc/test changes; one deferred (no simulator offline). All 5 gtest suites
+re-verified locally after the changes: `test_path_geometry` 23/23 (22 prior + 1
+new hairpin), `test_crabbing_control` 10/10, `test_curvature_speed_factor` 15/15,
+`test_gain_schedule` 9/9, `test_turn_speed_factor` 7/7 — 0 failures. Build clean
+(only pre-existing unused-parameter / sign-compare warnings on untouched lines).
+
+### Actions
+- [x] Correct discrete-step rate-bound comment: `max_yaw_rate_` defaults to ±pi rad/s (~180°/s) so the controller-level clamp is effectively a no-op at default params; the external `velocity_smoother` is the real rate limiter. Comment rewritten to credit it, cross-referencing `crabbing_path_follower.h:107-111` — `src/crabbing_path_follower.cpp:905` (`178d069`)
+- [x] Add worst-case (hairpin) test `HairpinReversalStepsByNearlyPi` characterizing the near-π single-cycle `base_heading` step at a ~180° reversal, and documenting that this pure geometry helper deliberately has no hysteresis (smoothing is the downstream `velocity_smoother`'s job) — `test/test_path_geometry.cpp` (`de0182c`). Hysteresis itself is a separate design change with its own state/tuning, out of scope for the #91 bug fix (deferred to a follow-up).
+- [x] Document the mixed-reference bend-regime limitation at the `target_heading = base_heading + crab_angle` superposition: proven-convergent only in the straight (same-segment) regime; the bend transition is a bounded, self-correcting heuristic verified by the owed sim check, not a unit test — `src/crabbing_path_follower.cpp:936` (`fc424d1`)
+- [x] Sim/log monotonic cross-track decay acceptance check — `n/a` (deferred: no simulator in this offline container; a manual review-code/merge deliverable, not a code change — still owed before merge, as the review itself flagged)

--- a/.agent/work-plans/issue-91/progress.md
+++ b/.agent/work-plans/issue-91/progress.md
@@ -67,3 +67,15 @@ gated on stable look-ahead). No blocking dependency on open issues.
 ### Actions
 - [ ] Add `lookaheadSegmentAzimuth` (or combined `lookaheadPointAndSegment`) to `path_geometry.hpp` and unit-test it in `test_path_geometry.cpp`.
 - [ ] Verify/update DEBUG log string at line 897 after changing the `base_heading` computation.
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-07-01 12:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Plan**: `.agent/work-plans/issue-91/plan.md` at `3c60486`
+**Branch**: feature/issue-91 at `3c60486`
+**Phases**: single
+
+### Open questions
+- [ ] No open questions — plan is review-plan-ready.

--- a/.agent/work-plans/issue-91/progress.md
+++ b/.agent/work-plans/issue-91/progress.md
@@ -144,7 +144,7 @@ None. Approach and all four planned tests implemented as specified, with the 3 P
 **Round**: 1 | **Ship**: recommended — no must-fix findings; clean, well-scoped control-law fix, 22/22 gtests re-verified locally, static analysis clean on changed lines.
 
 ### Findings
-- [ ] (suggestion) Comment at `:905-907` credits the `max_yaw_rate` clamp as the discrete-step bound, but at default params it is a no-op — the external `velocity_smoother` is the real bound (see `crabbing_path_follower.h:108-109`) — `src/crabbing_path_follower.cpp:905`
+- [x] (suggestion) Comment at `:905-907` credits the `max_yaw_rate` clamp as the discrete-step bound, but at default params it is a no-op — the external `velocity_smoother` is the real bound (see `crabbing_path_follower.h:108-109`) — `src/crabbing_path_follower.cpp:905`
 - [ ] (suggestion) Segment-tangent `base_heading` can toggle across a vertex cycle-to-cycle on dense/short-segment plans (chatter); no hysteresis and no worst-case (hairpin) test — `include/marine_nav_crabbing_path_follower/path_geometry.hpp:143`
 - [ ] (suggestion) Mixed-reference bend regime: `base_heading` (ahead segment) + `crab_angle` (current segment) superposed; convergence provable only in the straight regime; transition untested — `src/crabbing_path_follower.cpp:936`
 - [ ] (suggestion/owed) Sim/log monotonic cross-track decay acceptance check still unverified — could not run in offline container (no simulator); owed before merge — `n/a`

--- a/marine_nav_crabbing_path_follower/include/marine_nav_crabbing_path_follower/path_geometry.hpp
+++ b/marine_nav_crabbing_path_follower/include/marine_nav_crabbing_path_follower/path_geometry.hpp
@@ -105,6 +105,63 @@ inline geometry_msgs::msg::Point lookaheadPoint(
   return poses[last].pose.position;
 }
 
+/// Azimuth (radians, `atan2(dy, dx)`) of the path segment that CONTAINS the
+/// pure-pursuit look-ahead point — the path tangent `lookahead` metres ahead.
+///
+/// Walks the path with the SAME forward-only traversal as `lookaheadPoint`
+/// (same `start_seg`/`start_offset`/`lookahead` contract) but returns the
+/// azimuth of the segment the look-ahead point lands on rather than the point
+/// itself. Used as the follower's `base_heading` so cross-track correction is
+/// left solely to the crab PID (no pure-pursuit double-counting; #91).
+///
+/// If the look-ahead runs past the end of the path — or the start segment is
+/// already past the last segment — the FINAL segment's azimuth is returned
+/// (mirroring `lookaheadPoint`'s goal-clamp), so overshoot yields the tangent
+/// the boat is converging along, not a degenerate value. Only genuinely
+/// degenerate inputs return `0.0`: an empty path, a single point (no segment),
+/// or an all-coincident / zero-length path (`atan2(0, 0)` is naturally `0.0`).
+inline double lookaheadSegmentAzimuth(
+  const std::vector<geometry_msgs::msg::PoseStamped> & poses,
+  int start_seg, double start_offset, double lookahead)
+{
+  if (poses.empty()) {
+    return 0.0;
+  }
+  const int last = static_cast<int>(poses.size()) - 1;
+  if (last == 0) {
+    return 0.0;
+  }
+  if (start_seg < 0) {
+    start_seg = 0;
+  }
+  if (start_seg > last - 1) {
+    const auto & a = poses[last - 1].pose.position;
+    const auto & b = poses[last].pose.position;
+    return std::atan2(b.y - a.y, b.x - a.x);
+  }
+
+  double remaining = std::max(0.0, lookahead);
+  for (int i = start_seg; i < last; ++i) {
+    const auto & a = poses[i].pose.position;
+    const auto & b = poses[i + 1].pose.position;
+    const double seg_len = std::hypot(b.x - a.x, b.y - a.y);
+    const double offset = (i == start_seg) ? std::clamp(start_offset, 0.0, seg_len) : 0.0;
+    const double avail = seg_len - offset;
+
+    // Last segment, or the look-ahead lands within this segment: this is the
+    // segment containing the look-ahead point.
+    if (remaining <= avail || i == last - 1) {
+      return std::atan2(b.y - a.y, b.x - a.x);
+    }
+    remaining -= avail;
+  }
+  // Unreachable (the loop always returns on i == last - 1); mirrors the
+  // trailing final-segment return of `lookaheadPoint`.
+  const auto & a = poses[last - 1].pose.position;
+  const auto & b = poses[last].pose.position;
+  return std::atan2(b.y - a.y, b.x - a.x);
+}
+
 /// Speed-normalize (gain-schedule) the cross-track PID output `crab_angle_deg`.
 ///
 /// The outer cross-track loop has `ė ≈ v·sin(crab_angle) ≈ v·(p·e)`, so its

--- a/marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp
+++ b/marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp
@@ -948,8 +948,10 @@ geometry_msgs::msg::TwistStamped CrabbingPathFollower::computeVelocityCommands(
   // the tangent of the segment `lookahead` metres AHEAD while crab_angle still
   // corrects cross-track on the CURRENT segment, so during the vertex transition
   // the superposition is a heuristic, not a proven-convergent law. It is bounded
-  // (crab_angle is clamped and base_heading steps by at most one segment's
-  // turn), self-corrects once the boat and its look-ahead point are on the same
+  // (crab_angle is clamped; base_heading steps by the turn at each crossed
+  // vertex — usually one per cycle, but on dense/short-segment plans the
+  // look-ahead point may cross several vertices in a single cycle),
+  // self-corrects once the boat and its look-ahead point are on the same
   // segment again, and — being the whole point of #91 — anticipates the bend
   // rather than reacting to it. The bend-regime transition is verified by the
   // sim/log monotonic cross-track decay check owed at review-code (no offline

--- a/marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp
+++ b/marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp
@@ -941,6 +941,19 @@ geometry_msgs::msg::TwistStamped CrabbingPathFollower::computeVelocityCommands(
       global_plan_.poses, current_segment_, progress, lookahead));
   }
 
+  // Superpose the two references. In the straight regime base_heading and the
+  // crab PID's cross-track reference share the SAME segment, and the closed-loop
+  // cross-track convergence is provable (the crab loop alone; #76/#91). With
+  // look-ahead enabled through a bend the references are MIXED: base_heading is
+  // the tangent of the segment `lookahead` metres AHEAD while crab_angle still
+  // corrects cross-track on the CURRENT segment, so during the vertex transition
+  // the superposition is a heuristic, not a proven-convergent law. It is bounded
+  // (crab_angle is clamped and base_heading steps by at most one segment's
+  // turn), self-corrects once the boat and its look-ahead point are on the same
+  // segment again, and — being the whole point of #91 — anticipates the bend
+  // rather than reacting to it. The bend-regime transition is verified by the
+  // sim/log monotonic cross-track decay check owed at review-code (no offline
+  // simulator here), not by a unit test.
   AngleRadians target_heading = base_heading + crab_angle;
 
   // Inner heading loop: proportional heading-error -> yaw rate, with a tunable

--- a/marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp
+++ b/marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp
@@ -903,8 +903,12 @@ geometry_msgs::msg::TwistStamped CrabbingPathFollower::computeVelocityCommands(
   // boat-to-point bearing: that would fold cross-track correction into
   // base_heading and double-count with the crab PID, which already corrects
   // cross-track error (#91). This segment-tangent base_heading steps discretely
-  // as the look-ahead point crosses a vertex from one segment to the next; the
-  // step is bounded downstream by the max_yaw_rate clamp on the yaw command. The
+  // as the look-ahead point crosses a vertex from one segment to the next. That
+  // step is smoothed downstream by the external velocity_smoother, which
+  // enforces the physical yaw rate/accel limits: the controller-level
+  // max_yaw_rate_ clamp on the yaw command (crabbing_path_follower.h:107-111)
+  // defaults to ±pi rad/s and so is effectively a no-op at default params — a
+  // safety bound, not the real rate limiter. The
   // look-ahead distance is fixed (lookahead_distance_) or speed-scaled
   // (lookahead_time_ > 0: L = max(lookahead_min_distance_, V*time)).
   // Snapshot the live-tunable atomics once so a mid-cycle `ros2 param set`

--- a/marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp
+++ b/marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp
@@ -897,9 +897,15 @@ geometry_msgs::msg::TwistStamped CrabbingPathFollower::computeVelocityCommands(
   RCLCPP_DEBUG_STREAM(logger_, "CrabbingPathFollower: progress: " << progress << " cross_track_error: " << cross_track_error << " crab_angle: " << crab_angle.value() << " heading: " << heading.value() << " segment_azimuth: " << segment_azimuth.value());
 
   // Base heading: the local segment azimuth (default), or — with look-ahead
-  // enabled — the pure-pursuit bearing to a point `lookahead` metres ahead on
-  // the path, which anticipates bends instead of reacting to them. The look-
-  // ahead distance is fixed (lookahead_distance_) or speed-scaled
+  // enabled — the path tangent at the look-ahead point `lookahead` metres ahead
+  // on the path (the azimuth of the segment that point falls on), which
+  // anticipates bends instead of reacting to them. Deliberately NOT the
+  // boat-to-point bearing: that would fold cross-track correction into
+  // base_heading and double-count with the crab PID, which already corrects
+  // cross-track error (#91). This segment-tangent base_heading steps discretely
+  // as the look-ahead point crosses a vertex from one segment to the next; the
+  // step is bounded downstream by the max_yaw_rate clamp on the yaw command. The
+  // look-ahead distance is fixed (lookahead_distance_) or speed-scaled
   // (lookahead_time_ > 0: L = max(lookahead_min_distance_, V*time)).
   // Snapshot the live-tunable atomics once so a mid-cycle `ros2 param set`
   // can't tear the control law.
@@ -927,9 +933,8 @@ geometry_msgs::msg::TwistStamped CrabbingPathFollower::computeVelocityCommands(
     // the segment start measures the horizon from the segment start.
     la_point = lookaheadPoint(
       global_plan_.poses, current_segment_, progress, lookahead);
-    base_heading = AngleRadians(atan2(
-      la_point.y - pose_in_plan.pose.position.y,
-      la_point.x - pose_in_plan.pose.position.x));
+    base_heading = AngleRadians(lookaheadSegmentAzimuth(
+      global_plan_.poses, current_segment_, progress, lookahead));
   }
 
   AngleRadians target_heading = base_heading + crab_angle;

--- a/marine_nav_crabbing_path_follower/test/test_path_geometry.cpp
+++ b/marine_nav_crabbing_path_follower/test/test_path_geometry.cpp
@@ -138,6 +138,28 @@ TEST(LookaheadSegmentAzimuth, HandlesDegeneratePaths)
   EXPECT_EQ(lookaheadSegmentAzimuth(single, 0, 0.0, 5.0), 0.0);
 }
 
+// Worst-case (hairpin) discrete step. base_heading is the tangent of the
+// segment the look-ahead point lands on, so at a near-180° reversal it jumps
+// by nearly pi in the single cycle the point crosses the vertex — the largest
+// step this function can emit. This test characterizes that worst case (the
+// chatter bound flagged in #91 review): the step is real and, on
+// dense/short-segment plans, can toggle cycle-to-cycle. There is deliberately
+// NO hysteresis in this pure geometry helper — smoothing is left to the
+// downstream velocity_smoother; adding hysteresis would be a separate design
+// change with its own state and tuning (out of scope for the #91 bug fix).
+TEST(LookaheadSegmentAzimuth, HairpinReversalStepsByNearlyPi)
+{
+  // A(0,0) -> B(20,0): east (azimuth 0). B(20,0) -> C(0,1): back west with a
+  // slight north offset, azimuth atan2(1, -20) ~= pi - 0.05, a hairpin at B.
+  auto path = makePath({{0, 0}, {20, 0}, {0, 1}});
+  const double az_before = lookaheadSegmentAzimuth(path, 0, 16.0, 1.0);   // on A->B
+  const double az_after = lookaheadSegmentAzimuth(path, 0, 16.0, 10.0);   // past B
+  EXPECT_NEAR(az_before, 0.0, 1e-9);
+  EXPECT_NEAR(az_after, std::atan2(1.0, -20.0), 1e-9);
+  // The single-cycle base_heading step at the vertex approaches pi (worst case).
+  EXPECT_GT(std::abs(az_after - az_before), 3.0);
+}
+
 namespace
 {
 geometry_msgs::msg::Point pt(double x, double y)

--- a/marine_nav_crabbing_path_follower/test/test_path_geometry.cpp
+++ b/marine_nav_crabbing_path_follower/test/test_path_geometry.cpp
@@ -8,6 +8,7 @@
 #include "marine_nav_crabbing_path_follower/path_geometry.hpp"
 
 using marine_nav_crabbing_path_follower::lookaheadPoint;
+using marine_nav_crabbing_path_follower::lookaheadSegmentAzimuth;
 
 namespace
 {
@@ -84,6 +85,57 @@ TEST(LookaheadPoint, OutOfRangeStartSegmentReturnsGoal)
   auto path = makePath({{0, 0}, {20, 0}});
   auto p = lookaheadPoint(path, 5, 0.0, 3.0);
   EXPECT_NEAR(p.x, 20.0, 1e-6);
+}
+
+// The acceptance-criteria test: the look-ahead azimuth is the PATH TANGENT and
+// therefore independent of the boat's cross-track offset. Two boats with
+// different offsets project to the same along-track spot; both must get the
+// segment azimuth (0 rad for an eastbound straight), not a boat-to-point
+// bearing that would tilt with the offset.
+TEST(LookaheadSegmentAzimuth, StraightLineIsBoatPositionIndependent)
+{
+  auto path = makePath({{0, 0}, {20, 0}});  // eastbound, azimuth 0
+  // Same along-track projection (offset 5 m into segment 0), same look-ahead:
+  // the function takes no boat position at all, so the result is the segment
+  // azimuth regardless of any cross-track error the caller may be off by.
+  EXPECT_NEAR(lookaheadSegmentAzimuth(path, 0, 5.0, 10.0), 0.0, 1e-9);
+}
+
+// Look-ahead reaching past a vertex returns the NEXT segment's azimuth — the
+// tangent the boat should anticipate, not the segment it is currently on.
+TEST(LookaheadSegmentAzimuth, AnticipatesNextSegmentPastBend)
+{
+  // A(0,0) -> B(20,0) -> C(30,10): straight east, then a 45° left bend at B.
+  auto path = makePath({{0, 0}, {20, 0}, {30, 10}});
+  // Projected at x = 16 (offset 16 on seg 0), look 10 m: 4 m to B, then 6 m up
+  // B->C, so the look-ahead point lands on segment B->C (azimuth atan2(10,10)).
+  EXPECT_NEAR(
+    lookaheadSegmentAzimuth(path, 0, 16.0, 10.0), std::atan2(10.0, 10.0), 1e-9);
+  // A short horizon stays on the current segment (azimuth 0).
+  EXPECT_NEAR(lookaheadSegmentAzimuth(path, 0, 16.0, 1.0), 0.0, 1e-9);
+}
+
+// Past the end of the path, clamp to the FINAL segment's azimuth (mirrors
+// lookaheadPoint's goal-clamp) rather than folding into the 0.0 degenerate.
+TEST(LookaheadSegmentAzimuth, ClampsToFinalSegmentPastEnd)
+{
+  // Final segment B->C points north-east (azimuth atan2(10,10) = pi/4).
+  auto path = makePath({{0, 0}, {20, 0}, {30, 10}});
+  EXPECT_NEAR(
+    lookaheadSegmentAzimuth(path, 0, 0.0, 1000.0), std::atan2(10.0, 10.0), 1e-9);
+  // A start segment already past the last segment also clamps to the final one.
+  EXPECT_NEAR(
+    lookaheadSegmentAzimuth(path, 9, 0.0, 3.0), std::atan2(10.0, 10.0), 1e-9);
+}
+
+// Degenerate paths return 0.0 and must not read out of bounds.
+TEST(LookaheadSegmentAzimuth, HandlesDegeneratePaths)
+{
+  double a = -1.0;
+  EXPECT_NO_THROW(a = lookaheadSegmentAzimuth({}, 0, 0.0, 5.0));
+  EXPECT_EQ(a, 0.0);
+  auto single = makePath({{3, 4}});
+  EXPECT_EQ(lookaheadSegmentAzimuth(single, 0, 0.0, 5.0), 0.0);
 }
 
 namespace


### PR DESCRIPTION
## Summary

Fixes `CrabbingPathFollower` going off course when look-ahead is enabled (`lookahead_time` or `lookahead_distance` > 0), worst at short horizons (`lookahead_time` 1–2 s at survey speed).

**Root cause:** with look-ahead on, `base_heading` was set to the bearing *from the boat's position to* the look-ahead point (pure pursuit), then the crab-angle PID was added on top. Pure pursuit already corrects cross-track error, and the crab PID corrects the *same* error again → double correction → overshoot → oscillate off course. (With zero cross-track error the two headings coincide, so it looked fine on a straight line until any error appeared.)

**Fix:** `base_heading` now uses the **path tangent at the look-ahead point** (the azimuth of the segment the look-ahead point falls on), leaving cross-track correction solely to the crab PID. This still anticipates upcoming bends but removes the double-counting. On a straight path it's identical to the segment azimuth (zero-error case unchanged); on a bend it pre-rotates toward the upcoming segment.

## Changes

- New pure `lookaheadSegmentAzimuth()` in `path_geometry.hpp` — walks the path like `lookaheadPoint` but returns the containing segment's azimuth; **takes no boat position** (that's the whole point). Past-end overshoot clamps to the **final segment's** azimuth (mirrors `lookaheadPoint`'s goal-clamp); only genuinely degenerate inputs (empty/single-point/zero-length) return 0.0.
- `crabbing_path_follower.cpp`: swapped the `atan2(la_point − boat_pos)` bearing for `lookaheadSegmentAzimuth(...)`. `la_point` is **kept** — the #90 curvature block reuses it. Comment block updated (path-tangent rationale; the vertex-crossing step is bounded by the downstream `velocity_smoother`, not the effectively-no-op `max_yaw_rate` clamp; on dense plans multiple vertices may be crossed per cycle).

## Tests

`test_path_geometry` **23/23** (18 prior + 5 new `LookaheadSegmentAzimuth`: boat-position independence [the AC test], next-segment anticipation past a bend, past-end final-segment clamp, degenerate inputs, and a hairpin near-π step). Full package: `test_path_geometry` 23/23, `test_crabbing_control` 10/10, `test_curvature_speed_factor` 15/15, `test_gain_schedule` 9/9, `test_turn_speed_factor` 7/7 — 0 failures. Build clean.

## ⚠️ Owed before merge — manual sim verification

This changes **active steering behavior**, and the acceptance-criteria sim/log check is **not yet done** (no simulator in the offline review container). **Before merging**, run the sim with `lookahead_time` 0 vs 1–2 s and confirm cross-track error decays **monotonically** (no growing oscillation) with look-ahead enabled, and watch for vertex chatter on the bend regime. The bend-regime superposition (`base_heading` on the ahead segment + `crab_angle` on the current segment) is a bounded self-correcting heuristic, proven-convergent only on straights — the sim is what validates the transition.

## Review

Local pre-push review, 2 rounds (0 must-fix). Round-1's 4 suggestions addressed: comment corrected to credit the `velocity_smoother` as the real rate bound; hairpin/worst-case test added (hysteresis deliberately **not** added — that's a separate design change, deferred to a follow-up); bend-regime limitation documented. A Lens-B "must-fix" (discrete `base_heading` step → yaw) was triaged down — the default `segment_azimuth` law already steps identically at every vertex, and the smoother reliance predates #91.

**Noted follow-up (not filed):** the `velocity_smoother` is a documented-only hard dependency (not shipped/declared by this package). Pre-existing, out of scope for #91.

Reported by operator (off-course in sim). Related: #90 (curvature feature, which only activates with look-ahead enabled — this unblocks it). Field RCA: rolker/unh_echoboats_project11#361.

Closes #91

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
