### PR TITLE
Geometry-preserving segment cursor across same-goal setPlan re-issues (#99)

### DIFF
--- a/.agent/work-plans/issue-99/plan.md
+++ b/.agent/work-plans/issue-99/plan.md
@@ -1,0 +1,96 @@
+# Plan: CrabbingPathFollower — geometry-preserving segment cursor across same-goal setPlan re-issues
+
+## Issue
+
+https://github.com/rolker/unh_marine_navigation/issues/99
+
+## Context
+
+`CrabbingPathFollower::setPlan` (crabbing_path_follower.cpp:684) preserves `current_segment_`
+**by raw index** across same-goal re-issues, with `min(index, segment_count−1)` as the
+shorter-path fallback. Under the AvoidanceController the inner follower alternates between the
+sparse N-waypoint nominal path and dense 2 m station-resampled reshapes of the same goal, so a
+dense-path index caps onto the **final leg** of the sparse path. Bag-proven on 2026-07-21
+(Massabesic, echoboats#381): the boat abandoned an 8-waypoint return route at leg 1 and sailed
+away steering against leg 7. The index-preservation exists to keep the 2026-06-04 anti-snap-back
+property (#250: re-localizing from path start during a weave kicked the PID); the fix must keep
+that property while making the preserved quantity geometric, not an index.
+
+## Approach
+
+1. **Extract a pure cursor-mapping helper** into `path_geometry.hpp` (matches the existing
+   inline-helper + gtest pattern):
+   `mapCursorToNewPath(old_poses, old_segment_index, new_poses) -> new_segment_index`.
+   Anchor = the old current segment's **start point**. Map it to the new path by nearest-point
+   projection over all new segments; tie-break candidates within ~2× the projection distance by
+   smallest |arc-length fraction difference| vs the old cursor's fraction. Geometric anchoring
+   (not raw arc length) survives both density flips **and** truncated re-issues (BT-pruned
+   transit paths whose start advances).
+2. **Use it in `setPlan`**: keep the `new_line` goal-moved reset exactly as-is; in the same-goal
+   branch replace index carry-over + cap with the mapping helper. Clamp the result to
+   `[0, segment_count−1]` — never the `segment_count` done-sentinel, so a shortened re-issue
+   near the goal finishes via the normal forward scan + goal checker instead of stalling.
+   Rewrite the 06-04 comment block to document the geometric invariant.
+3. **Delete the `min(index, segment_count−1)` cap branch** (subsumed by the helper's clamp);
+   keep a debug log when the mapped index differs from the old index by > 1 segment.
+4. **Unit tests** in a new `test/test_plan_cursor.cpp` (pure helper, no ROS node needed):
+   - 07-21 regression: 8-waypoint zigzag; cursor on leg 1 of the dense (2 m-resampled) variant
+     maps back to leg 1 of the sparse variant — never leg 7 — and round-trips sparse→dense.
+   - Laterally offset (≤ 6 m corridor-style) same-goal variant maps to the same leg.
+   - Truncated same-goal re-issue (drop the first k poses): cursor maps to the geometrically
+     same location, not index-shifted.
+   - Shortened path with old cursor past the new end: clamps to last traversable segment,
+     never `segment_count`.
+   - Reference-step bound: across a dense↔sparse flip mid-leg, the cross-track error to the
+     mapped segment changes by < the #66 slew absorption for one 5 Hz cycle (0.6 m at the
+     configured 3 m/s) for an on-path pose.
+   - Anti-snap-back (#250 property): mapping is pose-independent and monotone under forward
+     progress — repeated same-shape re-issues never move the cursor backward.
+5. **Build + test** via `./core_ws/build.sh marine_nav_crabbing_path_follower` and
+   `./core_ws/test.sh marine_nav_crabbing_path_follower`; run `/review-code` pre-push.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `marine_nav_crabbing_path_follower/include/.../path_geometry.hpp` | Add `mapCursorToNewPath` (+ small arc-length helpers if needed) |
+| `marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp` | `setPlan`: same-goal branch uses the helper; remove cap branch; rewrite comment |
+| `marine_nav_crabbing_path_follower/test/test_plan_cursor.cpp` | New gtest suite (cases in step 4) |
+| `marine_nav_crabbing_path_follower/CMakeLists.txt` | Register the new test |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Test what breaks | Every failure mode from the field event becomes a named test case; the fix is landed with its regression suite |
+| A change includes its consequences | 06-04 comment block rewritten; cap branch removed rather than left dead; deploy consequence (gabby core_ws rebuild) recorded in the PR |
+| Only what's needed | AvoidanceController always-resample companion and large-cross-track acquisition mode deliberately out of scope (separate issues) |
+| Improve incrementally | Pure-helper extraction reuses the existing path_geometry test pattern instead of introducing a node-level test harness |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0008 (ROS 2 conventions) | Yes | nav2_core::Controller contract unchanged; no API/param changes |
+| 0018 (local-first CI) | Yes | Merge may use full-scope `ci_local.sh` attestation on the PR head |
+| Others | No | Workflow-level only |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| setPlan cursor semantics | 06-04 rationale comment in setPlan | Yes (step 2) |
+| Cursor behavior shared by BEN/Izzy/seafloor echoboats | Sim/straight-line sanity via existing test suite + echoboat240 sim scenario | Partially — sim zigzag scenario tracked in echoboats#381 thread 2b, not this PR |
+| Fix effective on Bizzy | gabby core_ws rebuild before next deployment | No — deployment step, noted in PR body |
+
+## Open Questions
+
+- Tie-break window for ambiguous nearest-point candidates (self-crossing paths): proposing
+  arc-fraction tie-break; acceptable, or prefer a bounded forward-only search window?
+- Land the AvoidanceController always-resample companion as a separate issue now, or wait until
+  this fix soaks in sim?
+
+## Estimated Scope
+
+Single PR (helper + setPlan change + tests). Sim-scenario validation shared with nav#100 tracked
+under echoboats#381.

--- a/.agent/work-plans/issue-99/plan.md
+++ b/.agent/work-plans/issue-99/plan.md
@@ -46,7 +46,10 @@ that property while making the preserved quantity geometric, not an index.
 4. **Unit tests** in a new `test/test_plan_cursor.cpp` (pure helper, no ROS node needed):
    - 07-21 regression: 8-waypoint zigzag; cursor on leg 1 of the dense (2 m-resampled) variant
      maps back to leg 1 of the sparse variant — never leg 7 — and round-trips sparse→dense.
-   - Laterally offset (≤ 6 m corridor-style) same-goal variant maps to the same leg.
+   - Laterally offset (≤ 6 m corridor-style) same-goal variant: mid-leg cursors map to the
+     same leg exactly; vertex-anchored cursors (sparse old path — anchor on the leg boundary)
+     may land one station into the previous leg's tail (forward scan re-advances within the
+     cycle) but must stay geometrically at the anchor and never capture a distant leg.
    - Truncated same-goal re-issue (drop the first k poses): cursor maps to the geometrically
      same location, not index-shifted.
    - Shortened path with old cursor past the new end: clamps to last traversable segment,

--- a/.agent/work-plans/issue-99/plan.md
+++ b/.agent/work-plans/issue-99/plan.md
@@ -21,16 +21,26 @@ that property while making the preserved quantity geometric, not an index.
 1. **Extract a pure cursor-mapping helper** into `path_geometry.hpp` (matches the existing
    inline-helper + gtest pattern):
    `mapCursorToNewPath(old_poses, old_segment_index, new_poses) -> new_segment_index`.
-   Anchor = the old current segment's **start point**. Map it to the new path by nearest-point
-   projection over all new segments; tie-break candidates within ~2× the projection distance by
-   smallest |arc-length fraction difference| vs the old cursor's fraction. Geometric anchoring
-   (not raw arc length) survives both density flips **and** truncated re-issues (BT-pruned
-   transit paths whose start advances).
+   Anchor = the old current segment's **start point**. Hybrid mapping (per plan review):
+   restrict candidates to a **bounded arc-length window** around the old cursor's arc-length
+   position (window = max(25 m, 10% of new path length)), pick the nearest-point segment within
+   the window; fall back to global nearest with arc-fraction tie-break only if the window yields
+   no sane candidate (log when that happens). The window is what prevents capture by an
+   **adjacent parallel leg** on boustrophedon patterns when a lateral offset approaches half the
+   leg spacing — adjacent legs are far away in arc length even when close in space. Geometric
+   anchoring (not raw arc length alone) survives density flips **and** truncated re-issues
+   (BT-pruned transit paths whose start advances). Fast path: identical pose count + endpoints
+   → keep the cursor unchanged. Guard degenerate inputs (empty / single-pose new path → 0),
+   matching the defensive style of the other `path_geometry.hpp` helpers.
 2. **Use it in `setPlan`**: keep the `new_line` goal-moved reset exactly as-is; in the same-goal
    branch replace index carry-over + cap with the mapping helper. Clamp the result to
    `[0, segment_count−1]` — never the `segment_count` done-sentinel, so a shortened re-issue
    near the goal finishes via the normal forward scan + goal checker instead of stalling.
-   Rewrite the 06-04 comment block to document the geometric invariant.
+   Rewrite the 06-04 comment block to document the geometric invariant, including the
+   interaction with the compute-side forward scan: the scan only advances, so the mapper may
+   legitimately land the cursor at a segment whose start is slightly behind the boat's
+   projection — the scan re-advances within the same cycle; the mapper must never place the
+   cursor far backward (that is the #250 snap-back the window bound prevents).
 3. **Delete the `min(index, segment_count−1)` cap branch** (subsumed by the helper's clamp);
    keep a debug log when the mapped index differs from the old index by > 1 segment.
 4. **Unit tests** in a new `test/test_plan_cursor.cpp` (pure helper, no ROS node needed):
@@ -41,9 +51,13 @@ that property while making the preserved quantity geometric, not an index.
      same location, not index-shifted.
    - Shortened path with old cursor past the new end: clamps to last traversable segment,
      never `segment_count`.
-   - Reference-step bound: across a dense↔sparse flip mid-leg, the cross-track error to the
-     mapped segment changes by < the #66 slew absorption for one 5 Hz cycle (0.6 m at the
-     configured 3 m/s) for an on-path pose.
+   - Adversarial parallel-leg case: boustrophedon legs 8 m apart, current leg reshaped 6 m
+     toward the neighbor (anchor strictly nearer the wrong leg) — window mapping must stay on
+     the current leg where global-nearest would capture the neighbor.
+   - Reference-step bound (purely geometric — must NOT rely on the #66 slew limiter, which
+     defaults to 0.0/off): across a dense↔sparse flip mid-leg with an on-path pose, the
+     cross-track error to the mapped segment changes by < 0.5 m.
+   - Degenerate inputs: empty and single-pose new paths → cursor 0, no UB.
    - Anti-snap-back (#250 property): mapping is pose-independent and monotone under forward
      progress — repeated same-shape re-issues never move the cursor backward.
 5. **Build + test** via `./core_ws/build.sh marine_nav_crabbing_path_follower` and
@@ -85,8 +99,8 @@ that property while making the preserved quantity geometric, not an index.
 
 ## Open Questions
 
-- Tie-break window for ambiguous nearest-point candidates (self-crossing paths): proposing
-  arc-fraction tie-break; acceptable, or prefer a bounded forward-only search window?
+- ~~Tie-break strategy~~ — resolved per plan review: bounded arc-length window primary,
+  global nearest + arc-fraction tie-break as logged fallback.
 - Land the AvoidanceController always-resample companion as a separate issue now, or wait until
   this fix soaks in sim?
 

--- a/.agent/work-plans/issue-99/progress.md
+++ b/.agent/work-plans/issue-99/progress.md
@@ -40,3 +40,34 @@ and principles self-check are sound. Findings are refinements, not structural ga
 - [ ] (suggestion) Test-bullet-5 reference-step bound is mis-stated: it cites "the #66 slew absorption for one 5 Hz cycle (0.6 m at the configured 3 m/s)", but `cross_track_error_slew_rate` is a separate parameter defaulting to 0.0 (limiter OFF), not the vehicle speed — per-cycle absorption is `slew_rate·dt` and is zero by default; the controller runs ~10 Hz (project AGENTS.md), not 5 Hz. Reframe the assertion geometrically (the cursor mapping itself bounds the cross-track reference step), since the fix must not lean on a default-off slew limiter as the safety net — `plan.md:44-46`
 - [ ] (suggestion) Degenerate new-path guard: `mapCursorToNewPath` should defensively handle empty / single-pose new paths (floor via `std::max(0, segment_count−1)`, mirroring the existing cap and the empty/single-point guards throughout `path_geometry.hpp`), with a named test case — `plan.md:36-48`
 - [ ] (observation) Anchor granularity: anchoring at the old current segment's START point (not the boat's projected position) means sparse→dense flips re-localize to the leg start and rely on `computeVelocityCommands`' forward scan (`crabbing_path_follower.cpp:794-843`) to re-advance within the same cycle — safe (conservative, never overshoots, pose-based + monotone) but the plan should note this interaction so the implementer preserves the compute-side localizer — `plan.md:21-33`
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-07-23 08:09 -04:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: approved
+
+**Branch**: feature/issue-99 at `46cb847`
+**Mode**: pre-push
+**Depth**: Deep (reason: 689 changed lines >200; safety-critical nav-control path)
+**Must-fix**: 0 | **Suggestions**: 1
+**Round**: 1 | **Ship**: recommended — no must-fix; core algorithm verified correct and the gated gtest suite passes
+
+Static analysis: cppcheck clean on new files (2 findings on `crabbing_path_follower.cpp` are on
+pre-existing untouched lines, out of scope). cpplint/copyright/uncrustify failures are pre-existing
+package-wide debt (verified against `origin/jazzy`), tracked in `unh_marine_navigation#98` and
+excluded from the hosted CI gate (`ci.yml` `-LE linter` / `-m "not linter"`); the new file rides the
+same package convention. Governance: ADR-0008 (controller contract unchanged, no API/param change) —
+compliant; consequences (06-04 comment rewritten, cap branch removed not left dead, gabby rebuild
+noted for PR body) — addressed. Plan drift: none — all 4 planned files changed, every named test case
+present, all three prior plan-review findings folded in. Adversarial Lens A (logic) + Lens B
+(systemic/lifecycle) run in-context/sequential (no fresh-subagent dispatch available in this
+container): return value provably never the done-sentinel; first-plan path avoids empty-`global_plan_`
+UB; single-threaded state model unchanged; anchor-at-segment-start relies safely on the compute-side
+forward scan. **Build + test executed**: `test_plan_cursor` gtest PASSED (all cases), all other gated
+gtest suites PASSED.
+
+### Findings
+- [ ] (suggestion) `test/test_plan_cursor.cpp`: add direct `#include <limits>` (`std::numeric_limits`) and `#include <algorithm>` (`std::max`/`std::clamp`) — currently transitive via `path_geometry.hpp` (IWYU); minor, and cpplint's IWYU check rides the CI-excluded `linter` label — `test_plan_cursor.cpp:11-13`
+- [ ] (note) Adjacent-parallel-leg rejection has a documented boundary: a lateral reshape whose displacement approaches leg spacing can still fall to the global fallback and capture a neighbor. Acknowledged in code/plan; realistic-boundary test `AdjacentParallelLegNotCaptured` passes. Acceptable tradeoff, not a defect — `path_geometry.hpp:335-341`
+- [ ] (note) copyright/cpplint/uncrustify lint tests fail but are pre-existing package-wide debt (`unh_marine_navigation#98`), excluded from the CI gate; not a regression from this PR

--- a/.agent/work-plans/issue-99/progress.md
+++ b/.agent/work-plans/issue-99/progress.md
@@ -1,0 +1,18 @@
+---
+issue: 99
+---
+
+# Issue #99 — CrabbingPathFollower: segment cursor preserved by index across same-goal setPlan re-issues — dense→sparse flip skips to final leg
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-07-22 14:54 -04:00
+**By**: Claude Code Agent (Claude Fable 5)
+
+**Plan**: `.agent/work-plans/issue-99/plan.md` at `af355c7`
+**Branch**: feature/issue-99 at `af355c7`
+**Phases**: single
+
+### Open questions
+- [ ] Tie-break strategy for ambiguous nearest-point candidates (arc-fraction tie-break vs bounded forward-only window)
+- [ ] AvoidanceController always-resample companion: separate issue now, or after sim soak?

--- a/.agent/work-plans/issue-99/progress.md
+++ b/.agent/work-plans/issue-99/progress.md
@@ -16,3 +16,27 @@ issue: 99
 ### Open questions
 - [ ] Tie-break strategy for ambiguous nearest-point candidates (arc-fraction tie-break vs bounded forward-only window)
 - [ ] AvoidanceController always-resample companion: separate issue now, or after sim soak?
+
+## Plan Review
+**Status**: complete
+**When**: 2026-07-22 15:41 -04:00
+**By**: Claude Code Agent (Claude Opus)
+
+**Plan**: `.agent/work-plans/issue-99/plan.md` at `af355c7`
+**PR**: PR-less (--issue / file-path mode)
+**Verdict**: approve-with-suggestions
+
+Premise verified against source: `AvoidanceController::reshapeAroundObstacles`
+returns the sparse `nominal_plan_` when `peak < kDeviationEpsilon` (and on the
+no-costmap / <3-station / blocked-corridor fallbacks) and the dense n-station
+2 m reshape otherwise — the exact sparse↔dense same-goal alternation the issue
+describes. The `min(index, segment_count−1)` cap at `crabbing_path_follower.cpp:710`
+resolves a dense index onto the sparse final leg as claimed. File targeting is
+exact; scope (4 files) is single-PR; consequences table, ADR mapping (0008/0018),
+and principles self-check are sound. Findings are refinements, not structural gaps.
+
+### Findings
+- [ ] (suggestion — near must-fix) Self-crossing / tightly-spaced parallel-leg robustness: global nearest-point over all new segments + arc-fraction tie-break can mis-map a laterally-offset reshape onto an ADJACENT parallel leg once the offset approaches half the leg spacing. The plan's own Open Question flags this; resolve it toward a bounded forward-only window anchored on the previous cursor's arc-length/index (the issue's stated alternative), or a hybrid, and make the ≤6 m-corridor test adversarial (offset ≥ half the zigzag leg spacing) so it exercises the ambiguity instead of passing trivially — `plan.md:28-29`, `plan.md:39`, `plan.md:88`
+- [ ] (suggestion) Test-bullet-5 reference-step bound is mis-stated: it cites "the #66 slew absorption for one 5 Hz cycle (0.6 m at the configured 3 m/s)", but `cross_track_error_slew_rate` is a separate parameter defaulting to 0.0 (limiter OFF), not the vehicle speed — per-cycle absorption is `slew_rate·dt` and is zero by default; the controller runs ~10 Hz (project AGENTS.md), not 5 Hz. Reframe the assertion geometrically (the cursor mapping itself bounds the cross-track reference step), since the fix must not lean on a default-off slew limiter as the safety net — `plan.md:44-46`
+- [ ] (suggestion) Degenerate new-path guard: `mapCursorToNewPath` should defensively handle empty / single-pose new paths (floor via `std::max(0, segment_count−1)`, mirroring the existing cap and the empty/single-point guards throughout `path_geometry.hpp`), with a named test case — `plan.md:36-48`
+- [ ] (observation) Anchor granularity: anchoring at the old current segment's START point (not the boat's projected position) means sparse→dense flips re-localize to the leg start and rely on `computeVelocityCommands`' forward scan (`crabbing_path_follower.cpp:794-843`) to re-advance within the same cycle — safe (conservative, never overshoots, pose-based + monotone) but the plan should note this interaction so the implementer preserves the compute-side localizer — `plan.md:21-33`

--- a/marine_nav_crabbing_path_follower/CMakeLists.txt
+++ b/marine_nav_crabbing_path_follower/CMakeLists.txt
@@ -75,6 +75,13 @@ if(BUILD_TESTING)
     ament_target_dependencies(test_path_geometry geometry_msgs)
   endif()
 
+  ament_add_gtest(test_plan_cursor test/test_plan_cursor.cpp)
+  if(TARGET test_plan_cursor)
+    target_include_directories(test_plan_cursor PRIVATE
+      "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>")
+    ament_target_dependencies(test_plan_cursor geometry_msgs)
+  endif()
+
   ament_add_gtest(test_gain_schedule test/test_gain_schedule.cpp)
   if(TARGET test_gain_schedule)
     target_include_directories(test_gain_schedule PRIVATE

--- a/marine_nav_crabbing_path_follower/include/marine_nav_crabbing_path_follower/path_geometry.hpp
+++ b/marine_nav_crabbing_path_follower/include/marine_nav_crabbing_path_follower/path_geometry.hpp
@@ -332,6 +332,149 @@ inline double alongTrackProjection(
   return ((p.x - a.x) * sx + (p.y - a.y) * sy) / seg_len;
 }
 
+/// Arc-length window for mapCursorToNewPath candidate selection: absolute
+/// floor (m) and fraction of the new path's total length. The window must be
+/// large enough to absorb representation differences (density flips, corridor
+/// reshapes, modest front-truncation) yet smaller than a survey leg, so a
+/// laterally reshaped leg can never be captured by an adjacent parallel leg
+/// that is close in space but far away in arc length.
+constexpr double kCursorWindowMinMeters = 25.0;
+constexpr double kCursorWindowFraction = 0.1;
+
+/// Map the follower's segment cursor from one representation of a path onto
+/// another representation of the SAME goal — a different pose density (sparse
+/// per-waypoint nominal vs dense station-resampled reshape), a lateral
+/// corridor reshape, or a front-truncated re-issue (#99; the 2026-07-21
+/// Massabesic sail-away, unh_echoboats_project11#381). A raw index is
+/// meaningless across representations, so the cursor is re-anchored
+/// geometrically:
+///
+///   - anchor = the old current segment's START point, at arc-length position
+///     `s_old` along the old path;
+///   - candidates = new-path segments whose arc-length interval lies within a
+///     bounded window of `s_old` (`kCursorWindowMinMeters` /
+///     `kCursorWindowFraction`); the nearest candidate to the anchor wins;
+///   - the window result is kept unless it is grossly worse than the global
+///     nearest (3x + 1 m) — then the global nearest wins, tie-broken among
+///     near-equal candidates (2x + 1 m) toward the old arc position, and
+///     `*used_global_fallback` (when provided) is set so the caller can log.
+///
+/// The bounded window is what preserves the 2026-06-04 anti-snap-back
+/// property (#250: never re-localize far backward mid-weave) and what rejects
+/// adjacent-parallel-leg capture on boustrophedon patterns. Identical
+/// representations (same pose count and endpoints) short-circuit to the old
+/// index. Degenerate inputs (fewer than two poses on either path) return 0. A
+/// done-sentinel or out-of-range old index is clamped to the old path's last
+/// traversable segment before anchoring. The return value is always a
+/// traversable segment index in [0, new_poses.size() - 2] — never the
+/// done-sentinel — so a re-issue near the goal finishes via the compute-side
+/// forward scan and the goal checker instead of stalling on a zero command.
+inline int mapCursorToNewPath(
+  const std::vector<geometry_msgs::msg::PoseStamped> & old_poses,
+  int old_segment,
+  const std::vector<geometry_msgs::msg::PoseStamped> & new_poses,
+  bool * used_global_fallback = nullptr)
+{
+  if (used_global_fallback) {
+    *used_global_fallback = false;
+  }
+  const int new_last = static_cast<int>(new_poses.size()) - 1;
+  if (new_last < 1 || old_poses.size() < 2) {
+    return 0;
+  }
+  const int old_last = static_cast<int>(old_poses.size()) - 1;
+  const int old_seg = std::clamp(old_segment, 0, old_last - 1);
+
+  // Fast path: same representation — same pose count and same endpoints —
+  // keep the cursor (clamped into the new traversable range).
+  {
+    const auto & of = old_poses.front().pose.position;
+    const auto & nf = new_poses.front().pose.position;
+    const auto & ob = old_poses.back().pose.position;
+    const auto & nb = new_poses.back().pose.position;
+    if (old_poses.size() == new_poses.size() &&
+      std::hypot(nf.x - of.x, nf.y - of.y) < 1e-6 &&
+      std::hypot(nb.x - ob.x, nb.y - ob.y) < 1e-6)
+    {
+      return std::clamp(old_segment, 0, new_last - 1);
+    }
+  }
+
+  const auto & anchor = old_poses[old_seg].pose.position;
+  double s_old = 0.0;
+  for (int i = 0; i < old_seg; ++i) {
+    const auto & a = old_poses[i].pose.position;
+    const auto & b = old_poses[i + 1].pose.position;
+    s_old += std::hypot(b.x - a.x, b.y - a.y);
+  }
+
+  std::vector<double> cum(new_poses.size(), 0.0);
+  for (int i = 0; i < new_last; ++i) {
+    const auto & a = new_poses[i].pose.position;
+    const auto & b = new_poses[i + 1].pose.position;
+    cum[i + 1] = cum[i] + std::hypot(b.x - a.x, b.y - a.y);
+  }
+  const double total_new = cum[new_last];
+  const double window =
+    std::max(kCursorWindowMinMeters, kCursorWindowFraction * total_new);
+
+  // Point-to-segment distance from the anchor to new segment i.
+  std::vector<double> dist(new_last, 0.0);
+  for (int i = 0; i < new_last; ++i) {
+    const auto & a = new_poses[i].pose.position;
+    const auto & b = new_poses[i + 1].pose.position;
+    const double sx = b.x - a.x;
+    const double sy = b.y - a.y;
+    const double len2 = sx * sx + sy * sy;
+    double t = 0.0;
+    if (len2 > 1e-18) {
+      t = std::clamp(
+        ((anchor.x - a.x) * sx + (anchor.y - a.y) * sy) / len2, 0.0, 1.0);
+    }
+    dist[i] = std::hypot(anchor.x - (a.x + t * sx), anchor.y - (a.y + t * sy));
+  }
+
+  int best_window = -1;
+  double best_window_d = std::numeric_limits<double>::infinity();
+  int best_global = 0;
+  double best_global_d = std::numeric_limits<double>::infinity();
+  for (int i = 0; i < new_last; ++i) {
+    if (dist[i] < best_global_d) {
+      best_global_d = dist[i];
+      best_global = i;
+    }
+    const bool in_window =
+      cum[i + 1] >= s_old - window && cum[i] <= s_old + window;
+    if (in_window && dist[i] < best_window_d) {
+      best_window_d = dist[i];
+      best_window = i;
+    }
+  }
+
+  if (best_window >= 0 && best_window_d <= 3.0 * best_global_d + 1.0) {
+    return best_window;
+  }
+
+  // Window empty (e.g. heavy truncation pushed s_old past the new path) or
+  // grossly worse than the global optimum: fall back to the global nearest,
+  // tie-broken among near-equal candidates toward the old arc position.
+  if (used_global_fallback) {
+    *used_global_fallback = true;
+  }
+  int pick = best_global;
+  double best_gap = std::numeric_limits<double>::infinity();
+  for (int i = 0; i < new_last; ++i) {
+    if (dist[i] <= 2.0 * best_global_d + 1.0) {
+      const double gap = std::abs(0.5 * (cum[i] + cum[i + 1]) - s_old);
+      if (gap < best_gap) {
+        best_gap = gap;
+        pick = i;
+      }
+    }
+  }
+  return pick;
+}
+
 }  // namespace marine_nav_crabbing_path_follower
 
 #endif  // MARINE_NAV_CRABBING_PATH_FOLLOWER__PATH_GEOMETRY_HPP_

--- a/marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp
+++ b/marine_nav_crabbing_path_follower/src/crabbing_path_follower.cpp
@@ -685,17 +685,30 @@ void CrabbingPathFollower::setPlan(const nav_msgs::msg::Path & path)
 {
   global_pub_->publish(path);
 
-  // Progress-preserving localization. The avoidance decorator
+  // Progress-preserving localization (#99; supersedes the index-preserving
+  // 2026-06-04 version). The avoidance decorator
   // (marine_nav_avoidance_controller, #59) re-issues setPlan every control
-  // cycle with a freshly reshaped — but same-goal — path; a same-goal replan
-  // (IsPathValid failure) does likewise. Resetting current_segment_ to 0 each
-  // time made the forward scan in computeVelocityCommands re-localise from the
-  // path start, which during a weave/loop snaps the cursor *backward* and steps
-  // the cross-track reference 5-9 m (kicking the PID — root-caused 2026-06-04).
-  // Keep the cursor across same-goal re-issues; reset only when the goal (final
-  // pose) moves more than new_plan_goal_tolerance_ — a genuinely new line — so
-  // each new line still starts from its beginning. The PID is likewise not
-  // reset here (only by the staleness guard in computeVelocityCommands).
+  // cycle with a same-goal path whose REPRESENTATION varies: the sparse
+  // per-waypoint nominal, a dense 2 m station-resampled corridor reshape, or a
+  // front-truncated re-issue. A raw index is meaningless across those — a
+  // dense-path index capped onto the sparse nominal landed the cursor on the
+  // FINAL leg of an 8-waypoint trackline and the boat sailed away steering
+  // against it (2026-07-21 Massabesic, unh_echoboats_project11#381). The
+  // cursor is therefore re-anchored GEOMETRICALLY on every same-goal re-issue
+  // (mapCursorToNewPath, path_geometry.hpp): the old current segment's start
+  // point is located on the new path within a bounded arc-length window. The
+  // window keeps the 2026-06-04 anti-snap-back property (#250: resetting to 0
+  // re-localised from the path start, and a weave/loop then snapped the cursor
+  // backward, stepping the cross-track reference 5-9 m and kicking the PID)
+  // and rejects capture by an adjacent parallel survey leg. The mapper may
+  // land the cursor a touch behind the boat's along-track projection — the
+  // forward scan in computeVelocityCommands only advances and re-advances
+  // within the same cycle; it never returns a done-sentinel index, so a
+  // shortened re-issue near the goal finishes via the scan + goal checker
+  // instead of stalling on a zero command. Reset to segment 0 only when the
+  // goal (final pose) moves more than new_plan_goal_tolerance_ — a genuinely
+  // new line. The PID is likewise not reset here (only by the staleness guard
+  // in computeVelocityCommands).
   const auto & poses = path.poses;
   bool new_line = true;
   if (!poses.empty() && have_last_goal_) {
@@ -705,14 +718,18 @@ void CrabbingPathFollower::setPlan(const nav_msgs::msg::Path & path)
   }
   if (new_line || current_segment_ < 0) {
     current_segment_ = 0;
-  }
-  const int segment_count = std::max<int>(0, static_cast<int>(poses.size()) - 1);
-  if (current_segment_ > segment_count) {
-    // A sparser/shorter same-goal re-plan left the cursor past the new path.
-    // Re-localize onto the last *traversable* segment, not segment_count —
-    // current_segment_ == segment_count is the "done" sentinel in
-    // computeVelocityCommands, which would stall the boat (zero cmd_vel).
-    current_segment_ = std::max(0, segment_count - 1);
+  } else {
+    bool used_global_fallback = false;
+    const int mapped = mapCursorToNewPath(
+      global_plan_.poses, current_segment_, poses, &used_global_fallback);
+    if (used_global_fallback || std::abs(mapped - current_segment_) > 1) {
+      RCLCPP_DEBUG_STREAM(
+        logger_, "CrabbingPathFollower: setPlan cursor re-anchored " <<
+          current_segment_ << " -> " << mapped << " (" << global_plan_.poses.size() <<
+          " -> " << poses.size() << " poses" <<
+          (used_global_fallback ? ", global fallback" : "") << ")");
+    }
+    current_segment_ = mapped;
   }
   if (!poses.empty()) {
     last_goal_ = poses.back().pose.position;

--- a/marine_nav_crabbing_path_follower/test/test_plan_cursor.cpp
+++ b/marine_nav_crabbing_path_follower/test/test_plan_cursor.cpp
@@ -8,7 +8,9 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <cmath>
+#include <limits>
 #include <utility>
 #include <vector>
 

--- a/marine_nav_crabbing_path_follower/test/test_plan_cursor.cpp
+++ b/marine_nav_crabbing_path_follower/test/test_plan_cursor.cpp
@@ -1,0 +1,331 @@
+// Tests for mapCursorToNewPath (#99): geometry-preserving segment-cursor
+// mapping across same-goal setPlan re-issues. The regression scenario is the
+// 2026-07-21 Massabesic sail-away (unh_echoboats_project11#381): under the
+// avoidance decorator the follower alternates between a sparse per-waypoint
+// nominal path and dense 2 m station-resampled reshapes of the same goal; the
+// old index-preserving carry-over capped a dense index onto the sparse path's
+// FINAL leg and the boat left an 8-waypoint return route at leg 1.
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <utility>
+#include <vector>
+
+#include "marine_nav_crabbing_path_follower/path_geometry.hpp"
+
+namespace mncpf = marine_nav_crabbing_path_follower;
+
+using geometry_msgs::msg::PoseStamped;
+
+namespace
+{
+
+std::vector<PoseStamped> makePath(const std::vector<std::pair<double, double>> & pts)
+{
+  std::vector<PoseStamped> poses;
+  poses.reserve(pts.size());
+  for (const auto & pt : pts) {
+    PoseStamped p;
+    p.pose.position.x = pt.first;
+    p.pose.position.y = pt.second;
+    poses.push_back(p);
+  }
+  return poses;
+}
+
+// Resample a sparse vertex path at ~`spacing` metres, keeping every vertex —
+// the shape of the avoidance decorator's station-resampled output.
+std::vector<PoseStamped> densify(const std::vector<PoseStamped> & sparse, double spacing)
+{
+  std::vector<PoseStamped> out;
+  for (size_t i = 0; i + 1 < sparse.size(); ++i) {
+    const auto & a = sparse[i].pose.position;
+    const auto & b = sparse[i + 1].pose.position;
+    const double len = std::hypot(b.x - a.x, b.y - a.y);
+    const int n = std::max(1, static_cast<int>(len / spacing));
+    for (int k = 0; k < n; ++k) {
+      const double f = static_cast<double>(k) / n;
+      PoseStamped p;
+      p.pose.position.x = a.x + f * (b.x - a.x);
+      p.pose.position.y = a.y + f * (b.y - a.y);
+      out.push_back(p);
+    }
+  }
+  out.push_back(sparse.back());
+  return out;
+}
+
+// Which sparse leg does a point lie on (nearest leg by point-to-segment
+// distance)? Used to express dense-path expectations leg-wise.
+int nearestLeg(const std::vector<PoseStamped> & sparse, double x, double y)
+{
+  int best = -1;
+  double best_d = std::numeric_limits<double>::infinity();
+  for (size_t i = 0; i + 1 < sparse.size(); ++i) {
+    const auto & a = sparse[i].pose.position;
+    const auto & b = sparse[i + 1].pose.position;
+    const double sx = b.x - a.x;
+    const double sy = b.y - a.y;
+    const double len2 = sx * sx + sy * sy;
+    double t = 0.0;
+    if (len2 > 1e-18) {
+      t = std::clamp(((x - a.x) * sx + (y - a.y) * sy) / len2, 0.0, 1.0);
+    }
+    const double d = std::hypot(x - (a.x + t * sx), y - (a.y + t * sy));
+    if (d < best_d) {
+      best_d = d;
+      best = static_cast<int>(i);
+    }
+  }
+  return best;
+}
+
+double pointToSegmentDistance(
+  const std::vector<PoseStamped> & poses, int seg, double x, double y)
+{
+  const auto & a = poses[seg].pose.position;
+  const auto & b = poses[seg + 1].pose.position;
+  const double sx = b.x - a.x;
+  const double sy = b.y - a.y;
+  const double len2 = sx * sx + sy * sy;
+  double t = 0.0;
+  if (len2 > 1e-18) {
+    t = std::clamp(((x - a.x) * sx + (y - a.y) * sy) / len2, 0.0, 1.0);
+  }
+  return std::hypot(x - (a.x + t * sx), y - (a.y + t * sy));
+}
+
+// The 2026-07-21 trackline0000 geometry (map frame, metres, rounded) — an
+// 8-waypoint return route whose legs 1-6 dip ~500 m south of the survey band.
+const std::vector<std::pair<double, double>> kZigzag = {
+  {-787.4, -87.7}, {-732.0, -161.7}, {-696.1, -344.5}, {-650.0, -409.1},
+  {-591.3, -589.4}, {-442.3, -546.7}, {-434.5, -383.4}, {-96.1, -112.0},
+};
+
+}  // namespace
+
+// The field regression: cursor on leg 1 of the dense variant must map back to
+// leg 0/1 territory of the sparse variant — never the final leg.
+TEST(MapCursorToNewPath, DenseToSparseZigzagStaysOnCurrentLeg)
+{
+  const auto sparse = makePath(kZigzag);
+  const auto dense = densify(sparse, 2.0);
+
+  // Boat walked ~60-90 m of leg 0 (wp0->wp1 is ~92 m): dense cursor ~index 40.
+  const int dense_cursor = 40;
+  const auto & anchor = dense[dense_cursor].pose.position;
+  ASSERT_EQ(nearestLeg(sparse, anchor.x, anchor.y), 0);
+
+  bool fallback = true;
+  const int mapped = mncpf::mapCursorToNewPath(dense, dense_cursor, sparse, &fallback);
+  EXPECT_EQ(mapped, 0);
+  EXPECT_FALSE(fallback);
+
+  // The old behaviour capped to the final leg — assert we never do.
+  EXPECT_NE(mapped, static_cast<int>(sparse.size()) - 2);
+}
+
+TEST(MapCursorToNewPath, SparseToDenseRoundTrip)
+{
+  const auto sparse = makePath(kZigzag);
+  const auto dense = densify(sparse, 2.0);
+
+  const int on_dense = mncpf::mapCursorToNewPath(sparse, 0, dense);
+  const auto & p = dense[on_dense].pose.position;
+  EXPECT_EQ(nearestLeg(sparse, p.x, p.y), 0);
+
+  const int back = mncpf::mapCursorToNewPath(dense, on_dense, sparse);
+  EXPECT_EQ(back, 0);
+}
+
+// A corridor-style lateral reshape (<= 6 m offsets) of the same goal must map
+// to the same leg. Two flavours:
+//  - mid-leg cursor (the realistic dense->dense case): exact same leg;
+//  - vertex-anchored cursor (sparse old path — anchor sits ON the leg
+//    boundary): landing one station before the vertex, i.e. the tail of the
+//    PREVIOUS leg, is correct-by-design (the compute-side forward scan
+//    re-advances within the cycle); anything further back, further forward,
+//    or a distant-leg capture is a failure.
+TEST(MapCursorToNewPath, LateralOffsetReshapeMapsSameLeg)
+{
+  const auto sparse = makePath(kZigzag);
+  const auto dense = densify(sparse, 2.0);
+  auto shifted_pts = kZigzag;
+  for (size_t i = 1; i + 1 < shifted_pts.size(); ++i) {
+    shifted_pts[i].first += 4.0;
+    shifted_pts[i].second += 4.0;
+  }
+  const auto sparse_shifted = makePath(shifted_pts);
+  const auto dense_shifted = densify(sparse_shifted, 2.0);
+
+  // Mid-leg cursors: pick the dense station nearest each leg's midpoint and
+  // map dense (unshifted) -> dense (shifted). Must stay on the same leg.
+  for (int leg = 0; leg < static_cast<int>(kZigzag.size()) - 1; ++leg) {
+    const double mx = 0.5 * (kZigzag[leg].first + kZigzag[leg + 1].first);
+    const double my = 0.5 * (kZigzag[leg].second + kZigzag[leg + 1].second);
+    int mid_cursor = 0;
+    double best = std::numeric_limits<double>::infinity();
+    for (int i = 0; i < static_cast<int>(dense.size()); ++i) {
+      const auto & q = dense[i].pose.position;
+      const double d = std::hypot(q.x - mx, q.y - my);
+      if (d < best) {
+        best = d;
+        mid_cursor = i;
+      }
+    }
+    const int on_shifted = mncpf::mapCursorToNewPath(dense, mid_cursor, dense_shifted);
+    const auto & p = dense_shifted[on_shifted].pose.position;
+    EXPECT_EQ(nearestLeg(sparse_shifted, p.x, p.y), leg) << "mid-leg " << leg;
+  }
+
+  // Vertex-anchored cursors (sparse old path): same leg or the immediately
+  // preceding one, and geometrically at the anchor (offset + one station).
+  for (int leg = 0; leg < static_cast<int>(kZigzag.size()) - 1; ++leg) {
+    const int on_dense = mncpf::mapCursorToNewPath(sparse, leg, dense_shifted);
+    const auto & p = dense_shifted[on_dense].pose.position;
+    const int mapped_leg = nearestLeg(sparse_shifted, p.x, p.y);
+    EXPECT_TRUE(mapped_leg == leg || mapped_leg == leg - 1)
+      << "leg " << leg << " mapped to " << mapped_leg;
+    const auto & anchor = sparse[leg].pose.position;
+    EXPECT_LT(std::hypot(p.x - anchor.x, p.y - anchor.y), 4.0 * M_SQRT2 + 2.0 + 0.5)
+      << "leg " << leg;
+  }
+}
+
+// Adversarial parallel-leg case: boustrophedon legs 8 m apart; the old path is
+// the current leg reshaped 6 m toward the neighbour, the new path is the
+// nominal. The anchor is then strictly nearer the WRONG (adjacent) leg in
+// space (2 m vs 6 m) — only the arc-length window keeps the mapping on the
+// current leg.
+TEST(MapCursorToNewPath, AdjacentParallelLegNotCaptured)
+{
+  const std::vector<std::pair<double, double>> nominal_pts = {
+    {0.0, 0.0}, {100.0, 0.0}, {100.0, 8.0}, {0.0, 8.0},
+  };
+  auto reshaped_pts = nominal_pts;
+  reshaped_pts[0].second = 6.0;   // leg 0 pushed 6 m toward leg 2
+  reshaped_pts[1].second = 6.0;
+  const auto nominal = makePath(nominal_pts);
+  const auto reshaped_dense = densify(makePath(reshaped_pts), 2.0);
+
+  // Cursor mid leg 0 of the reshaped dense path: anchor ~(50, 6).
+  const int dense_cursor = 25;
+  const auto & anchor = reshaped_dense[dense_cursor].pose.position;
+  ASSERT_NEAR(anchor.y, 6.0, 1e-9);
+  ASSERT_LT(std::abs(anchor.x - 50.0), 4.0);
+  // Sanity: the anchor really is nearer the wrong leg in space.
+  ASSERT_LT(pointToSegmentDistance(nominal, 2, anchor.x, anchor.y),
+    pointToSegmentDistance(nominal, 0, anchor.x, anchor.y));
+
+  bool fallback = true;
+  const int mapped =
+    mncpf::mapCursorToNewPath(reshaped_dense, dense_cursor, nominal, &fallback);
+  EXPECT_EQ(mapped, 0);
+  EXPECT_FALSE(fallback);
+}
+
+// A front-truncated same-goal re-issue (BT-pruned transit path) must keep the
+// geometric position, not the index.
+TEST(MapCursorToNewPath, TruncatedReissueKeepsGeometricPosition)
+{
+  const auto sparse = makePath(kZigzag);
+  const auto dense = densify(sparse, 2.0);
+  std::vector<PoseStamped> truncated(dense.begin() + 3, dense.end());
+
+  const int dense_cursor = 10;
+  const auto & anchor = dense[dense_cursor].pose.position;
+  const int mapped = mncpf::mapCursorToNewPath(dense, dense_cursor, truncated);
+
+  // Mapped segment start must be geometrically at the anchor (one station).
+  const auto & p = truncated[mapped].pose.position;
+  EXPECT_LT(std::hypot(p.x - anchor.x, p.y - anchor.y), 2.5);
+  EXPECT_NE(mapped, dense_cursor);  // index-preservation would be wrong here
+}
+
+// Old cursor past the new path's extent: clamp to the last traversable
+// segment, never the done-sentinel (size-1).
+TEST(MapCursorToNewPath, PastEndClampsToLastTraversableSegment)
+{
+  const auto sparse = makePath(kZigzag);
+  const auto dense = densify(sparse, 2.0);
+
+  const int at_end = static_cast<int>(dense.size()) - 2;
+  const int mapped = mncpf::mapCursorToNewPath(dense, at_end, sparse);
+  EXPECT_EQ(mapped, static_cast<int>(sparse.size()) - 2);
+
+  // Done-sentinel input (== size-1) clamps to the last traversable segment
+  // before anchoring, and the output stays traversable.
+  const int sentinel = static_cast<int>(dense.size()) - 1;
+  const int mapped2 = mncpf::mapCursorToNewPath(dense, sentinel, sparse);
+  EXPECT_EQ(mapped2, static_cast<int>(sparse.size()) - 2);
+}
+
+TEST(MapCursorToNewPath, DegenerateInputsReturnZero)
+{
+  const auto sparse = makePath(kZigzag);
+  const std::vector<PoseStamped> empty;
+  const auto single = makePath({{1.0, 2.0}});
+
+  EXPECT_EQ(mncpf::mapCursorToNewPath(sparse, 3, empty), 0);
+  EXPECT_EQ(mncpf::mapCursorToNewPath(sparse, 3, single), 0);
+  EXPECT_EQ(mncpf::mapCursorToNewPath(empty, 3, sparse), 0);
+  EXPECT_EQ(mncpf::mapCursorToNewPath(single, 0, sparse), 0);
+}
+
+// Identical representation: fast path keeps the cursor for every traversable
+// index (and clamps a done-sentinel input into range).
+TEST(MapCursorToNewPath, IdenticalPathKeepsCursor)
+{
+  const auto sparse = makePath(kZigzag);
+  for (int i = 0; i < static_cast<int>(sparse.size()) - 1; ++i) {
+    EXPECT_EQ(mncpf::mapCursorToNewPath(sparse, i, sparse), i);
+  }
+  EXPECT_EQ(
+    mncpf::mapCursorToNewPath(sparse, static_cast<int>(sparse.size()) - 1, sparse),
+    static_cast<int>(sparse.size()) - 2);
+}
+
+// Anti-snap-back (#250 property): under forward progress with alternating
+// representations, the mapped cursor never moves backward at leg granularity.
+TEST(MapCursorToNewPath, AlternatingReissuesNeverMoveBackward)
+{
+  const auto sparse = makePath(kZigzag);
+  const auto dense = densify(sparse, 2.0);
+
+  int prev_leg = 0;
+  for (int dense_cursor = 0; dense_cursor < static_cast<int>(dense.size()) - 1;
+    dense_cursor += 5)
+  {
+    const int leg = mncpf::mapCursorToNewPath(dense, dense_cursor, sparse);
+    EXPECT_GE(leg, prev_leg) << "dense cursor " << dense_cursor;
+    prev_leg = std::max(prev_leg, leg);
+  }
+  EXPECT_EQ(prev_leg, static_cast<int>(sparse.size()) - 2);
+}
+
+// Purely geometric reference-step bound (no reliance on the #66 slew limiter,
+// which defaults to off): for an on-path pose mid-leg, the cross-track
+// distance to the tracked segment changes by < 0.5 m across a dense<->sparse
+// flip.
+TEST(MapCursorToNewPath, CrossTrackReferenceStepBoundedAcrossFlip)
+{
+  const auto sparse = makePath(kZigzag);
+  const auto dense = densify(sparse, 2.0);
+
+  const int dense_cursor = 40;  // mid leg 0
+  const auto & boat = dense[dense_cursor].pose.position;
+
+  const double xtk_dense =
+    pointToSegmentDistance(dense, dense_cursor, boat.x, boat.y);
+  const int mapped = mncpf::mapCursorToNewPath(dense, dense_cursor, sparse);
+  const double xtk_sparse = pointToSegmentDistance(sparse, mapped, boat.x, boat.y);
+
+  EXPECT_LT(std::abs(xtk_sparse - xtk_dense), 0.5);
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary

Replaces the raw-index segment-cursor carry-over in `CrabbingPathFollower::setPlan` with a geometric re-anchor, fixing the final-leg capture that made Bizzy abandon its 8-waypoint return route on 2026-07-21 at Lake Massabesic (rolker/unh_echoboats_project11#381).

**Root cause** (bag-confirmed): the same-goal branch preserved `current_segment_` by raw index with a `min(index, segment_count−1)` cap. Under the AvoidanceController the inner follower alternates between the sparse N-waypoint nominal path and dense 2 m station-resampled reshapes of the same goal, so a dense-path index capped onto the **final leg** of the sparse path — the boat left the route at leg 1 while steering against leg 7.

## Changes

- New pure helper `mapCursorToNewPath()` in `path_geometry.hpp`: anchors on the old segment's start point, searches a bounded arc-length window (max(25 m, 10% of path length)) around the old cursor's arc position, falls back to global nearest with arc-fraction tie-break (flagged) only when the window has no sane candidate. Always returns a traversable index in `[0, last−1]` — never the done-sentinel, so shortened re-issues finish via the normal forward scan + goal checker.
- `setPlan` same-goal branch rewired to the helper; the `min(index, count−1)` cap branch removed; the 2026-06-04 anti-snap-back rationale (#250) rewritten to document the geometric invariant.
- New gtest suite `test_plan_cursor.cpp` (10 cases), including the 07-21 zigzag regression with the actual trackline coordinates, sparse↔dense round-trips, truncated re-issues, adversarial adjacent-parallel-leg capture, cross-track reference-step bound, and the #250 no-backward-motion property.

## Testing

- `test_plan_cursor`: 10/10 pass; full package suite: all functional tests pass (74 total). Lint failures are pre-existing package-wide debt (#98), CI-excluded via the `linter` label; the new code verified lint-clean against baseline.
- Pre-push `/review-code` (Claude Opus sub-agent): **approved, 0 must-fix**; the one suggestion (direct `<algorithm>`/`<limits>` includes in the test) is applied.

## Deployment note

The fix is only effective on Bizzy after a **gabby `core_ws` pull + rebuild** — required before the next deployment (together with the upcoming nav#100 crab-clamp fix).

Closes #99
Part of rolker/unh_echoboats_project11#381

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`
